### PR TITLE
Feature/large grid

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -196,7 +196,7 @@ fi
 # GNU Scientific Library
 
 AC_CHECK_FUNC(cblas_cgemm, [], [AC_CHECK_LIB(gslcblas, cblas_cgemm)])
-AC_CHECK_LIB([gslcblas],[cblas_cgemm])
+
 AC_CHECK_LIB(gsl, gsl_sf_bessel_Jn, [],
 	[AC_MSG_WARN([Missing GNU GSL library...Bessel-function field initialization will not be supported.])])
 

--- a/configure.ac
+++ b/configure.ac
@@ -79,8 +79,10 @@ fi
 
 # Add lots of compiler warnings in maintainer mode if we are using gcc:
 # (The variable $GXX is set to "yes" by AC_PROG_CXX if we are using g++.)
+# Warning flags must appear before all other flags to prevent reactivation
+# of deactivated warnings.
 if test "$GXX" = "yes" && test "$USE_MAINTAINER_MODE" = yes; then
-        CXXFLAGS="$CXXFLAGS -Wall -W"
+        CXXFLAGS="-Wall -W $CXXFLAGS"
 fi
 
 # For some annoying reason, g++ requires you to compile

--- a/configure.ac
+++ b/configure.ac
@@ -117,6 +117,15 @@ AC_CHECK_LIB(fftw3, fftw_plan_dft_1d, [],
     [AC_CHECK_LIB(fftw, fftw_create_plan, [],
        [AC_MSG_WARN([FFTW needed for MPB])])])])
 
+##############################################################################
+# check size and existence of interger types
+
+AC_TYPE_LONG_LONG_INT
+AC_CHECK_SIZEOF(int)
+AC_CHECK_SIZEOF(long int)
+AC_CHECK_SIZEOF(long long int)
+AC_CHECK_SIZEOF(ptrdiff_t)
+
 ###########################################################################
 
 AC_PROG_F77

--- a/configure.ac
+++ b/configure.ac
@@ -185,7 +185,7 @@ fi
 # GNU Scientific Library
 
 AC_CHECK_FUNC(cblas_cgemm, [], [AC_CHECK_LIB(gslcblas, cblas_cgemm)])
-
+AC_CHECK_LIB([gslcblas],[cblas_cgemm])
 AC_CHECK_LIB(gsl, gsl_sf_bessel_Jn, [],
 	[AC_MSG_WARN([Missing GNU GSL library...Bessel-function field initialization will not be supported.])])
 

--- a/libctl/structure.cpp
+++ b/libctl/structure.cpp
@@ -172,7 +172,7 @@ static geom_box gv2box(const meep::volume &v)
 /***********************************************************************/
 
 static meep::realnum *epsilon_data = NULL;
-static int epsilon_dims[3] = {0,0,0};
+static meep::integer epsilon_dims[3] = {0,0,0};
 
 static void read_epsilon_file(const char *eps_input_file)
 {
@@ -187,8 +187,10 @@ static void read_epsilon_file(const char *eps_input_file)
     meep::h5file eps_file(fname, meep::h5file::READONLY, false);
     int rank; // ignored since rank < 3 is equivalent to singleton dims
     epsilon_data = eps_file.read(dataname, &rank, epsilon_dims, 3);
-    master_printf("read in %dx%dx%d epsilon-input-file \"%s\"\n",
-		  epsilon_dims[0], epsilon_dims[1], epsilon_dims[2],
+    master_printf("read in %ldx%ldx%ld epsilon-input-file \"%s\"\n",
+		  static_cast<long int>(epsilon_dims[0]),
+		  static_cast<long int>(epsilon_dims[1]),
+		  static_cast<long int>(epsilon_dims[2]),
 		  eps_input_file);
   }
 }
@@ -198,9 +200,9 @@ static void read_epsilon_file(const char *eps_input_file)
    ... anything outside [0,1] is *mirror* reflected into [0,1] */
 static meep::realnum linear_interpolate(
 		     meep::realnum rx, meep::realnum ry, meep::realnum rz,
-		     meep::realnum *data, int nx, int ny, int nz, int stride)
+		     meep::realnum *data, meep::integer nx, meep::integer ny, meep::integer nz, meep::integer stride)
 {
-     int x, y, z, x2, y2, z2;
+     meep::integer x, y, z, x2, y2, z2;
      meep::realnum dx, dy, dz;
 
      /* mirror boundary conditions for r just beyond the boundary */
@@ -209,15 +211,15 @@ static meep::realnum linear_interpolate(
      if (rz < 0.0) rz = -rz; else if (rz > 1.0) rz = 1.0 - rz;
 
      /* get the point corresponding to r in the epsilon array grid: */
-     x = rx * nx; if (x == nx) --x;
-     y = ry * ny; if (y == ny) --y;
-     z = rz * nz; if (z == nz) --z;
+     x = static_cast<meep::integer>(rx * static_cast<double>(nx)); if (x == nx) --x;
+     y = static_cast<meep::integer>(ry * static_cast<double>(ny)); if (y == ny) --y;
+     z = static_cast<meep::integer>(rz * static_cast<double>(nz)); if (z == nz) --z;
 
      /* get the difference between (x,y,z) and the actual point
         ... we shift by 0.5 to center the data points in the pixels */
-     dx = rx * nx - x - 0.5;
-     dy = ry * ny - y - 0.5;
-     dz = rz * nz - z - 0.5;
+     dx = rx * static_cast<double>(nx) - static_cast<double>(x) - 0.5;
+     dy = ry * static_cast<double>(ny) - static_cast<double>(y) - 0.5;
+     dz = rz * static_cast<double>(nz) - static_cast<double>(z) - 0.5;
 
      /* get the other closest point in the grid, with mirror boundaries: */
      x2 = (dx >= 0.0 ? x + 1 : x - 1);

--- a/src/anisotropic_averaging.cpp
+++ b/src/anisotropic_averaging.cpp
@@ -191,8 +191,8 @@ void structure_chunk::set_chi1inv(component c,
   const double smoothing_diameter = 1.0; // FIXME: make user-changable?
       
   // may take a long time in 3d, so prepare to print status messages
-  int npixels = 0, ipixel = 0;
-  int loop_npixels = 0;
+  meep::integer npixels = 0, ipixel = 0;
+  meep::integer loop_npixels = 0;
   LOOP_OVER_VOL(gv, c, i) {
     loop_npixels = loop_n1 * loop_n2 * loop_n3;
     goto breakout; // hack to use loop-size computation from LOOP_OVER_VOL
@@ -213,7 +213,7 @@ void structure_chunk::set_chi1inv(component c,
   double trivial_val[3] = {0,0,0};
   trivial_val[idiag] = 1.0;
   ivec shift1(unit_ivec(gv.dim,component_direction(c))
-	      * (ft == E_stuff ? 1 : -1));
+	      * static_cast<meep::integer>(ft == E_stuff ? 1 : -1));
   LOOP_OVER_VOL(gv, c, i) {
     double chi1invrow[3], chi1invrow_offdiag[3];
     IVEC_LOOP_ILOC(gv, here);
@@ -237,9 +237,9 @@ void structure_chunk::set_chi1inv(component c,
     if (!quiet && (ipixel+1) % 1000 == 0
 	&& wall_time() > last_output_time + MIN_OUTPUT_TIME) {
       master_printf("subpixel-averaging is %g%% done, %g s remaining\n", 
-		    ipixel * 100.0 / npixels,
-		    (npixels - ipixel) *
-		    (wall_time() - last_output_time) / ipixel);
+		    static_cast<double>(ipixel) * 100.0 / static_cast<double>(npixels),
+		    static_cast<double>(npixels - ipixel) *
+		    (wall_time() - last_output_time) / static_cast<double>(ipixel));
       last_output_time = wall_time();
     }
     ++ipixel;
@@ -295,7 +295,7 @@ void structure_chunk::add_susceptibility(material_function &sigma,
     realnum *s1 = newsus->sigma[c][d1];
     realnum *s2 = newsus->sigma[c][d2];
     vec shift1(gv[unit_ivec(gv.dim,component_direction(c))
-		  * (ft == E_stuff ? 1 : -1)]);
+		  * static_cast<meep::integer>(ft == E_stuff ? 1 : -1)]);
     LOOP_OVER_VOL(gv, c, i) {
       double sigrow[3], sigrow_offdiag[3];
       IVEC_LOOP_LOC(gv, here);

--- a/src/bands.cpp
+++ b/src/bands.cpp
@@ -72,7 +72,7 @@ void fields::prepare_for_bands(const vec &p, double endtime, double fmax,
   bands->tend = t + (int)(endtime/dt) - 1;
 
   {
-    int ind[8];
+    meep::integer ind[8];
     double w[8];
     int indind = 0;
     while (bands->index[indind] != -1 && indind < num_bandpts) indind++;
@@ -93,7 +93,7 @@ void fields::prepare_for_bands(const vec &p, double endtime, double fmax,
 
   double cutoff_freq = 0.0;
   if (gv.dim == Dcyl) {
-    cutoff_freq = 1.84*a*dt/(2*pi)/gv.nr()/sqrt(epsmax);
+    cutoff_freq = 1.84*a*dt/(2*pi)/static_cast<double>(gv.nr())/sqrt(epsmax);
     if (m == 0) cutoff_freq *= 0.5;
   }
   bands->fmin = sqrt(cutoff_freq*cutoff_freq + abs(k[Z])*abs(k[Z])*(a*dt)*(a*dt)/epsmax); // FIXME

--- a/src/bicgstab.hpp
+++ b/src/bicgstab.hpp
@@ -24,8 +24,8 @@ namespace meep {
 
 typedef void (*bicgstab_op)(const realnum *x, realnum *y, void *data);
 
-int bicgstabL(const int L, 
-	      const int n, realnum *x,
+meep::integer bicgstabL(const meep::integer L,
+	      const meep::integer n, realnum *x,
 	      bicgstab_op A, void *Adata, const realnum *b,
 	      const double tol, 
 	      int *iters, // input *iters = max iters, output = actual iters

--- a/src/casimir.cpp
+++ b/src/casimir.cpp
@@ -298,7 +298,9 @@ complex<double> fields::casimir_stress_dct_integral(direction dforce,
     loop_in_chunks(stress_chunkloop, &data, where, c); 
 
   data.sum = sum_to_all(data.sum);
-  return coefficient * complex<double>(real(data.sum), imag(data.sum));
+  return coefficient * complex<double>(
+		  static_cast<double>(real(data.sum)),
+		  static_cast<double>(imag(data.sum)));
 }
 
   /* Similar to make_g above, but now air/metal systems

--- a/src/cw_fields.cpp
+++ b/src/cw_fields.cpp
@@ -80,7 +80,7 @@ static void array_to_fields(const complex<realnum> *x, fields &f)
 }
 
 typedef struct {
-  int n;
+  meep::integer n;
   fields *f;
   complex<double> iomega;
   int iters;
@@ -94,11 +94,11 @@ static void fieldop(const realnum *xr, realnum *yr, void *data_)
   array_to_fields(x, *data->f);
   data->f->step();
   fields_to_array(*data->f, y);
-  int n = data->n;
+  meep::integer n = data->n;
   realnum dt_inv = 1.0 / data->f->dt;
   complex<realnum> iomega = complex<realnum>(real(data->iomega),
 					     imag(data->iomega));
-  for (int i = 0; i < n; ++i) y[i] = (y[i] - x[i]) * dt_inv + iomega * x[i];
+  for (meep::integer i = 0; i < n; ++i) y[i] = (y[i] - x[i]) * dt_inv + iomega * x[i];
   data->iters++;
 }
 
@@ -122,7 +122,7 @@ bool fields::solve_cw(double tol, int maxiters, complex<double> frequency,
 
   step(); // step once to make sure everything is allocated
 
-  int N = 0; // size of linear system (on this processor, at least)
+  meep::integer N = 0; // size of linear system (on this processor, at least)
   for (int i=0;i<num_chunks;i++)
     if (chunks[i]->is_mine()) {
       FOR_COMPONENTS(c)
@@ -141,7 +141,7 @@ bool fields::solve_cw(double tol, int maxiters, complex<double> frequency,
 	}
     }
 
-  int nwork = bicgstabL(L, N, 0, 0, 0, 0, tol, &maxiters, 0, true);
+  meep::integer nwork = bicgstabL(L, N, 0, 0, 0, 0, tol, &maxiters, 0, true);
   realnum *work = new realnum[nwork + 2*N];
   complex<realnum> *x = reinterpret_cast<complex<realnum>*>(work + nwork);
   complex<realnum> *b = reinterpret_cast<complex<realnum>*>(work + nwork + N);
@@ -160,10 +160,10 @@ bool fields::solve_cw(double tol, int maxiters, complex<double> frequency,
   update_eh(E_stuff);
   fields_to_array(*this, b);
   double mdt_inv = -1.0 / dt;
-  for (int i = 0; i < N/2; ++i) b[i] *= mdt_inv;
+  for (meep::integer i = 0; i < N/2; ++i) b[i] *= mdt_inv;
   {
     double bmax = 0;
-    for (int i = 0; i < N/2; ++i) {
+    for (meep::integer i = 0; i < N/2; ++i) {
       double babs = abs(b[i]);
       if (babs > bmax) bmax = babs;
     }
@@ -177,7 +177,7 @@ bool fields::solve_cw(double tol, int maxiters, complex<double> frequency,
 		 * (1.0 / dt));
   data.iters = 0;
 
-  int ierr = bicgstabL(L, N, reinterpret_cast<realnum*>(x),
+  meep::integer ierr = bicgstabL(L, N, reinterpret_cast<realnum*>(x),
 		       fieldop, &data, reinterpret_cast<realnum*>(b),
 		       tol, &maxiters, work, quiet);
 
@@ -185,7 +185,8 @@ bool fields::solve_cw(double tol, int maxiters, complex<double> frequency,
     master_printf("Finished solve_cw after %d steps and %d CG iters.\n", 
 		  data.iters, maxiters);
     if (ierr)
-      master_printf(" -- CONVERGENCE FAILURE (%d) in solve_cw!\n", ierr);
+      master_printf(" -- CONVERGENCE FAILURE (%ld) in solve_cw!\n",
+    		  static_cast<long int>(ierr));
   }
 
   array_to_fields(x, *this);

--- a/src/dft_ldos.cpp
+++ b/src/dft_ldos.cpp
@@ -93,15 +93,15 @@ void dft_ldos::update(fields &f)
 	realnum *fr = f.chunks[ic]->f[c][0];
 	realnum *fi = f.chunks[ic]->f[c][1];
 	if (fr && fi) // complex E
-	  for (int j=0; j<sv->npts; j++) {
-	    const int idx = sv->index[j];
+	  for (meep::integer j=0; j<sv->npts; j++) {
+	    const meep::integer idx = sv->index[j];
 	    const complex<double> A = sv->A[j];
 	    EJ += complex<double>(fr[idx],fi[idx]) * conj(A);
 	    Jsum += abs(A);
 	  }
 	else if (fr) { // E is purely real
-	  for (int j=0; j<sv->npts; j++) {
-	    const int idx = sv->index[j];
+	  for (meep::integer j=0; j<sv->npts; j++) {
+	    const meep::integer idx = sv->index[j];
 	    const complex<double> A = sv->A[j];
 	    EJ += double(fr[idx]) * conj(A);
 	    Jsum += abs(A);
@@ -113,15 +113,15 @@ void dft_ldos::update(fields &f)
 	realnum *fr = f.chunks[ic]->f[c][0];
 	realnum *fi = f.chunks[ic]->f[c][1];
 	if (fr && fi) // complex H
-	  for (int j=0; j<sv->npts; j++) {
-	    const int idx = sv->index[j];
+	  for (meep::integer j=0; j<sv->npts; j++) {
+	    const meep::integer idx = sv->index[j];
 	    const complex<double> A = sv->A[j];
 	    HJ += complex<double>(fr[idx],fi[idx]) * conj(A);
 	    Jsum += abs(A);
 	  }
 	else if (fr) { // H is purely real
-	  for (int j=0; j<sv->npts; j++) {
-	    const int idx = sv->index[j];
+	  for (meep::integer j=0; j<sv->npts; j++) {
+	    const meep::integer idx = sv->index[j];
 	    const complex<double> A = sv->A[j];
 	    HJ += double(fr[idx]) * conj(A);
 	    Jsum += abs(A);

--- a/src/energy_and_flux.cpp
+++ b/src/energy_and_flux.cpp
@@ -39,7 +39,7 @@ double fields::count_volume(component c) {
 
 double fields_chunk::count_volume(component c) {
   double vol = 0;
-  for (int i=0;i<gv.ntot();i++)
+  for (meep::integer i=0;i<gv.ntot();i++)
     vol += gv.dV(c,i).full_volume();
   return vol;
 }
@@ -94,14 +94,14 @@ double fields::electric_energy_in_box(const volume &where) {
   long double sum = 0.0;
   FOR_ELECTRIC_COMPONENTS(c)
     sum += field_energy_in_box(c, where);
-  return sum;
+  return static_cast<double>(sum);
 }
 
 double fields::magnetic_energy_in_box(const volume &where) {
   long double sum = 0.0;
   FOR_MAGNETIC_COMPONENTS(c)
     sum += field_energy_in_box(c, where);
-  return sum;
+  return static_cast<double>(sum);
 }
 
 void fields_chunk::backup_component(component c) {
@@ -146,7 +146,7 @@ void fields_chunk::average_with_backup(component c) {
     realnum *fc = f[c][cmp];
     realnum *backup = f_backup[c][cmp];
     if (fc && backup)
-      for (int i = 0; i < gv.ntot(); i++)
+      for (meep::integer i = 0; i < gv.ntot(); i++)
 	fc[i] = 0.5 * (fc[i] + backup[i]);
   }
 }
@@ -189,7 +189,7 @@ double fields::thermo_energy_in_box(const volume &where) {
   long double sum = 0.0;
   (void) where; // unused
   abort("thermo_energy_in_box no longer supported");
-  return sum_to_all(sum);
+  return static_cast<double>(sum_to_all(sum));
 }
 
 /* Compute ExH integral in box using current fields, ignoring fact
@@ -219,7 +219,7 @@ double fields::flux_in_box_wrongH(direction d, const volume &where) {
     cs[0] = cE[i]; cs[1] = cH[i];
     sum += real(integrate(2, cs, dot_integrand, 0, where)) * (1 - 2*i);
   }
-  return sum;
+  return static_cast<double>(sum);
 }
 
 double fields::flux_in_box(direction d, const volume &where) {

--- a/src/fields.cpp
+++ b/src/fields.cpp
@@ -60,7 +60,7 @@ fields::fields(structure *s, double m, double beta,
 				 beta, zero_fields_near_cylorigin);
   FOR_FIELD_TYPES(ft) {
     for (int ip=0;ip<3;ip++) {
-      comm_sizes[ft][ip] = new int[num_chunks*num_chunks];
+      comm_sizes[ft][ip] = new meep::integer[num_chunks*num_chunks];
       for (int i=0;i<num_chunks*num_chunks;i++) comm_sizes[ft][ip][i] = 0;
     }
     typedef realnum *realnum_ptr;
@@ -111,7 +111,7 @@ fields::fields(const fields &thef) :
     chunks[i] = new fields_chunk(*thef.chunks[i]);
   FOR_FIELD_TYPES(ft) {
     for (int ip=0;ip<3;ip++) {
-      comm_sizes[ft][ip] = new int[num_chunks*num_chunks];
+      comm_sizes[ft][ip] = new meep::integer[num_chunks*num_chunks];
       for (int i=0;i<num_chunks*num_chunks;i++) comm_sizes[ft][ip][i] = 0;
     }
     typedef realnum *realnum_ptr;
@@ -441,13 +441,13 @@ bool fields_chunk::alloc_f(component c) {
 	  component bc = direction_component(Bx, component_direction(c));
 	  if (!f[bc][cmp]) {
 	    f[bc][cmp] = new realnum[gv.ntot()];
-	    for (int i=0;i<gv.ntot();i++) f[bc][cmp][i] = 0.0;
+	    for (meep::integer i=0;i<gv.ntot();i++) f[bc][cmp][i] = 0.0;
 	  }
 	  f[c][cmp] = f[bc][cmp];
 	}
 	else {
 	  f[c][cmp] = new realnum[gv.ntot()];
-	  for (int i=0;i<gv.ntot();i++) f[c][cmp][i] = 0.0;
+	  for (meep::integer i=0;i<gv.ntot();i++) f[c][cmp][i] = 0.0;
 	}
       }
     }

--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -80,46 +80,46 @@ static complex<double> JP(const vec &pt) {
   return polar(Jprime(m_for_J, ktrans*pt.r()),kax*pt.r());
 }
 
-void fields::initialize_with_nth_te(int np0) {
+void fields::initialize_with_nth_te(meep::integer np0) {
   require_component(Hz);
   for (int i=0;i<num_chunks;i++)
     chunks[i]->initialize_with_nth_te(np0, real(k[Z]));
 }
 
-void fields_chunk::initialize_with_nth_te(int np0, double kz) {
-  const int im = int(m);
-  const int n = (im==0) ? np0 - 0 : np0 - 1;
+void fields_chunk::initialize_with_nth_te(meep::integer np0, double kz) {
+  const int im = static_cast<int>(m);
+  const int n = static_cast<int>((im==0) ? np0 - 0 : np0 - 1);
   const double rmax = Jmax(im,n);
-  ktrans = rmax*a/gv.nr();
+  ktrans = rmax*a/static_cast<double>(gv.nr());
   kax = kz*2*pi/a;
   m_for_J = im;
   initialize_field(Hz, JJ);
 }
 
-void fields::initialize_with_nth_tm(int np0) {
+void fields::initialize_with_nth_tm(meep::integer np0) {
   require_component(Ez);
   require_component(Hp);
   for (int i=0;i<num_chunks;i++)
     chunks[i]->initialize_with_nth_tm(np0, real(k[Z]));
 }
 
-void fields_chunk::initialize_with_nth_tm(int np1, double kz) {
-  const int im = int(m);
-  const int n = np1 - 1;
+void fields_chunk::initialize_with_nth_tm(meep::integer np1, double kz) {
+  const int im = static_cast<int>(m);
+  const int n = static_cast<int>(np1 - 1);
   const double rroot = Jroot(im,n);
-  ktrans = rroot*a/gv.nr();
+  ktrans = rroot*a/static_cast<double>(gv.nr());
   kax = kz*2*pi/a;
   m_for_J = im;
   initialize_field(Ez, JJ);
   initialize_field(Hp, JP);
 }
 
-void fields::initialize_with_n_te(int ntot) {
-  for (int n=0;n<ntot;n++) initialize_with_nth_te(n+1);
+void fields::initialize_with_n_te(meep::integer ntot) {
+  for (meep::integer n=0;n<ntot;n++) initialize_with_nth_te(n+1);
 }
 
-void fields::initialize_with_n_tm(int ntot) {
-  for (int n=0;n<ntot;n++) initialize_with_nth_tm(n+1);
+void fields::initialize_with_n_tm(meep::integer ntot) {
+  for (meep::integer n=0;n<ntot;n++) initialize_with_nth_tm(n+1);
 }
 
 void fields::initialize_field(component c, complex<double> func(const vec &)) {

--- a/src/integrate.cpp
+++ b/src/integrate.cpp
@@ -30,7 +30,7 @@ struct integrate_data {
   component *cS;
   complex<double> *ph;
   complex<double> *fvals;
-  int *offsets;
+  meep::integer *offsets;
   int ninveps;
   component inveps_cs[3];
   direction inveps_ds[3];
@@ -53,17 +53,17 @@ static void integrate_chunkloop(fields_chunk *fc, int ichunk, component cgrid,
 {
   (void) ichunk; // unused
   integrate_data *data = (integrate_data *) data_;
-  int *off = data->offsets;
+  meep::integer *off = data->offsets;
   component *cS = data->cS;
   complex<double> *fvals = data->fvals, *ph = data->ph;
   complex<long double> sum = 0.0;
   double maxabs = 0;
   const component *iecs = data->inveps_cs;
   const direction *ieds = data->inveps_ds;
-  int ieos[6];
+  meep::integer ieos[6];
   const component *imcs = data->invmu_cs;
   const direction *imds = data->invmu_ds;
-  int imos[6];
+  meep::integer imos[6];
 
   for (int i = 0; i < data->num_fvals; ++i) {
     cS[i] = S.transform(data->components[i], -sn);
@@ -123,7 +123,7 @@ static void integrate_chunkloop(fields_chunk *fc, int ichunk, component cgrid,
     complex<double> integrand = 
       data->integrand(fvals, loc, data->integrand_data_);
     maxabs = max(maxabs, abs(integrand));
-    sum += integrand * IVEC_LOOP_WEIGHT(s0, s1, e0, e1, dV0 + dV1 * loop_i2);
+    sum += integrand * IVEC_LOOP_WEIGHT(s0, s1, e0, e1, dV0 + dV1 * static_cast<double>(loop_i2));
   }
 
   data->maxabs = max(data->maxabs, maxabs);
@@ -185,7 +185,7 @@ complex<double> fields::integrate(int num_fvals, const component *components,
       ++data.ninvmu;
     }
   
-  data.offsets = new int[2 * num_fvals];
+  data.offsets = new meep::integer[2 * num_fvals];
   for (int i = 0; i < 2 * num_fvals; ++i)
     data.offsets[i] = 0;
 
@@ -200,7 +200,9 @@ complex<double> fields::integrate(int num_fvals, const component *components,
     *maxabs = max_to_all(data.maxabs);
   data.sum = sum_to_all(data.sum);
 
-  return complex<double>(real(data.sum), imag(data.sum));
+  return complex<double>(
+		  static_cast<double>(real(data.sum)),
+		  static_cast<double>(imag(data.sum)));
 }
 
 typedef struct { 

--- a/src/integrate2.cpp
+++ b/src/integrate2.cpp
@@ -36,7 +36,7 @@ struct integrate_data {
   component *cS;
   complex<double> *ph;
   complex<double> *fvals;
-  int *offsets;
+  meep::integer *offsets;
   int ninveps;
   component inveps_cs[3];
   direction inveps_ds[3];
@@ -59,19 +59,19 @@ static void integrate_chunkloop(fields_chunk *fc, int ichunk, component cgrid,
 {
   (void) ichunk; // unused
   integrate_data *data = (integrate_data *) data_;
-  int *off = data->offsets;
+  meep::integer *off = data->offsets;
   component *cS = data->cS;
   complex<double> *fvals = data->fvals, *ph = data->ph;
   complex<long double> sum = 0.0;
   double maxabs = 0;
   const component *iecs = data->inveps_cs;
   const direction *ieds = data->inveps_ds;
-  int ieos[6];
+  meep::integer ieos[6];
   const component *imcs = data->invmu_cs;
   const direction *imds = data->invmu_ds;
   int num_fvals1 = data->num_fvals;
   int num_fvals2 = data->num_fvals2;
-  int imos[6];
+  meep::integer imos[6];
   const fields_chunk *fc2 = data->fields2->chunks[ichunk];
 
   for (int i = 0; i < num_fvals1; ++i) {
@@ -179,7 +179,7 @@ static void integrate_chunkloop(fields_chunk *fc, int ichunk, component cgrid,
     complex<double> integrand = 
       data->integrand(fvals, loc, data->integrand_data_);
     maxabs = max(maxabs, abs(integrand));
-    sum += integrand * IVEC_LOOP_WEIGHT(s0, s1, e0, e1, dV0 + dV1 * loop_i2);
+    sum += integrand * static_cast<double>(IVEC_LOOP_WEIGHT(s0, s1, e0, e1, dV0 + dV1 * static_cast<double>(loop_i2)));
   }
 
   data->maxabs = max(data->maxabs, maxabs);
@@ -268,7 +268,7 @@ complex<double> fields::integrate2(const fields &fields2,
       ++data.ninvmu;
     }
   
-  data.offsets = new int[2 * (num_fvals1 + num_fvals2)];
+  data.offsets = new meep::integer[2 * (num_fvals1 + num_fvals2)];
   for (int i = 0; i < 2 * (num_fvals1 + num_fvals2); ++i)
     data.offsets[i] = 0;
 
@@ -283,7 +283,9 @@ complex<double> fields::integrate2(const fields &fields2,
     *maxabs = max_to_all(data.maxabs);
   data.sum = sum_to_all(data.sum);
 
-  return complex<double>(real(data.sum), imag(data.sum));
+  return complex<double>(
+		  static_cast<double>(real(data.sum)),
+		  static_cast<double>(imag(data.sum)));
 }
 
 typedef struct { 

--- a/src/loop_in_chunks.cpp
+++ b/src/loop_in_chunks.cpp
@@ -210,6 +210,7 @@ static ivec vec2diel_ceil(const vec &pt, double a, const ivec &equal_shift) {
 }
 
 static inline int iabs(int i) { return (i < 0 ? -i : i); }
+static inline long int iabs(long int i) { return (i < 0L ? -i : i); }
 
 /* Generic function for computing loops within the chunks, often
    integral-like things, over a grid_volume WHERE.  The job of this
@@ -289,8 +290,10 @@ void fields::loop_in_chunks(field_chunkloop chunkloop, void *chunkloop_data,
   vec s0(gv.dim), e0(gv.dim), s1(gv.dim), e1(gv.dim);
   LOOP_OVER_DIRECTIONS(gv.dim, d) {
     double w0, w1;
-    w0 = 1. - wherec.in_direction_min(d)*gv.a + 0.5*is.in_direction(d);
-    w1 = 1. + wherec.in_direction_max(d)*gv.a - 0.5*ie.in_direction(d);
+    w0 = 1.0 - static_cast<double>(wherec.in_direction_min(d))*gv.a
+    		+ 0.5*static_cast<double>(is.in_direction(d));
+    w1 = 1.0 + static_cast<double>(wherec.in_direction_max(d))*gv.a
+    		- 0.5*static_cast<double>(ie.in_direction(d));
     if (ie.in_direction(d) >= is.in_direction(d) + 3*2) {
       s0.set_direction(d, w0*w0 / 2);
       s1.set_direction(d, 1 - (1-w0)*(1-w0) / 2);
@@ -307,8 +310,12 @@ void fields::loop_in_chunks(field_chunkloop chunkloop, void *chunkloop_data,
       if (snap_empty_dims) {
 	if (w0 > w1) ie.set_direction(d, is.in_direction(d));
 	else is.set_direction(d, ie.in_direction(d));
-	wherec.set_direction_min(d, is.in_direction(d) * (0.5*gv.inva));
-	wherec.set_direction_max(d, is.in_direction(d) * (0.5*gv.inva));
+	wherec.set_direction_min(d,
+			static_cast<double>(is.in_direction(d))
+			* (0.5*static_cast<double>(gv.inva)));
+	wherec.set_direction_max(d,
+			static_cast<double>(is.in_direction(d))
+			* (0.5*static_cast<double>(gv.inva)));
 	w0 = w1 = 1.0;
       }
       s0.set_direction(d, w0);
@@ -366,9 +373,13 @@ void fields::loop_in_chunks(field_chunkloop chunkloop, void *chunkloop_data,
       vec shift(gv.dim, 0.0);
       ivec shifti(gv.dim, 0);
       LOOP_OVER_DIRECTIONS(gv.dim, d) {
-	shift.set_direction(d, L.in_direction(d) * ishift.in_direction(d));
-	shifti.set_direction(d, iL.in_direction(d) * ishift.in_direction(d));
-	ph *= pow(eikna[d], ishift.in_direction(d));
+	shift.set_direction(d,
+			static_cast<double>(L.in_direction(d))
+			* static_cast<double>(ishift.in_direction(d)));
+	shifti.set_direction(d,
+			static_cast<meep::integer>(iL.in_direction(d))
+			* static_cast<meep::integer>(ishift.in_direction(d)));
+	ph *= pow(eikna[d], static_cast<double>(ishift.in_direction(d)));
       }
 
       for (int i = 0; i < num_chunks; ++i) {
@@ -391,7 +402,7 @@ void fields::loop_in_chunks(field_chunkloop chunkloop, void *chunkloop_data,
 	}
 
 	ivec iscS(max(is-shifti, vec2diel_ceil(vS.get_min_corner(),
-					       gv.a, one_ivec(gv.dim) * 2)));
+					       gv.a, one_ivec(gv.dim) * static_cast<meep::integer>(2))));
 	ivec iecS(min(ie-shifti, vec2diel_floor(vS.get_max_corner(),
 						gv.a, zero_ivec(gv.dim))));
 	if (iscS <= iecS) {
@@ -434,7 +445,7 @@ void fields::loop_in_chunks(field_chunkloop chunkloop, void *chunkloop_data,
 
 	    // swap endpoints/weights if in wrong order due to S.transform
 	    if (isc.in_direction(d) > iec.in_direction(d)) {
-	      int iswap = isc.in_direction(d);
+	      meep::integer iswap = isc.in_direction(d);
 	      isc.set_direction(d, iec.in_direction(d));
 	      iec.set_direction(d, iswap);
 	      double swap = s0c.in_direction(d);

--- a/src/loop_in_chunks.cpp
+++ b/src/loop_in_chunks.cpp
@@ -19,6 +19,7 @@
 #include <stdlib.h>
 #include <math.h>
 
+#include "config.h"
 #include "meep.hpp"
 #include "meep_internals.hpp"
 
@@ -211,6 +212,10 @@ static ivec vec2diel_ceil(const vec &pt, double a, const ivec &equal_shift) {
 
 static inline int iabs(int i) { return (i < 0 ? -i : i); }
 static inline long int iabs(long int i) { return (i < 0L ? -i : i); }
+
+#ifdef HAVE_LONG_LONG_INT
+static inline long long int iabs(long long int i) { return (i < 0L ? -i : i); }
+#endif
 
 /* Generic function for computing loops within the chunks, often
    integral-like things, over a grid_volume WHERE.  The job of this

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -20,6 +20,7 @@
 #include <stdio.h>
 #include <math.h>
 
+#include "meep/meeptypes.hpp"
 #include "meep/vec.hpp"
 #include "meep/mympi.hpp"
 
@@ -124,13 +125,13 @@ public:
   /* the number of notowned fields/data in the internal data that
      are needed by update_P for the c Yee grid (note: we assume that we only
      have internal data for c's where we have external polarizations) */
-  virtual int num_internal_notowned_needed(component c,
+  virtual meep::integer num_internal_notowned_needed(component c,
 					   void *P_internal_data) const {
     (void) c; (void) P_internal_data; return 0; }
   /* the offset into the internal data of the n'th Yee-grid point in
      the c Yee grid for the inotowned internal field, where
      0 <= inotowned < size_internal_notowned_needed. */
-  virtual realnum *internal_notowned_ptr(int inotowned, component c, int n,
+  virtual realnum *internal_notowned_ptr(meep::integer inotowned, component c, meep::integer n,
 					 void *P_internal_data) const {
     (void) inotowned; (void) n; (void) c; (void) P_internal_data; return 0; }
   
@@ -138,18 +139,18 @@ public:
      internal fields that need to be multiplied by the same phase
      factor as the fields at boundaries.  Note: we assume internal fields
      are complex if and only if !is_real (i.e. if EM fields are complex) */
-  virtual int num_cinternal_notowned_needed(component c,
+  virtual meep::integer num_cinternal_notowned_needed(component c,
 					   void *P_internal_data) const {
     (void) c; (void) P_internal_data; return 0; }
   // real/imaginary parts offsets for cmp = 0/1
-  virtual realnum *cinternal_notowned_ptr(int inotowned, component c, int cmp, 
-					  int n, 
+  virtual realnum *cinternal_notowned_ptr(meep::integer inotowned, component c, meep::integer cmp,
+		  meep::integer n,
 					  void *P_internal_data) const {
     (void) inotowned; (void) n; (void) c; (void) cmp; (void) P_internal_data; 
     return 0; }
   
   susceptibility *next;
-  int ntot;
+  meep::integer ntot;
   realnum *sigma[NUM_FIELD_COMPONENTS][5];
 
   /* trivial_sigma[c][d] is true only if *none* of the processes has a
@@ -191,10 +192,10 @@ public:
 			  double dt, const grid_volume &gv, void *data) const;
   virtual void *copy_internal_data(void *data) const;
 
-  virtual int num_cinternal_notowned_needed(component c,
+  virtual meep::integer num_cinternal_notowned_needed(component c,
 					    void *P_internal_data) const;
-  virtual realnum *cinternal_notowned_ptr(int inotowned, component c, int cmp, 
-					  int n, 
+  virtual realnum *cinternal_notowned_ptr(meep::integer inotowned, component c, meep::integer cmp,
+		  	  	  	  meep::integer n,
 					  void *P_internal_data) const;
 protected:
   double omega_0, gamma;
@@ -249,10 +250,10 @@ public:
   virtual void *copy_internal_data(void *data) const;
   virtual void delete_internal_data(void *data) const;
 
-  virtual int num_cinternal_notowned_needed(component c,
+  virtual meep::integer num_cinternal_notowned_needed(component c,
 					    void *P_internal_data) const;
-  virtual realnum *cinternal_notowned_ptr(int inotowned, component c, int cmp, 
-					  int n, 
+  virtual realnum *cinternal_notowned_ptr(meep::integer inotowned, component c, meep::integer cmp,
+		  	  	  	  meep::integer n,
 					  void *P_internal_data) const;
 
   // always need notowned W and W_prev for E dot dP/dt terms
@@ -290,26 +291,26 @@ public:
   
   bool ok();
   
-  realnum *read(const char *dataname, int *rank, int *dims, int maxrank);
-  void write(const char *dataname, int rank, const int *dims, realnum *data,
+  realnum *read(const char *dataname, int *rank, meep::integer *dims, int maxrank);
+  void write(const char *dataname, int rank, const meep::integer *dims, realnum *data,
 	     bool single_precision = true);
   
   char *read(const char *dataname);
   void write(const char *dataname, const char *data);
   
-  void create_data(const char *dataname, int rank, const int *dims,
+  void create_data(const char *dataname, int rank, const meep::integer *dims,
 		   bool append_data = false,
 		   bool single_precision = true);
-  void extend_data(const char *dataname, int rank, const int *dims);
+  void extend_data(const char *dataname, int rank, const meep::integer *dims);
   void create_or_extend_data(const char *dataname, int rank,
-			     const int *dims,
+			     const meep::integer *dims,
 			     bool append_data, bool single_precision);
-  void write_chunk(int rank, const int *chunk_start, const int *chunk_dims,
+  void write_chunk(int rank, const meep::integer *chunk_start, const meep::integer *chunk_dims,
 		   realnum *data);
   void done_writing_chunks();
   
-  void read_size(const char *dataname, int *rank, int *dims, int maxrank);
-  void read_chunk(int rank, const int *chunk_start, const int *chunk_dims,
+  void read_size(const char *dataname, int *rank, meep::integer *dims, int maxrank);
+  void read_chunk(int rank, const meep::integer *chunk_start, const meep::integer *chunk_dims,
 		  realnum *data);
   
   void remove();
@@ -442,7 +443,7 @@ class structure_chunk {
   realnum *condinv[NUM_FIELD_COMPONENTS][5]; // cache of 1/(1+conduct*dt/2)
   bool condinv_stale; // true if condinv needs to be recomputed
   double *sig[5], *kap[5], *siginv[5]; // conductivity array for uPML
-  int sigsize[5]; // conductivity array size
+  meep::integer sigsize[5]; // conductivity array size
   grid_volume gv;  // integer grid_volume that could be bigger than non-overlapping v below
   volume v;
   susceptibility *chiP[NUM_FIELD_TYPES]; // only E_stuff and H_stuff are used
@@ -843,7 +844,7 @@ public:
 
   component c; // component to DFT (possibly transformed by symmetry)
 
-  int N; // number of spatial points (on epsilon grid)
+  meep::integer N; // number of spatial points (on epsilon grid)
   std::complex<realnum> *dft; // N x Nomega array of DFT values.
 
   struct dft_chunk *next_in_chunk; // per-fields_chunk list of DFT chunks
@@ -871,7 +872,7 @@ public:
   // cache of exp(iwt) * scale, of length Nomega
   std::complex<realnum> *dft_phase;
 
-  int avg1, avg2; // index offsets for average to get epsilon grid
+  meep::integer avg1, avg2; // index offsets for average to get epsilon grid
 
   int vc; // component descriptor from the original volume
 };
@@ -1050,7 +1051,7 @@ class fields_chunk {
   realnum **zeroes[NUM_FIELD_TYPES]; // Holds pointers to metal points.
   int num_zeroes[NUM_FIELD_TYPES];
   realnum **connections[NUM_FIELD_TYPES][CONNECT_COPY+1][Outgoing+1];
-  int num_connections[NUM_FIELD_TYPES][CONNECT_COPY+1][Outgoing+1];
+  meep::integer num_connections[NUM_FIELD_TYPES][CONNECT_COPY+1][Outgoing+1];
   std::complex<realnum> *connection_phases[NUM_FIELD_TYPES];
 
   int npol[NUM_FIELD_TYPES]; // only E_stuff and H_stuff are used
@@ -1158,10 +1159,10 @@ class fields_chunk {
 
   // initialize.cpp
   void initialize_field(component, std::complex<double> f(const vec &));
-  void initialize_with_nth_te(int n, double kz);
-  void initialize_with_nth_tm(int n, double kz);
+  void initialize_with_nth_te(meep::integer n, double kz);
+  void initialize_with_nth_tm(meep::integer n, double kz);
   // boundaries.cpp
-  void alloc_extra_connections(field_type, connect_phase, in_or_out, int);
+  void alloc_extra_connections(field_type, connect_phase, in_or_out, meep::integer);
   // dft.cpp
   void update_dfts(double timeE, double timeH);
 
@@ -1202,9 +1203,9 @@ class fields {
   realnum **comm_blocks[NUM_FIELD_TYPES];
   // This is the same size as each comm_blocks array, and store the sizes
   // of the comm blocks themselves for each connection-phase type
-  int *comm_sizes[NUM_FIELD_TYPES][CONNECT_COPY+1];
-  int comm_size_tot(int f, int pair) const {
-    int sum = 0; for (int ip=0; ip<3; ++ip) sum+=comm_sizes[f][ip][pair];
+  meep::integer *comm_sizes[NUM_FIELD_TYPES][CONNECT_COPY+1];
+  meep::integer comm_size_tot(int f, int pair) const {
+    meep::integer sum = 0; for (int ip=0; ip<3; ++ip) sum+=comm_sizes[f][ip][pair];
     return sum;
   }
 
@@ -1335,10 +1336,10 @@ class fields {
 
   // initialize.cpp:
   void initialize_field(component, std::complex<double> f(const vec &));
-  void initialize_with_nth_te(int n);
-  void initialize_with_nth_tm(int n);
-  void initialize_with_n_te(int n);
-  void initialize_with_n_tm(int n);
+  void initialize_with_nth_te(meep::integer n);
+  void initialize_with_nth_tm(meep::integer n);
+  void initialize_with_n_te(meep::integer n);
+  void initialize_with_n_tm(meep::integer n);
   int phase_in_material(const structure *s, double time);
   int is_phasing();
 

--- a/src/meep/meeptypes.hpp
+++ b/src/meep/meeptypes.hpp
@@ -1,0 +1,34 @@
+/* Copyright (C) 2005-2015 Massachusetts Institute of Technology
+%
+%  This program is free software; you can redistribute it and/or modify
+%  it under the terms of the GNU General Public License as published by
+%  the Free Software Foundation; either version 2, or (at your option)
+%  any later version.
+%
+%  This program is distributed in the hope that it will be useful,
+%  but WITHOUT ANY WARRANTY; without even the implied warranty of
+%  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%  GNU General Public License for more details.
+%
+%  You should have received a copy of the GNU General Public License
+%  along with this program; if not, write to the Free Software Foundation,
+%  Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+*/
+
+#ifndef MEEPTYPES_HPP_
+#define MEEPTYPES_HPP_
+
+#include <stddef.h>
+
+/*
+ * Integer type used by meep for indexing arrays. It should be set to an SIGNED
+ * INTEGER TYPE that can hold all possible memory addresses on the particular
+ * system, e.g. a 32 bit int on a 32 bit system and a 64 bit int on a 64 bit
+ * system. Usually ptrdiff_t should be a reasonable default as it fulfills those
+ * requirements.
+ */
+namespace meep{
+	typedef ptrdiff_t integer;
+} /* namespace meep */
+
+#endif /* MEEPTYPES_HPP_ */

--- a/src/meep/mympi.hpp
+++ b/src/meep/mympi.hpp
@@ -19,7 +19,19 @@
 #define MEEP_MY_MPI_H
 
 #include <complex>
+#include "config.h"
 #include "meeptypes.hpp"
+
+#ifdef HAVE_MPI
+#  include <mpi.h>
+#  if SIZEOF_PTRDIFF_T == SIZEOF_INT
+#    define MPI_MEEP_INTEGER MPI_INT
+#  elif SIZEOF_PTRDIFF_T == SIZEOF_LONG_INT
+#    define MPI_MEEP_INTEGER MPI_LONG
+#  elif SIZEOF_PTRDIFF_T == SIZEOF_LONG_LONG_INT
+#    define MPI_MEEP_INTEGER MPI_LONG_LONG_INT
+#  endif
+#endif
 
 namespace meep {
 
@@ -76,15 +88,22 @@ void sum_to_master(const std::complex<double> *in, std::complex<double> *out, me
 long double sum_to_all(long double);
 std::complex<double> sum_to_all(std::complex<double> in);
 std::complex<long double> sum_to_all(std::complex<long double> in);
-int sum_to_all(int);
+int sum_to_all(int in);
 int partial_sum_to_all(int in);
-long int sum_to_all(long int );
+long int sum_to_all(long int in);
 long int partial_sum_to_all(long int in);
 
 bool or_to_all(bool in);
 void or_to_all(const int *in, int *out, int size);
 bool and_to_all(bool in);
 void and_to_all(const int *in, int *out, int size);
+
+#ifdef HAVE_LONG_LONG_INT
+void broadcast(int from, long long int *data, meep::integer size);
+long long int broadcast(int from, long long int data);
+long long int sum_to_all(long long int in);
+long long int partial_sum_to_all(long long int in);
+#endif
 
 // IO routines:
 void master_printf(const char *fmt, ...) PRINTF_ATTR(1,2);

--- a/src/meep/mympi.hpp
+++ b/src/meep/mympi.hpp
@@ -19,6 +19,7 @@
 #define MEEP_MY_MPI_H
 
 #include <complex>
+#include "meeptypes.hpp"
 
 namespace meep {
 
@@ -51,30 +52,35 @@ bool am_really_master();
 inline int am_master() { return my_rank() == 0; }
 
 void send(int from, int to, double *data, int size=1);
-void broadcast(int from, double *data, int size);
-void broadcast(int from, char *data, int size);
-void broadcast(int from, int *data, int size);
-void broadcast(int from, std::complex<double> *data, int size);
+void broadcast(int from, double *data, meep::integer size);
+void broadcast(int from, char *data, meep::integer size);
+void broadcast(int from, int *data, meep::integer size);
+void broadcast(int from, long int *data, meep::integer size);
+void broadcast(int from, std::complex<double> *data, meep::integer size);
 std::complex<double> broadcast(int from, std::complex<double> data);
 double broadcast(int from, double data);
 int broadcast(int from, int data);
+long int broadcast(int from, long int data);
 bool broadcast(int from, bool);
 double max_to_master(double); // Only returns the correct value to proc 0.
 double max_to_all(double);
 int max_to_all(int);
 double sum_to_master(double); // Only returns the correct value to proc 0.
 double sum_to_all(double);
-void sum_to_all(const double *in, double *out, int size);
-void sum_to_master(const double *in, double *out, int size);
-void sum_to_all(const float *in, double *out, int size);
-void sum_to_all(const std::complex<float> *in, std::complex<double> *out, int size);
-void sum_to_all(const std::complex<double> *in, std::complex<double> *out, int size);
-void sum_to_master(const std::complex<double> *in, std::complex<double> *out, int size);
+void sum_to_all(const double *in, double *out, meep::integer size);
+void sum_to_master(const double *in, double *out, meep::integer size);
+void sum_to_all(const float *in, double *out, meep::integer size);
+void sum_to_all(const std::complex<float> *in, std::complex<double> *out, meep::integer size);
+void sum_to_all(const std::complex<double> *in, std::complex<double> *out, meep::integer size);
+void sum_to_master(const std::complex<double> *in, std::complex<double> *out, meep::integer size);
 long double sum_to_all(long double);
 std::complex<double> sum_to_all(std::complex<double> in);
 std::complex<long double> sum_to_all(std::complex<long double> in);
 int sum_to_all(int);
 int partial_sum_to_all(int in);
+long int sum_to_all(long int );
+long int partial_sum_to_all(long int in);
+
 bool or_to_all(bool in);
 void or_to_all(const int *in, int *out, int size);
 bool and_to_all(bool in);

--- a/src/meep/vec.hpp
+++ b/src/meep/vec.hpp
@@ -20,6 +20,7 @@
 #define MEEP_VEC_H
 
 #include <complex>
+#include "meeptypes.hpp"
 
 namespace meep {
 
@@ -119,7 +120,7 @@ component first_field_component(field_type ft);
 
 // loop over indices idx from is to ie (inclusive) in gv
 #define LOOP_OVER_IVECS(gv, is, ie, idx) \
-  for (int loop_is1 = (is).yucky_val(0), \
+  for (meep::integer loop_is1 = (is).yucky_val(0), \
            loop_is2 = (is).yucky_val(1), \
            loop_is3 = (is).yucky_val(2), \
            loop_n1 = ((ie).yucky_val(0) - loop_is1) / 2 + 1, \
@@ -135,8 +136,8 @@ component first_field_component(field_type ft);
                 + (is - (gv).little_corner()).yucky_val(1) / 2 * loop_s2 \
                 + (is - (gv).little_corner()).yucky_val(2) / 2 * loop_s3,\
            loop_i1 = 0; loop_i1 < loop_n1; loop_i1++) \
-    for (int loop_i2 = 0; loop_i2 < loop_n2; loop_i2++) \
-      for (int idx = idx0 + loop_i1*loop_s1 + loop_i2*loop_s2, \
+    for (meep::integer loop_i2 = 0; loop_i2 < loop_n2; loop_i2++) \
+      for (meep::integer idx = idx0 + loop_i1*loop_s1 + loop_i2*loop_s2, \
            loop_i3 = 0; loop_i3 < loop_n3; loop_i3++, idx+=loop_s3)
 
 #define LOOP_OVER_VOL(gv, c, idx) \
@@ -151,7 +152,7 @@ component first_field_component(field_type ft);
 #define LOOP_OVER_VOL_NOTOWNED(gv, c, idx) \
  for (ivec loop_notowned_is((gv).dim,0), loop_notowned_ie((gv).dim,0); \
       loop_notowned_is == zero_ivec((gv).dim);) \
-   for (int loop_ibound = 0; (gv).get_boundary_icorners(c, loop_ibound,     \
+   for (meep::integer loop_ibound = 0; (gv).get_boundary_icorners(c, loop_ibound,     \
 		  				       &loop_notowned_is,  \
 						       &loop_notowned_ie); \
 	loop_ibound++) \
@@ -172,7 +173,7 @@ component first_field_component(field_type ft);
 
 // loop over indices idx from is to ie (inclusive) in gv
 #define S1LOOP_OVER_IVECS(gv, is, ie, idx) \
-  for (int loop_is1 = (is).yucky_val(0), \
+  for (meep::integer loop_is1 = (is).yucky_val(0), \
            loop_is2 = (is).yucky_val(1), \
            loop_is3 = (is).yucky_val(2), \
            loop_n1 = ((ie).yucky_val(0) - loop_is1) / 2 + 1, \
@@ -187,8 +188,8 @@ component first_field_component(field_type ft);
                 + (is - (gv).little_corner()).yucky_val(1) / 2 * loop_s2 \
                 + (is - (gv).little_corner()).yucky_val(2) / 2 * loop_s3,\
            loop_i1 = 0; loop_i1 < loop_n1; loop_i1++) \
-    for (int loop_i2 = 0; loop_i2 < loop_n2; loop_i2++) _Pragma("ivdep") \
-      for (int idx = idx0 + loop_i1*loop_s1 + loop_i2*loop_s2, \
+    for (meep::integer loop_i2 = 0; loop_i2 < loop_n2; loop_i2++) _Pragma("ivdep") \
+      for (meep::integer idx = idx0 + loop_i1*loop_s1 + loop_i2*loop_s2, \
            loop_i3 = 0; loop_i3 < loop_n3; loop_i3++, idx++)
 
 #define S1LOOP_OVER_VOL(gv, c, idx) \
@@ -203,7 +204,7 @@ component first_field_component(field_type ft);
 #define S1LOOP_OVER_VOL_NOTOWNED(gv, c, idx) \
  for (ivec loop_notowned_is((gv).dim,0), loop_notowned_ie((gv).dim,0); \
       loop_notowned_is == meep::zero_ivec((gv).dim);)			\
-   for (int loop_ibound = 0; (gv).get_boundary_icorners(c, loop_ibound,     \
+   for (meep::integer loop_ibound = 0; (gv).get_boundary_icorners(c, loop_ibound,     \
 		  				       &loop_notowned_is,  \
 						       &loop_notowned_ie); \
 	loop_ibound++) \
@@ -222,9 +223,12 @@ component first_field_component(field_type ft);
 
 #define IVEC_LOOP_LOC(gv, loc) \
   vec loc((gv).dim); \
-  loc.set_direction(direction(loop_d1), (0.5*loop_is1 + loop_i1) * (gv).inva); \
-  loc.set_direction(direction(loop_d2), (0.5*loop_is2 + loop_i2) * (gv).inva); \
-  loc.set_direction(direction(loop_d3), (0.5*loop_is3 + loop_i3) * (gv).inva)
+  loc.set_direction(direction(loop_d1), (0.5*static_cast<double>(loop_is1) \
+		  + static_cast<double>(loop_i1)) * static_cast<double>((gv).inva)); \
+  loc.set_direction(direction(loop_d2), (0.5*static_cast<double>(loop_is2) \
+		  + static_cast<double>(loop_i2)) * static_cast<double>((gv).inva)); \
+  loc.set_direction(direction(loop_d3), (0.5*static_cast<double>(loop_is3) \
+		  + static_cast<double>(loop_i3)) * static_cast<double>((gv).inva))
 
 // integration weight for using LOOP_OVER_IVECS with field::integrate
 #define IVEC_LOOP_WEIGHT1x(s0, s1, e0, e1, i, n, dir) ((i > 1 && i < n - 2) ? 1.0 : (i == 0 ? (s0).in_direction(meep::direction(dir)) : (i == 1 ? (s1).in_direction(meep::direction(dir)) : i == n - 1 ? (e0).in_direction(meep::direction(dir)) : (i == n - 2 ? (e1).in_direction(meep::direction(dir)) : 1.0))))
@@ -511,7 +515,7 @@ inline vec veccyl(double rr, double zz) {
 }
 
 class ivec;
-ivec iveccyl(int xx, int yy);
+ivec iveccyl(meep::integer xx, meep::integer yy);
 ivec zero_ivec(ndim);
 ivec one_ivec(ndim);
 
@@ -519,17 +523,17 @@ class ivec {
  public:
   ivec() { dim = D2; t[X] = t[Y] = 0; };
   ivec(ndim di) { dim = di; };
-  ivec(ndim di, int val) { dim = di; t[0]=t[1]=t[2]=t[3]=t[4]=val; };
-  ivec(int zz) { dim = D1; t[Z] = zz; };
-  ivec(int xx, int yy) { dim = D2; t[X] = xx; t[Y] = yy; };
-  ivec(int xx, int yy, int zz) {
+  ivec(ndim di, meep::integer val) { dim = di; t[0]=t[1]=t[2]=t[3]=t[4]=val; };
+  ivec(meep::integer zz) { dim = D1; t[Z] = zz; };
+  ivec(meep::integer xx, meep::integer yy) { dim = D2; t[X] = xx; t[Y] = yy; };
+  ivec(meep::integer xx, meep::integer yy, meep::integer zz) {
     dim = D3; t[X] = xx; t[Y] = yy; t[Z] = zz; };
-  friend ivec iveccyl(int xx, int yy);
+  friend ivec iveccyl(meep::integer xx, meep::integer yy);
   ~ivec() {};
 
   // Only an idiot (or a macro) would use a yucky function.  Don't be an
   // idiot.
-  int yucky_val(int) const;
+  meep::integer yucky_val(int) const;
 
   ivec operator+(const ivec &a) const {
     ivec result = a;
@@ -589,7 +593,7 @@ class ivec {
     return true;
   };
 
-  ivec operator*(int s) const {
+  ivec operator*(meep::integer s) const {
     ivec result = *this;
     LOOP_OVER_DIRECTIONS(dim, d) result.t[d] *= s;
     return result;
@@ -597,17 +601,17 @@ class ivec {
 
   vec operator*(double s) const {
     vec result(dim);
-    LOOP_OVER_DIRECTIONS(dim, d) result.set_direction(d, t[d] * s);
+    LOOP_OVER_DIRECTIONS(dim, d) result.set_direction(d, static_cast<double>(t[d]) * s);
     return result;
   };
   ndim dim;
 
-  int r() const { return t[R]; };
-  int x() const { return t[X]; };
-  int y() const { return t[Y]; };
-  int z() const { return t[Z]; };
-  int in_direction(direction d) const { return t[d]; };
-  void set_direction(direction d, int val) { t[d] = val; };
+  meep::integer r() const { return t[R]; };
+  meep::integer x() const { return t[X]; };
+  meep::integer y() const { return t[Y]; };
+  meep::integer z() const { return t[Z]; };
+  meep::integer in_direction(direction d) const { return t[d]; };
+  void set_direction(direction d, meep::integer val) { t[d] = val; };
 
   ivec round_up_to_even(void) const { 
     ivec result(dim);
@@ -619,7 +623,7 @@ class ivec {
   friend ivec zero_ivec(ndim);
   friend ivec one_ivec(ndim);
  private:
-  int t[5];
+  meep::integer t[5];
 };
 
 inline ivec zero_ivec(ndim di) {
@@ -638,7 +642,7 @@ inline ivec unit_ivec(ndim di, direction d) {
   return pt;
 }
 
-inline ivec iveccyl(int rr, int zz) {
+inline ivec iveccyl(meep::integer rr, meep::integer zz) {
   ivec pt(Dcyl); pt.t[R] = rr; pt.t[Z] = zz; return pt;
 }
 
@@ -722,19 +726,19 @@ class grid_volume {
   double a, inva /* = 1/a */;
 
   void print() const;
-  int stride(direction d) const { return the_stride[d]; };
-  int num_direction(direction d) const {
+  meep::integer stride(direction d) const { return the_stride[d]; };
+  meep::integer num_direction(direction d) const {
     return num[((int) d) % 3];
   };
   // Only an idiot (or a macro) would use a yucky function.  Don't be an
   // idiot.
-  int yucky_num(int) const;
+  meep::integer yucky_num(int) const;
   direction yucky_direction(int) const;
-  void set_num_direction(direction d, int value);
-  int nr() const { return num_direction(R); }
-  int nx() const { return num_direction(X); }
-  int ny() const { return num_direction(Y); }
-  int nz() const { return num_direction(Z); }
+  void set_num_direction(direction d, meep::integer value);
+  meep::integer nr() const { return num_direction(R); }
+  meep::integer nx() const { return num_direction(X); }
+  meep::integer ny() const { return num_direction(Y); }
+  meep::integer nz() const { return num_direction(Z); }
 
   bool has_field(component c) const {
     if (dim == D1) return c == Ex || c == Hy || c == Dx || c == By;
@@ -747,16 +751,16 @@ class grid_volume {
   vec dy() const;
   vec dz() const;
 
-  int ntot() const { return the_ntot; }
-  int nowned_min() const { int n = 1; LOOP_OVER_DIRECTIONS(dim,d) n *= num_direction(d); return n; }
-  int nowned(component c) const;
+  meep::integer ntot() const { return the_ntot; }
+  meep::integer nowned_min() const { meep::integer n = 1; LOOP_OVER_DIRECTIONS(dim,d) n *= num_direction(d); return n; }
+  meep::integer nowned(component c) const;
   vec operator[](const ivec &p) const { return p*(0.5*inva); };
-  int index(component, const ivec &) const;
+  meep::integer index(component, const ivec &) const;
   ivec round_vec(const vec &) const;
-  void interpolate(component, const vec &, int indices[8], double weights[8]) const;
+  void interpolate(component, const vec &, meep::integer indices[8], double weights[8]) const;
   void interpolate(component, const vec &, ivec locs[8], double weights[8]) const;
 
-  volume dV(component c, int index) const;
+  volume dV(component c, meep::integer index) const;
   volume dV(const ivec &, double diameter = 1.0) const;
   bool intersect_with(const grid_volume &vol_in, grid_volume *intersection = NULL, grid_volume *others = NULL, int *num_others = NULL) const;
   double rmin() const;
@@ -769,21 +773,21 @@ class grid_volume {
   double zmax() const;
   vec center() const;
   ivec icenter() const;
-  vec loc(component, int index) const;
+  vec loc(component, meep::integer index) const;
   vec loc_at_resolution(int index, double res) const;
-  int ntot_at_resolution(double res) const;
-  ivec iloc(component, int index) const;
+  meep::integer ntot_at_resolution(double res) const;
+  ivec iloc(component, meep::integer index) const;
 
-  int yee_index(component c) const {
-    int idx = 0;
+  meep::integer yee_index(component c) const {
+    meep::integer idx = 0;
     LOOP_OVER_DIRECTIONS(dim,d)
       idx += (1-iyee_shift(c).in_direction(d))*stride(d);
     return idx;
   }
   vec yee_shift(component) const;
   component eps_component() const;
-  void yee2cent_offsets(component c, int &offset1, int &offset2) const;
-  void cent2yee_offsets(component c, int &offset1, int &offset2) const;
+  void yee2cent_offsets(component c, meep::integer &offset1, meep::integer &offset2) const;
+  void cent2yee_offsets(component c, meep::integer &offset1, meep::integer &offset2) const;
 
   double boundary_location(boundary_side, direction) const;
   ivec big_corner() const;
@@ -796,7 +800,7 @@ class grid_volume {
   /* differs from little_owned_corner in that it doesn't count
      "ownership" of the r=0 origin for Dcyl, which is updated separately */
   ivec little_owned_corner0(component c) const {
-    return ivec(little_corner() + one_ivec(dim)*2 - iyee_shift(c));
+    return ivec(little_corner() + one_ivec(dim)*static_cast<meep::integer>(2) - iyee_shift(c));
   }
 
   ivec little_owned_corner(component c) const;
@@ -804,7 +808,7 @@ class grid_volume {
   volume surroundings() const;
   volume interior() const;
 
-  bool get_boundary_icorners(component c, int ib, ivec *cs, ivec *ce) const;
+  bool get_boundary_icorners(component c, meep::integer ib, ivec *cs, ivec *ce) const;
 
   friend grid_volume volcyl(double rsize, double zsize, double a);
   friend grid_volume volone(double zsize, double a);
@@ -813,9 +817,9 @@ class grid_volume {
   friend grid_volume vol2d(double xsize, double ysize, double a);
   friend grid_volume vol3d(double xsize, double ysize, double zsize, double a);
 
-  grid_volume split(int num, int which) const;
-  grid_volume split_by_effort(int num, int which, int Ngv = 0, const grid_volume *v = NULL, double *effort = NULL) const;
-  grid_volume split_at_fraction(bool want_high, int numer) const;
+  grid_volume split(meep::integer num, meep::integer which) const;
+  grid_volume split_by_effort(meep::integer num, meep::integer which, int Ngv = 0, const grid_volume *v = NULL, double *effort = NULL) const;
+  grid_volume split_at_fraction(bool want_high, meep::integer numer) const;
   grid_volume halve(direction d) const;
   void pad_self(direction d);
   grid_volume pad(direction d) const;
@@ -840,26 +844,26 @@ class grid_volume {
   void set_origin(const ivec &o);
   void shift_origin(const vec &s) { set_origin(origin + s); }
   void shift_origin(const ivec &s) { set_origin(io + s); }
-  void shift_origin(direction d, int s) {shift_origin(unit_ivec(dim, d) * s);}
-  void set_origin(direction d, int o);
+  void shift_origin(direction d, meep::integer s) {shift_origin(unit_ivec(dim, d) * s);}
+  void set_origin(direction d, meep::integer o);
   void center_origin(void) { shift_origin(-icenter()); }
   double origin_in_direction(direction d) const{return origin.in_direction(d);}
-  int iorigin_in_direction(direction d) const{return io.in_direction(d);}
+  meep::integer iorigin_in_direction(direction d) const{return io.in_direction(d);}
   double origin_r() const { return origin.r(); }
   double origin_x() const { return origin.x(); }
   double origin_y() const { return origin.y(); }
   double origin_z() const { return origin.z(); }
 
  private:
-  grid_volume(ndim d, double ta, int na, int nb, int nc);
+  grid_volume(ndim d, double ta, meep::integer na, meep::integer nb, meep::integer nc);
   ivec io; // integer origin ... always change via set_origin etc.!
   vec origin; // cache of operator[](io), for performance
   void update_ntot();
   void set_strides();
   void num_changed() { update_ntot(); set_strides(); }
-  int num[3];
-  int the_stride[5];
-  int the_ntot;
+  meep::integer  num[3];
+  meep::integer the_stride[5];
+  meep::integer the_ntot;
 };
 
 class volume_list;

--- a/src/meep_internals.hpp
+++ b/src/meep_internals.hpp
@@ -15,6 +15,7 @@
 %  Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 */
 
+#include "config.h"
 #include "meep.hpp"
 
 namespace meep {
@@ -28,8 +29,12 @@ inline int max(int a, int b) { return (a > b) ? a : b; }
 inline int min(int a, int b) { return (a < b) ? a : b; }
 inline long int  max(long int  a, long int  b) { return (a > b) ? a : b; }
 inline long int  min(long int  a, long int  b) { return (a < b) ? a : b; }
-//inline long long int  max(long long int  a, long long int  b) { return (a > b) ? a : b; }
-//inline long long int  min(long long int  a, long long int  b) { return (a < b) ? a : b; }
+
+#ifdef HAVE_LONG_LONG_INT
+inline long long int  max(long long int  a, long long int  b) { return (a > b) ? a : b; }
+inline long long int  min(long long int  a, long long int  b) { return (a < b) ? a : b; }
+static inline long long int abs(long long int a) { return a < 0L ? -a : a; }
+#endif
 
 static inline int abs(int a) { return a < 0 ? -a : a; }
 static inline long int abs(long int a) { return a < 0L ? -a : a; }

--- a/src/meep_internals.hpp
+++ b/src/meep_internals.hpp
@@ -26,7 +26,13 @@ inline double max(double a, double b) { return (a > b) ? a : b; }
 inline double min(double a, double b) { return (a < b) ? a : b; }
 inline int max(int a, int b) { return (a > b) ? a : b; }
 inline int min(int a, int b) { return (a < b) ? a : b; }
+inline long int  max(long int  a, long int  b) { return (a > b) ? a : b; }
+inline long int  min(long int  a, long int  b) { return (a < b) ? a : b; }
+//inline long long int  max(long long int  a, long long int  b) { return (a > b) ? a : b; }
+//inline long long int  min(long long int  a, long long int  b) { return (a < b) ? a : b; }
+
 static inline int abs(int a) { return a < 0 ? -a : a; }
+static inline long int abs(long int a) { return a < 0L ? -a : a; }
 static inline double abs(double a) { return fabs(a); }
 
 // note that C99 has a round() function, but I don't want to rely on it
@@ -46,18 +52,18 @@ inline int rmin_bulk(int m) {
 
 class src_vol {
  public:
-  src_vol(component cc, src_time *st, int n, int *ind, std::complex<double> *amps);
+  src_vol(component cc, src_time *st, meep::integer n, meep::integer *ind, std::complex<double> *amps);
   src_vol(const src_vol &sv);
   ~src_vol() { delete next; delete[] index; delete[] A;}
 
   src_time *t;
-  int *index; // list of locations of sources in grid (indices)
-  int npts; // number of points in list
+  meep::integer *index; // list of locations of sources in grid (indices)
+  meep::integer npts; // number of points in list
   component c; // field component the source applies to
   std::complex<double> *A; // list of amplitudes
 
-  std::complex<double> dipole(int j) { return A[j] * t->dipole(); }
-  std::complex<double> current(int j) { return A[j] * t->current(); }
+  std::complex<double> dipole(meep::integer j) { return A[j] * t->dipole(); }
+  std::complex<double> current(meep::integer j) { return A[j] * t->current(); }
   void update(double time, double dt) { t->update(time, dt); }
 
   bool operator==(const src_vol &sv) const {
@@ -80,7 +86,9 @@ class bandsdata {
   // added together (a crude compromize for speed, while still observing the
   // phonon bands).
   std::complex<double> *P;
-  int tstart, tend, index[num_bandpts], maxbands, scale_factor;
+  int tstart, tend;
+  meep::integer index[num_bandpts];
+  int maxbands, scale_factor;
   fields_chunk *chunk[num_bandpts];
   double dt, fmin, fmax, qmin, fpmin;
   int ntime;
@@ -103,7 +111,7 @@ symmetry r_to_minus_r_symmetry(int m);
 // functions in step_generic.cpp:
 
 void step_curl(realnum *f, component c, const realnum *g1, const realnum *g2,
-	       int s1, int s2, // strides for g1/g2 shift
+	       meep::integer s1, meep::integer s2, // strides for g1/g2 shift
 	       const grid_volume &gv, double dtdx,
 	       direction dsig, const double *sig, const double *kap, const double *siginv,
 	       realnum *fu, direction dsigu, const double *sigu, const double *kapu, const double *siginvu,
@@ -113,7 +121,7 @@ void step_curl(realnum *f, component c, const realnum *g1, const realnum *g2,
 void step_update_EDHB(realnum *f, component fc, const grid_volume &gv,
 		      const realnum *g, const realnum *g1, const realnum *g2,
 		      const realnum *u, const realnum *u1, const realnum *u2,
-		      int s, int s1, int s2,
+		      meep::integer s, meep::integer s1, meep::integer s2,
 		      const realnum *chi2, const realnum *chi3,
 		      realnum *fw, direction dsigw, const double *sigw, const double *kapw);
 
@@ -126,7 +134,7 @@ void step_beta(realnum *f, component c, const realnum *g,
 // functions in step_generic_stride1.cpp, generated from step_generic.cpp:
 
 void step_curl_stride1(realnum *f, component c, const realnum *g1, const realnum *g2,
-	       int s1, int s2, // strides for g1/g2 shift
+	       meep::integer s1, meep::integer s2, // strides for g1/g2 shift
 	       const grid_volume &gv, double dtdx,
 	       direction dsig, const double *sig, const double *kap, const double *siginv,
 	       realnum *fu, direction dsigu, const double *sigu, const double *kapu, const double *siginvu,
@@ -136,7 +144,7 @@ void step_curl_stride1(realnum *f, component c, const realnum *g1, const realnum
 void step_update_EDHB_stride1(realnum *f, component fc, const grid_volume &gv,
 		      const realnum *g, const realnum *g1, const realnum *g2,
 		      const realnum *u, const realnum *u1, const realnum *u2,
-		      int s, int s1, int s2,
+		      meep::integer s, meep::integer s1, meep::integer s2,
 		      const realnum *chi2, const realnum *chi3,
 		      realnum *fw, direction dsigw, const double *sigw, const double *kapw);
 

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -46,7 +46,7 @@ monitor_point::~monitor_point() {
   if (next) delete next;
 }
 
-inline complex<double> getcm(const realnum * const f[2], int i) {
+inline complex<double> getcm(const realnum * const f[2], meep::integer i) {
   return complex<double>(f[0][i],f[1][i]);
 }
 

--- a/src/multilevel-atom.cpp
+++ b/src/multilevel-atom.cpp
@@ -117,7 +117,7 @@ static bool invert(realnum *S, int p)
 typedef realnum *realnumP;
 typedef struct {
   size_t sz_data;
-  int ntot;
+  meep::integer ntot;
   realnum *GammaInv; // inv(1 + Gamma * dt / 2)
   realnumP *P[NUM_FIELD_COMPONENTS][2]; // P[c][cmp][transition][i]
   realnumP *P_prev[NUM_FIELD_COMPONENTS][2];
@@ -129,7 +129,7 @@ typedef struct {
 void *multilevel_susceptibility::new_internal_data(
 				    realnum *W[NUM_FIELD_COMPONENTS][2],
 				    const grid_volume &gv) const {
-  int num = 0; // number of P components
+  meep::integer num = 0; // number of P components
   FOR_COMPONENTS(c) DOCMP2 if (needs_P(c, cmp, W)) num += 2 * gv.ntot();
   size_t sz = sizeof(multilevel_data)
     + sizeof(realnum) * (L*L + L + gv.ntot()*L + num*T - 1);
@@ -146,7 +146,7 @@ void multilevel_susceptibility::init_internal_data(
   size_t sz_data = d->sz_data;
   memset(d, 0, sz_data);
   d->sz_data = sz_data;
-  int ntot = d->ntot = gv.ntot();
+  meep::integer ntot = d->ntot = gv.ntot();
 
   /* d->data points to a big block of data that holds GammaInv, P,
      P_prev, Ntmp, and N.  We also initialize a bunch of convenience
@@ -199,7 +199,7 @@ void *multilevel_susceptibility::copy_internal_data(void *data) const {
   if (!d) return 0;
   multilevel_data *dnew = (multilevel_data *) malloc(d->sz_data);
   memcpy(dnew, d, d->sz_data);
-  int ntot = d->ntot;
+  meep::integer ntot = d->ntot;
   dnew->GammaInv = dnew->data;
   realnum *P = dnew->data + L*L;
   realnum *P_prev = P + ntot;
@@ -218,15 +218,15 @@ void *multilevel_susceptibility::copy_internal_data(void *data) const {
   return (void*) dnew;
 }
 
-int multilevel_susceptibility::num_cinternal_notowned_needed(component c,
+meep::integer multilevel_susceptibility::num_cinternal_notowned_needed(component c,
 				   void *P_internal_data) const {
   multilevel_data *d = (multilevel_data *) P_internal_data;
   return d->P[c][0] ? T : 0;
 }
 
 realnum *multilevel_susceptibility::cinternal_notowned_ptr(
-				        int inotowned, component c, int cmp, 
-					int n, 
+				        meep::integer inotowned, component c, meep::integer cmp,
+				        meep::integer n,
 					void *P_internal_data) const {
   multilevel_data *d = (multilevel_data *) P_internal_data;
   if (!d->P[c][cmp] || inotowned < 0 || inotowned >= T) // never true
@@ -243,7 +243,7 @@ void multilevel_susceptibility::update_P
 
   // field directions and offsets for E * dP dot product.
   component cdot[3] = {Dielectric,Dielectric,Dielectric};
-  int o1[3], o2[3];
+  meep::integer o1[3], o2[3];
   int idot = 0;
   FOR_COMPONENTS(c) if (d->P[c][0]) {
     if (idot == 3) abort("bug in meep: too many polarization components");
@@ -326,7 +326,7 @@ void multilevel_susceptibility::update_P
       if (w && s) {
 	realnum *p = d->P[c][cmp][t], *pp = d->P_prev[c][cmp][t];
 
-	int o1, o2;
+	meep::integer o1, o2;
 	gv.cent2yee_offsets(c, o1, o2);
 	o1 *= L; o2 *= L;
 	const realnum *N = d->N;
@@ -368,14 +368,14 @@ void multilevel_susceptibility::subtract_P(field_type ft,
 					   void *P_internal_data) const {
   multilevel_data *d = (multilevel_data *) P_internal_data;
   field_type ft2 = ft == E_stuff ? D_stuff : B_stuff; // for sources etc.
-  int ntot = d->ntot;
+  meep::integer ntot = d->ntot;
   for (int t = 0; t < T; ++t) { 
     FOR_FT_COMPONENTS(ft, ec) DOCMP2 if (d->P[ec][cmp]) {
       component dc = field_type_component(ft2, ec);
       if (f_minus_p[dc][cmp]) {
 	realnum *p = d->P[ec][cmp][t];
 	realnum *fmp = f_minus_p[dc][cmp];
-	for (int i = 0; i < ntot; ++i) fmp[i] -= p[i];
+	for (meep::integer i = 0; i < ntot; ++i) fmp[i] -= p[i];
       }
     }
   }

--- a/src/mympi.cpp
+++ b/src/mympi.cpp
@@ -221,6 +221,18 @@ void broadcast(int from, long int *data, meep::integer size) {
 #endif
 }
 
+#ifdef HAVE_LONG_LONG_INT
+void broadcast(int from, long long int *data, meep::integer size) {
+#ifdef HAVE_MPI
+  if (size == 0) return;
+  MPI_Bcast(data, cast_message_size(size), MPI_LONG_LONG_INT, from, mycomm);
+#else
+  UNUSED(from);
+  UNUSED(data);
+  UNUSED(size);
+#endif
+}
+#endif
 
 complex<double> broadcast(int from, complex<double> data) {
 #ifdef HAVE_MPI
@@ -258,6 +270,17 @@ long int broadcast(int from, long int data) {
   return data;
 }
 
+#ifdef HAVE_LONG_LONG_INT
+long long int broadcast(int from, long long int data) {
+#ifdef HAVE_MPI
+  MPI_Bcast(&data, 1, MPI_LONG_LONG_INT, from, mycomm);
+#else
+  UNUSED(from);
+#endif
+  return data;
+}
+#endif
+
 bool broadcast(int from, bool b) {
   return broadcast(from, (int) b);
 }
@@ -287,10 +310,10 @@ int max_to_all(int in) {
 }
 
 ivec max_to_all(const ivec &pt) {
-  long int  in[5], out[5];
+  meep::integer in[5], out[5];
   for (int i=0; i<5; ++i) in[i] = out[i] = pt.in_direction(direction(i));
 #ifdef HAVE_MPI
-  MPI_Allreduce(&in,&out,5,MPI_LONG,MPI_MAX,mycomm);
+  MPI_Allreduce(&in,&out,5,MPI_MEEP_INTEGER,MPI_MAX,mycomm);
 #endif
   ivec ptout(pt.dim);
   for (int i=0; i<5; ++i) ptout.set_direction(direction(i), out[i]);
@@ -377,6 +400,16 @@ long int sum_to_all(long int in) {
   return out;
 }
 
+#ifdef HAVE_LONG_LONG_INT
+long long int sum_to_all(long long int in) {
+  long long int out = in;
+#ifdef HAVE_MPI
+  MPI_Allreduce(&in,&out,1,MPI_LONG_LONG_INT,MPI_SUM,mycomm);
+#endif
+  return out;
+}
+#endif
+
 int partial_sum_to_all(int in) {
   int out = in;
 #ifdef HAVE_MPI
@@ -386,12 +419,22 @@ int partial_sum_to_all(int in) {
 }
 
 long int partial_sum_to_all(long int  in) {
-	long int  out = in;
+  long int  out = in;
 #ifdef HAVE_MPI
   MPI_Scan(&in,&out,1,MPI_LONG,MPI_SUM,mycomm);
 #endif
   return out;
 }
+
+#ifdef HAVE_LONG_LONG_INT
+long long int partial_sum_to_all(long long int in) {
+  long long int  out = in;
+#ifdef HAVE_MPI
+  MPI_Scan(&in,&out,1,MPI_LONG_LONG_INT,MPI_SUM,mycomm);
+#endif
+  return out;
+}
+#endif
 
 complex<double> sum_to_all(complex<double> in) {
   complex<double> out = in;

--- a/src/near2far.cpp
+++ b/src/near2far.cpp
@@ -284,18 +284,19 @@ std::complex<double> *dft_near2far::farfield(const vec &x) {
 void dft_near2far::save_farfields(const char *fname, const char *prefix,
                                   const volume &where, double resolution) {
     /* compute output grid size etc. */
-    int dims[4] = {1,1,1,1};
+    meep::integer dims[4] = {1,1,1,1};
     double dx[3] = {0,0,0};
     direction dirs[3] = {X,Y,Z};
-    int rank = 0, N = 1;
+    int rank = 0;
+    meep::integer N = 1;
     LOOP_OVER_DIRECTIONS(where.dim, d) {
-        dims[rank] = int(floor(where.in_direction(d) * resolution));
+        dims[rank] = static_cast<meep::integer>(floor(where.in_direction(d) * resolution));
         if (dims[rank] <= 1) {
             dims[rank] = 1;
             dx[rank] = 0;
         }
         else
-            dx[rank] = where.in_direction(d) / (dims[rank] - 1);
+            dx[rank] = where.in_direction(d) / static_cast<double>(dims[rank] - 1);
         N *= dims[rank];
         dirs[rank++] = d;
     }
@@ -310,18 +311,21 @@ void dft_near2far::save_farfields(const char *fname, const char *prefix,
     std::complex<double> *EH1 = new std::complex<double>[6*Nfreq];
 
     vec x(where.dim);
-    for (int i0 = 0; i0 < dims[0]; ++i0) {
-        x.set_direction(dirs[0], where.in_direction_min(dirs[0]) + i0*dx[0]);
-        for (int i1 = 0; i1 < dims[1]; ++i1) {
+    for (meep::integer i0 = 0; i0 < dims[0]; ++i0) {
+        x.set_direction(dirs[0], where.in_direction_min(dirs[0])
+        		+ static_cast<double>(i0)*dx[0]);
+        for (meep::integer i1 = 0; i1 < dims[1]; ++i1) {
             x.set_direction(dirs[1], 
-                            where.in_direction_min(dirs[1]) + i1*dx[1]);
-            for (int i2 = 0; i2 < dims[2]; ++i2) {
+                            where.in_direction_min(dirs[1])
+                            + static_cast<double>(i1)*dx[1]);
+            for (meep::integer i2 = 0; i2 < dims[2]; ++i2) {
                 x.set_direction(dirs[2], 
-                                where.in_direction_min(dirs[2]) + i2*dx[2]);
+                                where.in_direction_min(dirs[2])
+                                + static_cast<double>(i2)*dx[2]);
                 farfield_lowlevel(EH1, x);
-                int idx = (i0 * dims[1] + i1) * dims[2] + i2;
-                for (int i = 0; i < Nfreq; ++i)
-                    for (int k = 0; k < 6; ++k) {
+                meep::integer idx = (i0 * dims[1] + i1) * dims[2] + i2;
+                for (meep::integer i = 0; i < Nfreq; ++i)
+                    for (meep::integer k = 0; k < 6; ++k) {
                         EH_[((k * 2 + 0) * N + idx) * Nfreq + i] =
                             real(EH1[i * 6 + k]);
                         EH_[((k * 2 + 1) * N + idx) * Nfreq + i] =

--- a/src/output_directory.cpp
+++ b/src/output_directory.cpp
@@ -102,7 +102,7 @@ const char *make_output_directory(const char *exename, const char *jobname) {
   
   snprintf(stripped_name, buflen, "%s", bnp);
   for (int i = 0; i < (int)(sizeof(evil_suffs) / sizeof(evil_suffs[0])); ++i) {
-    int sufflen = strlen(evil_suffs[i]);
+    meep::integer sufflen = strlen(evil_suffs[i]);
     if (strcmp(stripped_name + strlen(stripped_name) - sufflen, 
 	       evil_suffs[i]) == 0
 	&& strlen(stripped_name) > size_t(sufflen)) {

--- a/src/sources.cpp
+++ b/src/sources.cpp
@@ -156,7 +156,7 @@ bool custom_src_time::is_equal(const src_time &t) const
 
 /*********************************************************************/
 
-src_vol::src_vol(component cc, src_time *st, int n, int *ind, complex<double> *amps) {
+src_vol::src_vol(component cc, src_time *st, meep::integer n, meep::integer *ind, complex<double> *amps) {
   c = cc;
   if (is_D(c)) c = direction_component(Ex, component_direction(c));
   if (is_B(c)) c = direction_component(Hx, component_direction(c));
@@ -170,9 +170,9 @@ src_vol::src_vol(const src_vol &sv) {
   c = sv.c;
   t = sv.t;
   npts = sv.npts;
-  index = new int[npts];
+  index = new meep::integer[npts];
   A = new complex<double>[npts];
-  for (int j=0; j<npts; j++) {
+  for (meep::integer j=0; j<npts; j++) {
     index[j] = sv.index[j];
     A[j] = sv.A[j];
   }
@@ -189,7 +189,7 @@ src_vol *src_vol::add_to(src_vol *others) {
         abort("Cannot add grid_volume sources with different number of points\n");
       /* Compare all of the indices...if this ever becomes too slow,
 	 we can just compare the first and last indices. */
-      for (int j=0; j<npts; j++) {
+      for (meep::integer j=0; j<npts; j++) {
         if (others->index[j] != index[j])
           abort("Different indices\n");
         others->A[j] += A[j];
@@ -275,10 +275,10 @@ static void src_vol_chunkloop(fields_chunk *fc, int ichunk, component c,
   (void) dV0; (void) dV1; // grid_volume weighting is included in data->amp
   (void) ichunk;
 
-  int npts = 1;
+  meep::integer npts = 1;
   LOOP_OVER_DIRECTIONS(is.dim, d)
     npts *= (ie.in_direction(d) - is.in_direction(d)) / 2 + 1;
-  int *index_array = new int[npts];
+  meep::integer *index_array = new meep::integer[npts];
   complex<double> *amps_array = new complex<double>[npts];
 
   complex<double> amp = data->amp * conj(shift_phase);
@@ -305,7 +305,9 @@ static void src_vol_chunkloop(fields_chunk *fc, int ichunk, component c,
   }
 
   if (idx_vol != npts)
-    abort("add_volume_source: computed wrong npts (%d vs. %d)", npts, idx_vol);
+    abort("add_volume_source: computed wrong npts (%ld vs. %ld)",
+    		static_cast<long int>(npts),
+    		static_cast<long int>(idx_vol));
 
   src_vol *tmp = new src_vol(c, data->src, npts, index_array, amps_array);
   field_type ft = is_magnetic(c) ? B_stuff : D_stuff;

--- a/src/step.cpp
+++ b/src/step.cpp
@@ -158,9 +158,9 @@ void fields::step_boundaries(field_type ft) {
       int wh[3] = {0,0,0};
       for (int i=0;i<num_chunks;i++) {
 	const int pair = j+i*num_chunks;
-	int n0 = 0;
+	meep::integer n0 = 0;
 	for (int ip=0;ip<3;ip++) {
-	  for (int n=0;n<comm_sizes[ft][ip][pair];n++)
+	  for (meep::integer n=0;n<comm_sizes[ft][ip][pair];n++)
 	    comm_blocks[ft][pair][n0 + n] =
 	      *(chunks[j]->connections[ft][ip][Outgoing][wh[ip]++]);
 	  n0 += comm_sizes[ft][ip][pair];
@@ -177,7 +177,7 @@ void fields::step_boundaries(field_type ft) {
       for (int j=0;j<num_chunks;j++) {
         const int pair = j+i*num_chunks;
 	connect_phase ip = CONNECT_PHASE;
-        for (int n = 0; n < comm_sizes[ft][ip][pair]; n += 2, wh[ip] += 2) {
+        for (meep::integer n = 0; n < comm_sizes[ft][ip][pair]; n += 2, wh[ip] += 2) {
           const double phr = real(chunks[i]->connection_phases[ft][wh[ip]/2]);
           const double phi = imag(chunks[i]->connection_phases[ft][wh[ip]/2]);
           *(chunks[i]->connections[ft][ip][Incoming][wh[ip]]) =
@@ -185,14 +185,14 @@ void fields::step_boundaries(field_type ft) {
           *(chunks[i]->connections[ft][ip][Incoming][wh[ip]+1]) =
             phr*comm_blocks[ft][pair][n+1] + phi*comm_blocks[ft][pair][n];
         }
-	int n0 = comm_sizes[ft][ip][pair];
+	meep::integer n0 = comm_sizes[ft][ip][pair];
 	ip = CONNECT_NEGATE;
-        for (int n = 0; n < comm_sizes[ft][ip][pair]; ++n)
+        for (meep::integer n = 0; n < comm_sizes[ft][ip][pair]; ++n)
           *(chunks[i]->connections[ft][ip][Incoming][wh[ip]++])
 	    = -comm_blocks[ft][pair][n0 + n];
 	n0 += comm_sizes[ft][ip][pair];
 	ip = CONNECT_COPY;
-        for (int n = 0; n < comm_sizes[ft][ip][pair]; ++n)
+        for (meep::integer n = 0; n < comm_sizes[ft][ip][pair]; ++n)
           *(chunks[i]->connections[ft][ip][Incoming][wh[ip]++])
 	    = comm_blocks[ft][pair][n0 + n];
       }
@@ -217,16 +217,16 @@ void fields_chunk::step_source(field_type ft, bool including_integrated) {
 	&& ((ft == D_stuff && is_electric(sv->c))
 	    || (ft == B_stuff && is_magnetic(sv->c)))) {
       if (cndinv)
-	for (int j=0; j<sv->npts; j++) {
-	  const int i = sv->index[j];
+	for (meep::integer j=0; j<sv->npts; j++) {
+	  const meep::integer i = sv->index[j];
 	  const complex<double> A = sv->current(j) * dt * double(cndinv[i]);
 	  f[c][0][i] -= real(A);
 	  if (!is_real) f[c][1][i] -= imag(A);
 	}
       else
-	for (int j=0; j<sv->npts; j++) {
+	for (meep::integer j=0; j<sv->npts; j++) {
 	  const complex<double> A = sv->current(j) * dt;
-	  const int i = sv->index[j];
+	  const meep::integer i = sv->index[j];
 	  f[c][0][i] -= real(A);
 	  if (!is_real) f[c][1][i] -= imag(A);
 	}

--- a/src/step_db.cpp
+++ b/src/step_db.cpp
@@ -57,8 +57,8 @@ bool fields_chunk::step_db(field_type ft) {
       const direction dsig = s->sigsize[dsig0] > 1 ? dsig0 : NO_DIRECTION;
       const direction dsigu0 = cycle_direction(gv.dim,d_c,2);
       const direction dsigu = s->sigsize[dsigu0] > 1 ? dsigu0 : NO_DIRECTION;
-      int stride_p = have_p?gv.stride(d_deriv_p):0;
-      int stride_m = have_m?gv.stride(d_deriv_m):0;
+      meep::integer stride_p = have_p?gv.stride(d_deriv_p):0;
+      meep::integer stride_m = have_m?gv.stride(d_deriv_m):0;
       realnum *f_p = have_p?f[c_p][cmp]:NULL;
       realnum *f_m = have_m?f[c_m][cmp]:NULL;
       realnum *the_f = f[cc][cmp];
@@ -100,15 +100,16 @@ bool fields_chunk::step_db(field_type ft) {
 	   and sums, but you get the idea). */
 	if (!f_rderiv_int) f_rderiv_int = new realnum[gv.ntot()];
 	double ir0 = gv.origin_r() * gv.a 
-	  + 0.5 * gv.iyee_shift(c_p).in_direction(R);
-	for (int iz = 0; iz <= gv.nz(); ++iz) f_rderiv_int[iz] = 0;
-	int sr = gv.nz() + 1;
-	for (int ir = 1; ir <= gv.nr(); ++ir) {
-	  double rinv = 1.0 / ((ir+ir0)-0.5);
-	  for (int iz = 0; iz <= gv.nz(); ++iz) {
-	    int idx = ir*sr + iz;
+	  + 0.5 * static_cast<double>(gv.iyee_shift(c_p).in_direction(R));
+	for (meep::integer iz = 0; iz <= gv.nz(); ++iz) f_rderiv_int[iz] = 0;
+	meep::integer sr = gv.nz() + 1;
+	for (meep::integer ir = 1; ir <= gv.nr(); ++ir) {
+	  double rinv = 1.0 / ((static_cast<double>(ir)+ir0)-0.5);
+	  for (meep::integer iz = 0; iz <= gv.nz(); ++iz) {
+	    meep::integer idx = ir*sr + iz;
 	    f_rderiv_int[idx] = f_rderiv_int[idx - sr] +
-	      rinv * (f_p[idx] * (ir+ir0) - f_p[idx - sr] * ((ir-1)+ir0));
+	      rinv * (f_p[idx] * (static_cast<double>(ir)+ir0)
+	    		  - f_p[idx - sr] * (static_cast<double>(ir-1)+ir0));
 	  }
 	}
 	f_p = f_rderiv_int;
@@ -168,27 +169,27 @@ bool fields_chunk::step_db(field_type ft) {
       realnum *fu = f_u[cc][cmp];
       const direction dsig = cycle_direction(gv.dim,d_c,1);
       const double *siginv = s->sigsize[dsig] > 1 ? s->siginv[dsig] : 0;
-      const int dk = gv.iyee_shift(cc).in_direction(dsig);
+      const meep::integer dk = gv.iyee_shift(cc).in_direction(dsig);
       const direction dsigu = cycle_direction(gv.dim,d_c,2);
       const double *siginvu = s->sigsize[dsigu] > 1 ? s->siginv[dsigu] : 0;
-      const int dku = gv.iyee_shift(cc).in_direction(dsigu);
+      const meep::integer dku = gv.iyee_shift(cc).in_direction(dsigu);
       const double the_m = 
 	m * (1-2*cmp) * (1-2*(ft==B_stuff)) * (1-2*(d_c==R)) * Courant;
       const double ir0 = gv.origin_r() * gv.a 
-	+ 0.5 * gv.iyee_shift(cc).in_direction(R);
-      int sr = gv.nz() + 1;
+	+ 0.5 * static_cast<double>(gv.iyee_shift(cc).in_direction(R));
+      meep::integer sr = gv.nz() + 1;
 
       // 8 special cases of the same loop (sigh):
       if (siginv) { // PML in f update
 	if (siginvu) { // PML + fu
 	  if (cndinv) // PML + fu + conductivity
 	    //////////////////// MOST GENERAL CASE //////////////////////
-	    for (int ir = ir0 == 0; ir <= gv.nr(); ++ir) {
-	      double rinv = the_m / (ir+ir0);
-	      for (int iz = 0; iz <= gv.nz(); ++iz) {
-		int idx = ir*sr + iz;
-		int k = dk + 2*(dsig==Z ? iz : ir);
-		int ku = dku + 2*(dsigu==Z ? iz : ir);
+	    for (meep::integer ir = ir0 == 0; ir <= gv.nr(); ++ir) {
+	      double rinv = the_m / (static_cast<double>(ir)+ir0);
+	      for (meep::integer iz = 0; iz <= gv.nz(); ++iz) {
+		meep::integer idx = ir*sr + iz;
+		meep::integer k = dk + 2*(dsig==Z ? iz : ir);
+		meep::integer ku = dku + 2*(dsigu==Z ? iz : ir);
 		double df, dfcnd = rinv * g[idx] * cndinv[idx];
 		fcnd[idx] += dfcnd;
 		fu[idx] += (df = dfcnd * siginv[k]);
@@ -197,12 +198,12 @@ bool fields_chunk::step_db(field_type ft) {
 	    }
 	    /////////////////////////////////////////////////////////////
 	  else // PML + fu - conductivity
-	    for (int ir = ir0 == 0; ir <= gv.nr(); ++ir) {
-	      double rinv = the_m / (ir+ir0);
-	      for (int iz = 0; iz <= gv.nz(); ++iz) {
-		int idx = ir*sr + iz;
-		int k = dk + 2*(dsig==Z ? iz : ir);
-		int ku = dku + 2*(dsigu==Z ? iz : ir);
+	    for (meep::integer ir = ir0 == 0; ir <= gv.nr(); ++ir) {
+	      double rinv = the_m / (static_cast<double>(ir)+ir0);
+	      for (meep::integer iz = 0; iz <= gv.nz(); ++iz) {
+		meep::integer idx = ir*sr + iz;
+		meep::integer k = dk + 2*(dsig==Z ? iz : ir);
+		meep::integer ku = dku + 2*(dsigu==Z ? iz : ir);
 		double df, dfcnd = rinv * g[idx];
 		fu[idx] += (df = dfcnd * siginv[k]);
 		the_f[idx] += siginvu[ku] * df;
@@ -211,22 +212,22 @@ bool fields_chunk::step_db(field_type ft) {
 	}
 	else { // PML - fu
 	  if (cndinv) // PML - fu + conductivity
-	    for (int ir = ir0 == 0; ir <= gv.nr(); ++ir) {
-	      double rinv = the_m / (ir+ir0);
-	      for (int iz = 0; iz <= gv.nz(); ++iz) {
-		int idx = ir*sr + iz;
-		int k = dk + 2*(dsig==Z ? iz : ir);
+	    for (meep::integer ir = ir0 == 0; ir <= gv.nr(); ++ir) {
+	      double rinv = the_m / (static_cast<double>(ir)+ir0);
+	      for (meep::integer iz = 0; iz <= gv.nz(); ++iz) {
+		meep::integer idx = ir*sr + iz;
+		meep::integer k = dk + 2*(dsig==Z ? iz : ir);
 		double dfcnd = rinv * g[idx] * cndinv[idx];
 		fcnd[idx] += dfcnd;
 		the_f[idx] += dfcnd * siginv[k];
 	      }
 	    }
 	  else // PML - fu - conductivity
-	    for (int ir = ir0 == 0; ir <= gv.nr(); ++ir) {
-	      double rinv = the_m / (ir+ir0);
-	      for (int iz = 0; iz <= gv.nz(); ++iz) {
-		int idx = ir*sr + iz;
-		int k = dk + 2*(dsig==Z ? iz : ir);
+	    for (meep::integer ir = ir0 == 0; ir <= gv.nr(); ++ir) {
+	      double rinv = the_m / (static_cast<double>(ir)+ir0);
+	      for (meep::integer iz = 0; iz <= gv.nz(); ++iz) {
+		meep::integer idx = ir*sr + iz;
+		meep::integer k = dk + 2*(dsig==Z ? iz : ir);
 		double dfcnd = rinv * g[idx];
 		the_f[idx] += dfcnd * siginv[k];
 	      }
@@ -236,22 +237,22 @@ bool fields_chunk::step_db(field_type ft) {
       else { // no PML in f update
 	if (siginvu) { // no PML + fu
 	  if (cndinv) // no PML + fu + conductivity
-	    for (int ir = ir0 == 0; ir <= gv.nr(); ++ir) {
-	      double rinv = the_m / (ir+ir0);
-	      for (int iz = 0; iz <= gv.nz(); ++iz) {
-		int idx = ir*sr + iz;
-		int ku = dku + 2*(dsigu==Z ? iz : ir);
+	    for (meep::integer ir = ir0 == 0; ir <= gv.nr(); ++ir) {
+	      double rinv = the_m / (static_cast<double>(ir)+ir0);
+	      for (meep::integer iz = 0; iz <= gv.nz(); ++iz) {
+		meep::integer idx = ir*sr + iz;
+		meep::integer ku = dku + 2*(dsigu==Z ? iz : ir);
 		double df = rinv * g[idx] * cndinv[idx];
 		fu[idx] += df;
 		the_f[idx] += siginvu[ku] * df;
 	      }
 	    }
 	  else // no PML + fu - conductivity
-	    for (int ir = ir0 == 0; ir <= gv.nr(); ++ir) {
-	      double rinv = the_m / (ir+ir0);
-	      for (int iz = 0; iz <= gv.nz(); ++iz) {
-		int idx = ir*sr + iz;
-		int ku = dku + 2*(dsigu==Z ? iz : ir);
+	    for (meep::integer ir = ir0 == 0; ir <= gv.nr(); ++ir) {
+	      double rinv = the_m / (static_cast<double>(ir)+ir0);
+	      for (meep::integer iz = 0; iz <= gv.nz(); ++iz) {
+		meep::integer idx = ir*sr + iz;
+		meep::integer ku = dku + 2*(dsigu==Z ? iz : ir);
 		double df = rinv * g[idx];
 		fu[idx] += df;
 		the_f[idx] += siginvu[ku] * df;
@@ -260,18 +261,18 @@ bool fields_chunk::step_db(field_type ft) {
 	}
 	else { // no PML - fu
 	  if (cndinv) // no PML - fu + conductivity
-	    for (int ir = ir0 == 0; ir <= gv.nr(); ++ir) {
-	      double rinv = the_m / (ir+ir0);
-	      for (int iz = 0; iz <= gv.nz(); ++iz) {
-		int idx = ir*sr + iz;
+	    for (meep::integer ir = ir0 == 0; ir <= gv.nr(); ++ir) {
+	      double rinv = the_m / (static_cast<double>(ir)+ir0);
+	      for (meep::integer iz = 0; iz <= gv.nz(); ++iz) {
+		meep::integer idx = ir*sr + iz;
 		the_f[idx] += rinv * g[idx] * cndinv[idx];
 	      }
 	    }
 	  else // no PML - fu - conductivity
-	    for (int ir = ir0 == 0; ir <= gv.nr(); ++ir) {
-	      double rinv = the_m / (ir+ir0);
-	      for (int iz = 0; iz <= gv.nz(); ++iz) {
-		int idx = ir*sr + iz;
+	    for (meep::integer ir = ir0 == 0; ir <= gv.nr(); ++ir) {
+	      double rinv = the_m / (static_cast<double>(ir)+ir0);
+	      for (meep::integer iz = 0; iz <= gv.nz(); ++iz) {
+		meep::integer idx = ir*sr + iz;
 		the_f[idx] += rinv * g[idx];
 	      }
 	    }
@@ -284,7 +285,7 @@ bool fields_chunk::step_db(field_type ft) {
 
   // deal with annoying r=0 boundary conditions for m=0 and m=1
   if (gv.dim == Dcyl && gv.origin_r() == 0.0) DOCMP {
-    const int nz = gv.nz();
+    const meep::integer nz = gv.nz();
     if (m == 0 && ft == D_stuff && f[Dz][cmp]) {
       // d(Dz)/dt = (1/r) * d(r*Hp)/dr
       const realnum *g = f[Hp][cmp];
@@ -292,13 +293,13 @@ bool fields_chunk::step_db(field_type ft) {
       realnum *fcnd = f_cond[Dz][cmp];
       const direction dsig = cycle_direction(gv.dim,Z,1);
       const double *siginv = s->sigsize[dsig] > 1 ? s->siginv[dsig] : 0;
-      const int dk = gv.iyee_shift(Dz).in_direction(dsig);
+      const meep::integer dk = gv.iyee_shift(Dz).in_direction(dsig);
       const direction dsigu = cycle_direction(gv.dim,Z,2);
       const double *siginvu = s->sigsize[dsigu] > 1 ? s->siginv[dsigu] : 0;
-      const int dku = gv.iyee_shift(Dz).in_direction(dsigu);
+      const meep::integer dku = gv.iyee_shift(Dz).in_direction(dsigu);
       realnum *fu = siginvu && f_u[Dz][cmp] ? f[Dz][cmp] : 0;
       realnum *the_f = fu ? f_u[Dz][cmp] : f[Dz][cmp];
-      for (int iz = 0; iz < nz; ++iz) {
+      for (meep::integer iz = 0; iz < nz; ++iz) {
 	// Note: old code (prior to Meep 0.2) was missing factor of 4??
 	double df, dfcnd = g[iz] * (Courant * 4) * (cndinv ? cndinv[iz] : 1);
 	if (fcnd) fcnd[iz] += dfcnd;
@@ -327,16 +328,16 @@ bool fields_chunk::step_db(field_type ft) {
       realnum *fcnd = f_cond[cc][cmp];
       const direction dsig = cycle_direction(gv.dim,d_c,1);
       const double *siginv = s->sigsize[dsig] > 1 ? s->siginv[dsig] : 0;
-      const int dk = gv.iyee_shift(cc).in_direction(dsig);
+      const meep::integer dk = gv.iyee_shift(cc).in_direction(dsig);
       const direction dsigu = cycle_direction(gv.dim,d_c,2);
       const double *siginvu = s->sigsize[dsigu] > 1 ? s->siginv[dsigu] : 0;
-      const int dku = gv.iyee_shift(cc).in_direction(dsigu);
+      const meep::integer dku = gv.iyee_shift(cc).in_direction(dsigu);
       realnum *fu = siginvu && f_u[cc][cmp] ? f[cc][cmp] : 0;
       realnum *the_f = fu ? f_u[cc][cmp] : f[cc][cmp];
       int sd = ft == D_stuff ? +1 : -1;
       double f_m_mult = ft == D_stuff ? 2 : (1-2*cmp);
 
-      for (int iz = (ft == D_stuff); iz < nz + (ft == D_stuff); ++iz) {
+      for (meep::integer iz = (ft == D_stuff); iz < nz + (ft == D_stuff); ++iz) {
 	double df;
 	double dfcnd = (sd*Courant) * (f_p[iz]-f_p[iz-sd] - f_m_mult*f_m[iz])
 	  * (cndinv ? cndinv[iz] : 1);
@@ -371,8 +372,8 @@ bool fields_chunk::step_db(field_type ft) {
 	   for large m). */
 	double rmax = fabs(m) - int(gv.origin_r()*gv.a+0.5);
 	if (ft == D_stuff)
-	  for (int r = 0; r <= gv.nr() && r < rmax; r++) {
-	    const int ir = r*(nz+1);
+	  for (meep::integer r = 0; r <= gv.nr() && r < rmax; r++) {
+	    const meep::integer ir = r*(nz+1);
 	    ZERO_Z(f[Dp][cmp]+ir);
 	    ZERO_Z(f[Dz][cmp]+ir);
 	    if (f_cond[Dp][cmp]) ZERO_Z(f_cond[Dp][cmp]+ir);
@@ -381,8 +382,8 @@ bool fields_chunk::step_db(field_type ft) {
 	    if (f_u[Dz][cmp]) ZERO_Z(f_u[Dz][cmp]+ir);
 	  }
 	else
-	  for (int r = 0; r <= gv.nr() && r < rmax; r++) {
-	    const int ir = r*(nz+1);
+	  for (meep::integer r = 0; r <= gv.nr() && r < rmax; r++) {
+	    const meep::integer ir = r*(nz+1);
 	    ZERO_Z(f[Br][cmp]+ir);
 	    if (f_cond[Br][cmp]) ZERO_Z(f_cond[Br][cmp]+ir);
 	    if (f_u[Br][cmp]) ZERO_Z(f_u[Br][cmp]+ir);

--- a/src/step_generic.cpp
+++ b/src/step_generic.cpp
@@ -1,7 +1,6 @@
 #include "meep.hpp"
 #include "meep_internals.hpp"
 #include "config.h"
-
 #define DPR double * restrict
 #define RPR realnum * restrict
 
@@ -13,12 +12,12 @@
    KSTRIDE_DEF defines the relevant strides etc. and goes outside the
    LOOP, wheras KDEF defines the k index and goes inside the LOOP. */
 #define KSTRIDE_DEF(dsig, k, corner)				\
-     const int k##0 = corner.in_direction(dsig)			\
+     const meep::integer k##0 = corner.in_direction(dsig)			\
                       - gv.little_corner().in_direction(dsig);	\
-     const int s##k##1 = gv.yucky_direction(0) == dsig ? 2 : 0; \
-     const int s##k##2 = gv.yucky_direction(1) == dsig ? 2 : 0; \
-     const int s##k##3 = gv.yucky_direction(2) == dsig ? 2 : 0
-#define KDEF(k,dsig) const int k = ((k##0 + s##k##1*loop_i1) + s##k##2*loop_i2) + s##k##3*loop_i3
+     const meep::integer s##k##1 = gv.yucky_direction(0) == dsig ? 2 : 0; \
+     const meep::integer s##k##2 = gv.yucky_direction(1) == dsig ? 2 : 0; \
+     const meep::integer s##k##3 = gv.yucky_direction(2) == dsig ? 2 : 0
+#define KDEF(k,dsig) const meep::integer k = ((k##0 + s##k##1*loop_i1) + s##k##2*loop_i2) + s##k##3*loop_i3
 #define DEF_k KDEF(k,dsig)
 #define DEF_ku KDEF(ku,dsigu)
 #define DEF_kw KDEF(kw,dsigw)
@@ -60,7 +59,7 @@ namespace meep {
    and fu replaces f in the equations above (fu += dt curl g etcetera).
 */
 void step_curl(RPR f, component c, const RPR g1, const RPR g2,
-	       int s1, int s2, // strides for g1/g2 shift
+	       meep::integer s1, meep::integer s2, // strides for g1/g2 shift
 	       const grid_volume &gv, double dtdx,
 	       direction dsig, const DPR sig, const DPR kap, const DPR siginv,
 	       RPR fu, direction dsigu, const DPR sigu, const DPR kapu, const DPR siginvu,
@@ -69,7 +68,7 @@ void step_curl(RPR f, component c, const RPR g1, const RPR g2,
 {
   if (!g1) { // swap g1 and g2
     SWAP(const RPR, g1, g2);
-    SWAP(int, s1, s2);
+    SWAP(meep::integer, s1, s2);
     dtdx = -dtdx; // need to flip derivative sign
   }
 
@@ -351,7 +350,7 @@ inline double calc_nonlinear_u(const double Dsqr,
 void step_update_EDHB(RPR f, component fc, const grid_volume &gv, 
 		      const RPR g, const RPR g1, const RPR g2,
 		      const RPR u, const RPR u1, const RPR u2,
-		      int s, int s1, int s2,
+		      meep::integer s, meep::integer s1, meep::integer s2,
 		      const RPR chi2, const RPR chi3,
 		      RPR fw, direction dsigw, const DPR sigw, const DPR kapw)
 {
@@ -360,7 +359,7 @@ void step_update_EDHB(RPR f, component fc, const grid_volume &gv,
   if ((!g1 && g2) || (g1 && g2 && !u1 && u2)) { /* swap g1 and g2 */
     SWAP(const RPR, g1, g2);
     SWAP(const RPR, u1, u2);
-    SWAP(int, s1, s2);
+    SWAP(meep::integer, s1, s2);
   }
 
   // stable averaging of offdiagonal components

--- a/src/stress.cpp
+++ b/src/stress.cpp
@@ -72,8 +72,8 @@ static void stress_sum(int Nfreq, double *F,
        curF1 = curF1->next_in_dft, curF2 = curF2->next_in_dft) {
     complex<realnum> extra_weight(real(curF1->extra_weight),
 				  imag(curF1->extra_weight));
-    for (int k = 0; k < curF1->N; ++k)
-      for (int i = 0; i < Nfreq; ++i)
+    for (meep::integer k = 0; k < curF1->N; ++k)
+      for (meep::integer i = 0; i < Nfreq; ++i)
 	F[i] += real(extra_weight * curF1->dft[k*Nfreq + i]
 		     * conj(curF2->dft[k*Nfreq + i]));  
   }

--- a/src/susceptibility.cpp
+++ b/src/susceptibility.cpp
@@ -92,7 +92,7 @@ bool susceptibility::needs_W_notowned(component c,
 
 typedef struct {
   size_t sz_data;
-  int ntot;
+  meep::integer ntot;
   realnum *P[NUM_FIELD_COMPONENTS][2];
   realnum *P_prev[NUM_FIELD_COMPONENTS][2];
   realnum data[1];
@@ -103,7 +103,7 @@ typedef struct {
 void *lorentzian_susceptibility::new_internal_data(
 			 realnum *W[NUM_FIELD_COMPONENTS][2],
 			 const grid_volume &gv) const {
-  int num = 0;
+  meep::integer num = 0;
   FOR_COMPONENTS(c) DOCMP2 if (needs_P(c, cmp, W)) num += 2 * gv.ntot();
   size_t sz = sizeof(lorentzian_data) + sizeof(realnum) * (num - 1);
   lorentzian_data *d = (lorentzian_data *) malloc(sz);
@@ -119,7 +119,7 @@ void lorentzian_susceptibility::init_internal_data(
   size_t sz_data = d->sz_data;
   memset(d, 0, sz_data);
   d->sz_data = sz_data;
-  int ntot = d->ntot = gv.ntot();
+  meep::integer ntot = d->ntot = gv.ntot();
   realnum *P = d->data;
   realnum *P_prev = d->data + ntot;
   FOR_COMPONENTS(c) DOCMP2 if (needs_P(c, cmp, W)) {
@@ -135,7 +135,7 @@ void *lorentzian_susceptibility::copy_internal_data(void *data) const {
   if (!d) return 0;
   lorentzian_data *dnew = (lorentzian_data *) malloc(d->sz_data);
   memcpy(dnew, d, d->sz_data);
-  int ntot = d->ntot;
+  meep::integer ntot = d->ntot;
   realnum *P = dnew->data;
   realnum *P_prev = dnew->data + ntot;
   FOR_COMPONENTS(c) DOCMP2 if (d->P[c][cmp]) {
@@ -188,22 +188,22 @@ void lorentzian_susceptibility::update_P
 
       // directions/strides for offdiagonal terms, similar to update_eh
       const direction d = component_direction(c);
-      const int is = gv.stride(d) * (is_magnetic(c) ? -1 : +1);
+      const meep::integer is = gv.stride(d) * (is_magnetic(c) ? -1 : +1);
       direction d1 = cycle_direction(gv.dim, d, 1);
       component c1 = direction_component(c, d1);
-      int is1 = gv.stride(d1) * (is_magnetic(c) ? -1 : +1);
+      meep::integer is1 = gv.stride(d1) * (is_magnetic(c) ? -1 : +1);
       const realnum *w1 = W[c1][cmp];
       const realnum *s1 = w1 ? sigma[c][d1] : NULL;
       direction d2 = cycle_direction(gv.dim, d, 2);
       component c2 = direction_component(c, d2);
-      int is2 = gv.stride(d2) * (is_magnetic(c) ? -1 : +1);
+      meep::integer is2 = gv.stride(d2) * (is_magnetic(c) ? -1 : +1);
       const realnum *w2 = W[c2][cmp];
       const realnum *s2 = w2 ? sigma[c][d2] : NULL;
 
       if (s2 && !s1) { // make s1 the non-NULL one if possible
 	SWAP(direction, d1, d2);
 	SWAP(component, c1, c2);
-	SWAP(int, is1, is2);
+	SWAP(meep::integer, is1, is2);
 	SWAP(const realnum *, w1, w2);
 	SWAP(const realnum *, s1, s2);
       }
@@ -246,26 +246,26 @@ void lorentzian_susceptibility::subtract_P(field_type ft,
 					   void *P_internal_data) const {
   lorentzian_data *d = (lorentzian_data *) P_internal_data;
   field_type ft2 = ft == E_stuff ? D_stuff : B_stuff; // for sources etc.
-  int ntot = d->ntot;
+  meep::integer ntot = d->ntot;
   FOR_FT_COMPONENTS(ft, ec) DOCMP2 if (d->P[ec][cmp]) {
     component dc = field_type_component(ft2, ec);
     if (f_minus_p[dc][cmp]) {
       realnum *p = d->P[ec][cmp];
       realnum *fmp = f_minus_p[dc][cmp];
-      for (int i = 0; i < ntot; ++i) fmp[i] -= p[i];
+      for (meep::integer i = 0; i < ntot; ++i) fmp[i] -= p[i];
     }
   }
 }
 
-int lorentzian_susceptibility::num_cinternal_notowned_needed(component c,
+meep::integer lorentzian_susceptibility::num_cinternal_notowned_needed(component c,
 				   void *P_internal_data) const {
   lorentzian_data *d = (lorentzian_data *) P_internal_data;
   return d->P[c][0] ? 1 : 0;
 }
 
 realnum *lorentzian_susceptibility::cinternal_notowned_ptr(
-				        int inotowned, component c, int cmp, 
-					int n, 
+		meep::integer inotowned, component c, meep::integer cmp,
+					meep::integer n,
 					void *P_internal_data) const {
   lorentzian_data *d = (lorentzian_data *) P_internal_data;
   (void) inotowned; // always = 0

--- a/src/update_eh.cpp
+++ b/src/update_eh.cpp
@@ -80,7 +80,7 @@ bool fields_chunk::update_eh(field_type ft, bool skip_w_components) {
     break;
   }
 
-  const int ntot = s->gv.ntot();
+  const meep::integer ntot = s->gv.ntot();
 
   if (have_f_minus_p && doing_solve_cw)
     abort("dispersive materials are not yet implemented for solve_cw");
@@ -107,7 +107,7 @@ bool fields_chunk::update_eh(field_type ft, bool skip_w_components) {
     for (src_vol *sv = sources[ft2]; sv; sv = sv->next) {  
       if (sv->t->is_integrated && f[sv->c][0] && ft == type(sv->c)) {
 	component c = field_type_component(ft2, sv->c);
-	for (int j = 0; j < sv->npts; ++j) { 
+	for (meep::integer j = 0; j < sv->npts; ++j) {
 	  const complex<double> A = sv->dipole(j);
 	  DOCMP {
 	    f_minus_p[c][cmp][sv->index[j]] -= 
@@ -129,13 +129,13 @@ bool fields_chunk::update_eh(field_type ft, bool skip_w_components) {
     if (type(ec) != ft) abort("bug in FOR_FT_COMPONENTS");
     component dc = field_type_component(ft2, ec);
     const direction d_ec = component_direction(ec);
-    const int s_ec = gv.stride(d_ec) * (ft == H_stuff ? -1 : +1);
+    const meep::integer s_ec = gv.stride(d_ec) * (ft == H_stuff ? -1 : +1);
     const direction d_1 = cycle_direction(gv.dim, d_ec, 1);
     const component dc_1 = direction_component(dc,d_1);
-    const int s_1 = gv.stride(d_1) * (ft == H_stuff ? -1 : +1);
+    const meep::integer s_1 = gv.stride(d_1) * (ft == H_stuff ? -1 : +1);
     const direction d_2 = cycle_direction(gv.dim, d_ec, 2);
     const component dc_2 = direction_component(dc,d_2);
-    const int s_2 = gv.stride(d_2) * (ft == H_stuff ? -1 : +1);
+    const meep::integer s_2 = gv.stride(d_2) * (ft == H_stuff ? -1 : +1);
 
     direction dsigw0 = d_ec;
     direction dsigw = s->sigsize[dsigw0] > 1 ? dsigw0 : NO_DIRECTION;
@@ -183,20 +183,20 @@ bool fields_chunk::update_eh(field_type ft, bool skip_w_components) {
 						      || ec == Hr)) {
       component dc = field_type_component(ft2, ec);
       if (f[ec][cmp] == f[dc][cmp]) continue;
-      const int yee_idx = gv.yee_index(ec);
+      const meep::integer yee_idx = gv.yee_index(ec);
       const int d_ec = component_direction(ec);
-      const int sR = gv.stride(R), nZ = gv.num_direction(Z);
+      const meep::integer sR = gv.stride(R), nZ = gv.num_direction(Z);
       realnum *E = f[ec][cmp];
       const realnum *D = f_minus_p[dc][cmp] ? f_minus_p[dc][cmp] : f[dc][cmp];
       const realnum *chi1inv = s->chi1inv[ec][d_ec];
       if (chi1inv)
-	for (int iZ=0; iZ<nZ; iZ++) {
-	  const int i = yee_idx + iZ - sR;
+	for (meep::integer iZ=0; iZ<nZ; iZ++) {
+	  const meep::integer i = yee_idx + iZ - sR;
 	  E[i] = chi1inv[i] * D[i];
 	}
       else
-	for (int iZ=0; iZ<nZ; iZ++) {
-	  const int i = yee_idx + iZ - sR;
+	for (meep::integer iZ=0; iZ<nZ; iZ++) {
+	  const meep::integer i = yee_idx + iZ - sR;
 	  E[i] = D[i];
 	}
     }

--- a/tests/aniso_disp.cpp
+++ b/tests/aniso_disp.cpp
@@ -108,14 +108,14 @@ int main(int argc, char **argv) {
     f.use_bloch(vec(0.813,0,0));
     f.add_point_source(Ez, 0.5, 1.0, 0.0, 4.0, vec(0,0,0));
     double T = f.last_source_time();
-    int iT = T / f.dt;
+    int iT = static_cast<int>(T / f.dt);
     while (f.t < iT) {
       if (f.t % (iT / 10) == 0)
 	master_printf("%g%% done with source\n", f.time()/T * 100);
       f.step();
     }
     double T2 = 200;
-    int iT2 = T2 / f.dt;
+    int iT2 = static_cast<int>(T2 / f.dt);
     complex<double> *vals = new complex<double>[iT2];
     while (f.t - iT < iT2) {
       if ((f.t - iT) % (iT2 / 10) == 0)

--- a/tests/cylindrical.cpp
+++ b/tests/cylindrical.cpp
@@ -83,7 +83,8 @@ int test_simple_periodic(double eps(const vec &), int splitting, const char *myd
     f1.add_point_source(Ez, 0.8, 0.6, 0.0, 4.0, veccyl(0.401, 0.301), 1.0);
     if (!compare(f1.count_volume(Ep), f.count_volume(Ep), "grid_volume")) return 0;
     master_printf("Chunks are %g by %g\n",
-                  f.chunks[0]->gv.nr()/a, f.chunks[0]->gv.nz()/a);
+                  static_cast<double>(f.chunks[0]->gv.nr())/a,
+				  static_cast<double>(f.chunks[0]->gv.nz())/a);
     double field_energy_check_time = 29.0;
     while (f.time() < ttot) {
       f.step();
@@ -132,7 +133,8 @@ int test_simple_metallic(double eps(const vec &), int splitting, const char *myd
     f1.add_point_source(Ez, 0.8, 0.6, 0.0, 4.0, veccyl(0.401, 0.301), 1.0);
     if (!compare(f1.count_volume(Ep), f.count_volume(Ep), "grid_volume")) return 0;
     master_printf("Chunks are %g by %g\n",
-                  f.chunks[0]->gv.nr()/a, f.chunks[0]->gv.nz()/a);
+                  static_cast<double>(f.chunks[0]->gv.nr())/a,
+				  static_cast<double>(f.chunks[0]->gv.nz())/a);
     double field_energy_check_time = 29.0;
     while (f.time() < ttot) {
       f.step();
@@ -226,7 +228,8 @@ int test_pml(double eps(const vec &), int splitting, const char *mydirname) {
     f1.add_point_source(Ez, 0.8, 0.6, 0.0, 4.0, veccyl(0.3, 7.0), 1.0);
     if (!compare(f1.count_volume(Ep), f.count_volume(Ep), "grid_volume", 3e-14)) return 0;
     master_printf("Chunks are %g by %g\n",
-                  f.chunks[0]->gv.nr()/a, f.chunks[0]->gv.nz()/a);
+    				static_cast<double>(f.chunks[0]->gv.nr())/a,
+    				static_cast<double>(f.chunks[0]->gv.nz())/a);
     double field_energy_check_time = 10.0;
     while (f.time() < ttot) {
       f.step();
@@ -286,7 +289,8 @@ int test_pattern(double eps(const vec &), int splitting,
     f1.use_bloch(0.0);
     if (!compare(f1.count_volume(Ep), f.count_volume(Ep), "grid_volume")) return 0;
     master_printf("First chunk is %g by %g\n",
-                  f.chunks[0]->gv.nr()/a, f.chunks[0]->gv.nz()/a);
+    		static_cast<double>(f.chunks[0]->gv.nr())/a,
+			static_cast<double>(f.chunks[0]->gv.nz())/a);
     f1.initialize_field(Hp, checkers);
     f.initialize_field(Hp, checkers);
 

--- a/tests/flux.cpp
+++ b/tests/flux.cpp
@@ -213,7 +213,7 @@ int flux_2d(const double xmax, const double ymax,
     fluxL += f.dt * (left->flux() - right->flux()
 		     + bottom->flux() - top->flux());
   }
-  double flux = fluxL;
+  double flux = static_cast<double>(fluxL);
   double del_energy = f.field_energy_in_box(box) - init_energy;
   master_printf("Final energy is %g\n", f.field_energy_in_box(box));
   master_printf("  delta E: %g\n  net flux: %g\n  ratio: %g\n",
@@ -284,7 +284,7 @@ int flux_cyl(const double rmax, const double zmax,
     fluxL += f.dt * (left->flux() - right->flux()
 		      + bottom->flux() - top->flux());
   }
-  double flux = fluxL;
+  double flux = static_cast<double>(fluxL);
   double del_energy = f.field_energy_in_box(box) - init_energy;
   master_printf("Final energy is %g\n", f.field_energy_in_box(box));
   master_printf("  delta E: %g\n  net flux: %g\n  ratio: %g\n",

--- a/tests/h5test.cpp
+++ b/tests/h5test.cpp
@@ -60,11 +60,14 @@ symmetry make_rotate4z(const grid_volume &gv)
 typedef symmetry (*symfunc)(const grid_volume &);
 
 const double tol = sizeof(realnum) == sizeof(float) ? 1e-4 : 1e-8;
-double compare(double a, double b, const char *nam, int i0,int i1,int i2) {
+double compare(double a, double b, const char *nam, meep::integer i0,meep::integer i1,meep::integer i2) {
   if (fabs(a-b) > tol*tol + fabs(b) * tol || b != b) {
     master_printf("%g vs. %g differs by\t%g\n", a, b, fabs(a-b));
     master_printf("This gives a fractional error of %g\n", fabs(a-b)/fabs(b));
-    abort("Error in %s at (%d,%d,%d)\n", nam, i0,i1,i2);
+    abort("Error in %s at (%ld,%ld,%ld)\n", nam,
+    		static_cast<long int>(i0),
+			static_cast<long int>(i1),
+			static_cast<long int>(i2));
   }
   return fabs(a-b);
 }
@@ -118,8 +121,10 @@ bool check_2d(double eps(const vec &), double a, int splitting, symfunc Sf,
   LOOP_OVER_DIRECTIONS(gv.dim, d) {
     iloc0.set_direction(d, 1+2*int(floor(loc0.in_direction(d)*a-.5)));
     if (file_gv.in_direction(d) == 0.0 &&
-	1. - file_gv.in_direction_min(d)*a + 0.5*iloc0.in_direction(d)
-	<= 1. + file_gv.in_direction_max(d)*a - 0.5*(iloc0.in_direction(d)+2))
+	1. - file_gv.in_direction_min(d)*a
+		+ 0.5*static_cast<double>(iloc0.in_direction(d))
+	<= 1. + file_gv.in_direction_max(d)*a
+		- 0.5*static_cast<double>(iloc0.in_direction(d)+2))
       iloc0.set_direction(d, iloc0.in_direction(d) + 2); // snap to grid
   }
   loc0 = gv[iloc0];
@@ -127,7 +132,8 @@ bool check_2d(double eps(const vec &), double a, int splitting, symfunc Sf,
   double data_min = meep::infinity, data_max = -meep::infinity;
   double err_max = 0;
   for (int reim = 0; reim < (real_fields ? 1 : 2); ++reim) {
-    int rank, dims[2] = {1, 1};
+    int rank;
+    meep::integer dims[2] = {1, 1};
 
     char dataname[256];
     snprintf(dataname, 256, "%s%s", component_name(file_c),
@@ -150,7 +156,7 @@ bool check_2d(double eps(const vec &), double a, int splitting, symfunc Sf,
       for (int i1 = 0; i1 < dims[1]; ++i1) {
 	loc.set_direction(X, loc0.in_direction(X) + i0 * gv.inva);
 	loc.set_direction(Y, loc0.in_direction(Y) + i1 * gv.inva);
-	int idx = i0 * dims[1] + i1;
+	meep::integer idx = i0 * dims[1] + i1;
 
 	/* Ugh, for rotational symmetries (which mix up components etc.),
 	   we can't guarantee that a component is *exactly* the
@@ -235,8 +241,10 @@ bool check_3d(double eps(const vec &), double a, int splitting, symfunc Sf,
   LOOP_OVER_DIRECTIONS(gv.dim, d) {
     iloc0.set_direction(d, 1+2*int(floor(loc0.in_direction(d)*a-.5)));
     if (file_gv.in_direction(d) == 0.0 &&
-	1. - file_gv.in_direction_min(d)*a + 0.5*iloc0.in_direction(d)
-	<= 1. + file_gv.in_direction_max(d)*a - 0.5*(iloc0.in_direction(d)+2))
+	1. - file_gv.in_direction_min(d)*a
+		+ 0.5*static_cast<double>(iloc0.in_direction(d))
+	<= 1. + file_gv.in_direction_max(d)*a
+		- 0.5*static_cast<double>(iloc0.in_direction(d)+2))
       iloc0.set_direction(d, iloc0.in_direction(d) + 2); // snap to grid
   }
   loc0 = gv[iloc0];
@@ -244,7 +252,8 @@ bool check_3d(double eps(const vec &), double a, int splitting, symfunc Sf,
   double data_min = meep::infinity, data_max = -meep::infinity;
   double err_max = 0;
   for (int reim = 0; reim < (real_fields ? 1 : 2); ++reim) {
-    int rank, dims[3] = {1, 1, 1};
+    int rank;
+    meep::integer dims[3] = {1, 1, 1};
 
     char dataname[256];
     snprintf(dataname, 256, "%s%s", component_name(file_c),
@@ -258,13 +267,13 @@ bool check_3d(double eps(const vec &), double a, int splitting, symfunc Sf,
 	 abort("incorrect rank (%d instead of %d) in %s:%s\n",
 	       rank, expected_rank, name, dataname);
     vec loc(loc0.dim);
-    for (int i0 = 0; i0 < dims[0]; ++i0) {
-      for (int i1 = 0; i1 < dims[1]; ++i1) {
-	for (int i2 = 0; i2 < dims[2]; ++i2) {
-	  loc.set_direction(X, loc0.in_direction(X) + i0 * gv.inva);
-	  loc.set_direction(Y, loc0.in_direction(Y) + i1 * gv.inva);
-	  loc.set_direction(Z, loc0.in_direction(Z) + i2 * gv.inva);
-	  int idx = (i0 * dims[1] + i1) * dims[2] + i2;
+    for (meep::integer i0 = 0; i0 < dims[0]; ++i0) {
+      for (meep::integer i1 = 0; i1 < dims[1]; ++i1) {
+	for (meep::integer i2 = 0; i2 < dims[2]; ++i2) {
+	  loc.set_direction(X, loc0.in_direction(X) + static_cast<double>(i0) * gv.inva);
+	  loc.set_direction(Y, loc0.in_direction(Y) + static_cast<double>(i1) * gv.inva);
+	  loc.set_direction(Z, loc0.in_direction(Z) + static_cast<double>(i2) * gv.inva);
+	  meep::integer idx = (i0 * dims[1] + i1) * dims[2] + i2;
 	  
 	  /* Ugh, for rotational symmetries (which mix up components etc.),
 	     we can't guarantee that a component is *exactly* the
@@ -331,8 +340,8 @@ bool check_2d_monitor(double eps(const vec &),
   ivec iloc0(gv.dim);
   LOOP_OVER_DIRECTIONS(gv.dim, d) {
     iloc0.set_direction(d, 1+2*int(floor(pt.in_direction(d)*a-.5)));
-    if (1. - pt.in_direction(d)*a + 0.5*iloc0.in_direction(d)
-	<= 1. + pt.in_direction(d)*a - 0.5*(iloc0.in_direction(d)+2))
+    if (1. - pt.in_direction(d)*a + 0.5*static_cast<double>(iloc0.in_direction(d))
+	<= 1. + pt.in_direction(d)*a - 0.5*static_cast<double>(iloc0.in_direction(d)+2))
       iloc0.set_direction(d, iloc0.in_direction(d) + 2); // snap to grid
   }
   vec pt0(gv[iloc0]);
@@ -358,7 +367,8 @@ bool check_2d_monitor(double eps(const vec &),
   double err_max = 0;
 
   for (int reim = 0; reim < (real_fields ? 1 : 2); ++reim) {
-    int rank, dims[1] = {1};
+    int rank;
+    meep::integer dims[1] = {1};
 
     char dataname[256];
     snprintf(dataname, 256, "%s%s", component_name(file_c),

--- a/tests/integrate.cpp
+++ b/tests/integrate.cpp
@@ -265,7 +265,7 @@ void check_splitsym(const grid_volume &gv, int splitting,
 // check LOOP_OVER_VOL and LOOP_OVER_VOL_OWNED macros
 void check_loop_vol(const grid_volume &gv, component c)
 {
-  int count = 0, min_i = gv.ntot(), max_i = 0, count_owned = 0;
+  meep::integer count = 0, min_i = gv.ntot(), max_i = 0, count_owned = 0;
 
   master_printf("Checking %s loops for %s grid_volume...\n",
 		component_name(c), dimension_name(gv.dim));
@@ -279,28 +279,28 @@ void check_loop_vol(const grid_volume &gv, component c)
     ivec ihere0(gv.iloc(c, i));
     vec here0(gv[ihere0]);
     if (ihere0 != ihere)
-      abort("FAILED: wrong LOOP_OVER_VOL iloc at i=%d\n", i);
+      abort("FAILED: wrong LOOP_OVER_VOL iloc at i=%ld\n", static_cast<long int>(i));
     if (abs(here0 - here) > 1e-13)
-      abort("FAILED: wrong LOOP_OVER_VOL loc (err = %g) at i=%d\n",
-	    abs(here0 - here), i);
+      abort("FAILED: wrong LOOP_OVER_VOL loc (err = %g) at i=%ld\n",
+	    abs(here0 - here), static_cast<long int>(i));
     ++count;
     if (i < min_i) min_i = i;
     if (i > max_i) max_i = i;
     if (gv.owns(ihere))
       ++count_owned;
     if (ihere < vmin || ihere > vmax)
-      abort("FAILED: LOOP_OVER_VOL outside V at i=%d\n", i);
+      abort("FAILED: LOOP_OVER_VOL outside V at i=%ld\n", static_cast<long int>(i));
   }
   if (count != gv.ntot())
-    abort("FAILED: LOOP_OVER_VOL has %d iterations instead of ntot=%d\n",
-	  count, gv.ntot());
+    abort("FAILED: LOOP_OVER_VOL has %ld iterations instead of ntot=%ld\n",
+	  static_cast<long int>(count), static_cast<long int>(gv.ntot()));
   if (count_owned != gv.nowned(c))
-    abort("FAILED: LOOP_OVER_VOL has %d owned points instead of nowned=%d\n",
-	  count_owned, gv.nowned(c));
+    abort("FAILED: LOOP_OVER_VOL has %ld owned points instead of nowned=%ld\n",
+	  static_cast<long int>(count_owned), static_cast<long int>(gv.nowned(c)));
   if (min_i != 0)
-    abort("FAILED: LOOP_OVER_VOL has minimum index %d instead of 0\n", min_i);
+    abort("FAILED: LOOP_OVER_VOL has minimum index %ld instead of 0\n", static_cast<long int>(min_i));
   if (max_i != gv.ntot() - 1)
-    abort("FAILED: LOOP_OVER_VOL has max index %d instead of ntot-1\n", max_i);
+    abort("FAILED: LOOP_OVER_VOL has max index %ld instead of ntot-1\n", static_cast<long int>(max_i));
 
   count = 0;
   LOOP_OVER_VOL_OWNED(gv, c, i) {
@@ -309,17 +309,17 @@ void check_loop_vol(const grid_volume &gv, component c)
     ivec ihere0(gv.iloc(c, i));
     vec here0(gv[ihere0]);
     if (ihere0 != ihere)
-      abort("FAILED: wrong LOOP_OVER_VOL_OWNED iloc at i=%d\n", i);
+      abort("FAILED: wrong LOOP_OVER_VOL_OWNED iloc at i=%ld\n", static_cast<long int>(i));
     if (abs(here0 - here) > 1e-13)
-      abort("FAILED: wrong LOOP_OVER_VOL_OWNED loc (err = %g) at i=%d\n",
-	    abs(here0 - here), i);
+      abort("FAILED: wrong LOOP_OVER_VOL_OWNED loc (err = %g) at i=%ld\n",
+	    abs(here0 - here), static_cast<long int>(i));
     if (!gv.owns(ihere))
-      abort("FAILED: LOOP_OVER_VOL_OWNED includes non-owned at i=%d\n", i);
+      abort("FAILED: LOOP_OVER_VOL_OWNED includes non-owned at i=%ld\n", static_cast<long int>(i));
     ++count;
   }
   if (count != count_owned)
-    abort("FAILED: LOOP_OVER_VOL_OWNED has %d iterations instead of %d\n",
-	  count, count_owned);
+    abort("FAILED: LOOP_OVER_VOL_OWNED has %ld iterations instead of %ld\n",
+    		static_cast<long int>(count), static_cast<long int>(count_owned));
 
   count = 0;
   LOOP_OVER_VOL_NOTOWNED(gv, c, i) {
@@ -328,19 +328,19 @@ void check_loop_vol(const grid_volume &gv, component c)
     ivec ihere0(gv.iloc(c, i));
     vec here0(gv[ihere0]);
     if (ihere0 != ihere)
-      abort("FAILED: wrong LOOP_OVER_VOL_NOTOWNED iloc at i=%d\n", i);
+      abort("FAILED: wrong LOOP_OVER_VOL_NOTOWNED iloc at i=%ld\n", static_cast<long int>(i));
     if (abs(here0 - here) > 1e-13)
-      abort("FAILED: wrong LOOP_OVER_VOL_NOTOWNED loc (err = %g) at i=%d\n",
-	    abs(here0 - here), i);
+      abort("FAILED: wrong LOOP_OVER_VOL_NOTOWNED loc (err = %g) at i=%ld\n",
+	    abs(here0 - here), static_cast<long int>(i));
     if (gv.owns(ihere))
-      abort("FAILED: LOOP_OVER_VOL_NOTOWNED includes owned at i=%d\n", i);
+      abort("FAILED: LOOP_OVER_VOL_NOTOWNED includes owned at i=%ld\n", static_cast<long int>(i));
     if (ihere < vmin || ihere > vmax)
-      abort("FAILED: LOOP_OVER_VOL_NOTOWNED outside V at i=%d\n", i);
+      abort("FAILED: LOOP_OVER_VOL_NOTOWNED outside V at i=%ld\n", static_cast<long int>(i));
     ++count;
   }
   if (count != gv.ntot() - count_owned)
-    abort("FAILED: LOOP_OVER_VOL_NOTOWNED has %d iterations instead of %d\n",
-	  count, gv.ntot() - count_owned);
+    abort("FAILED: LOOP_OVER_VOL_NOTOWNED has %ld iterations instead of %ld\n",
+    		static_cast<long int>(count), static_cast<long int>(gv.ntot() - count_owned));
 
   master_printf("...PASSED.\n");
 }


### PR DESCRIPTION
This is a quite invasive commit to enable very large grids with more than 2^31-1 grid points. Basically the changes consist of setting the type of `meep::grid_volume::the_ntot` and all related variables to `ptrdiff_t` (via a typedef) and tracking down all errors, conversion warnings and loop variables (for details see the commit message of [521cb13](https://github.com/stevengj/meep/commit/521cb1331fad734d427d063a2d6331642fa2f1bb)). 
So far the changes have been tested only on x86-64 with gcc 4.8 and 4.9. I ran some simulations with very large grids (>2^31-1 grid points) for a dispersive gold grating (x and y periodic, z pmls) and a dipole emitter in a large box terminated with pmls. The obtained resuts were consistent with smaller grid sizes and unchanged versions of meep. I can provide both the results and the ctl files if you are interested. If there are any further tests you would like me to perform please let me know.
