### PR TITLE
meep change protos with harminv complex

### DIFF
--- a/src/bands.cpp
+++ b/src/bands.cpp
@@ -468,9 +468,12 @@ int do_harminv(complex<double> *data, int n, double dt,
       }
   
   double min_err = harminv_get_freq_error(hd, fsort[0]);
-  double max_amp = abs(harminv_get_amplitude(hd, 0));
+  harminv_complex aa;
+  harminv_get_amplitude(&aa, hd, 0);
+  double max_amp = abs(aa);
   for (int i = 1; i < nf; ++i) {
-    double amp = abs(harminv_get_amplitude(hd, i));
+    harminv_get_amplitude(&aa, hd, i);
+    double amp = abs(aa);
     if (max_amp < amp)
       max_amp = amp;
   }
@@ -479,7 +482,8 @@ int do_harminv(complex<double> *data, int n, double dt,
     for (int i = 0; i < nf; ++i) {
       double f = abs(harminv_get_freq(hd, fsort[i]) / dt);
       double err = harminv_get_freq_error(hd, fsort[i]);
-      double amp = abs(harminv_get_amplitude(hd, fsort[i]));
+      harminv_get_amplitude(&aa, hd, fsort[i]);
+      double amp = abs(aa);
       if (f >= fmin && f <= fmax
 	  && abs(harminv_get_Q(hd, fsort[i])) > Q_thresh
 	  && err < err_thresh
@@ -538,10 +542,13 @@ int do_harminv(complex<double> *data, int n, double dt,
       }
   
   for (int i = 0; i < nf; ++i) {
-    complex<double> freq = harminv_get_omega(hd, fsort[i]) / (2*pi*dt);
+    harminv_complex oo;
+    complex<double> freq;
+    harminv_get_omega(&oo, hd, fsort[i]);
+    freq = oo / (2*pi*dt);
     freq_re[i] = abs(real(freq));
     freq_im[i] = imag(freq);
-    amps[i] = harminv_get_amplitude(hd, fsort[i]);
+    harminv_get_amplitude(&(amps[i]), hd, fsort[i]);
     if (errors)
       errors[i] = harminv_get_freq_error(hd, fsort[i]);
   }


### PR DESCRIPTION
meep change protos with harminv complex

This patch concern the meep package,
it needs a prereq of similar patch for harminv package.

This is related to meep issue 13
https://github.com/stevengj/meep/issues/13

The initial reported problem was at make check:
===
[  259s] FAIL: aniso_disp
[  273s] FAIL: convergence_cyl_waveguide
[  396s] FAIL: 2D_convergence
===
../meep-1.2.1/tests> grep failure test-suite.log
test-suite.log:harminv: failure on line 853 of harminv.c: argument out of range in harminv_get_amplitude
test-suite.log:harminv: failure on line 853 of harminv.c: argument out of range in harminv_get_amplitude
test-suite.log:harminv: failure on line 853 of harminv.c: argument out of range in harminv_get_amplitude
===

Signed-off-by: Michel Normand <normand@linux.vnet.ibm.com>