### PR TITLE
add support for multilevel susceptibility

### DIFF
--- a/libctl/meep.scm.in
+++ b/libctl/meep.scm.in
@@ -119,19 +119,20 @@
 ; ****************************************************************
 ; Multilevel-atom nonlinear susceptibilities
 
-;(define-class transition no-parent
-;  (define-property from-level no-default 'integer non-negative?)
-;  (define-property to-level no-default 'integer non-negative?)
-;  (define-property transition-rate 0 'number) ; nonradiative rate (0 if none)
-;  (define-property frequency 0 'number) ; radiative frequency (0 if none)
-;  (define-property sigma-diag (vector3 1 1 1) 'vector3) ; per-transition sigma
-;  (define-property gamma 0 'number)) ; optical damping rate
+(define-class transition no-parent
+ (define-property from-level no-default 'integer non-negative?)
+ (define-property to-level no-default 'integer non-negative?)
+ (define-property transition-rate 0 'number) ; nonradiative rate (0 if none)
+ (define-property frequency 0 'number) ; radiative frequency (0 if none)
+ (define-property sigma-diag (vector3 1 1 1) 'vector3) ; per-transition sigma
+ (define-property gamma 0 'number) ; optical damping rate
+ (define-property pumping-rate 0 'number)) ; pumping rate (0 if none)
 
-;(define (transition-time t) (transition-rate (/ t)))
+(define (transition-time t) (transition-rate (/ t)))
 
-;(define-class multilevel-atom susceptibility
-;  (define-property initial-populations '() (make-list-type 'number))
-;  (define-property transitions '() (make-list-type 'transition)))
+(define-class multilevel-atom susceptibility
+ (define-property initial-populations '() (make-list-type 'number))
+ (define-property transitions '() (make-list-type 'transition)))
 
 ; ****************************************************************
 ; Add some predefined variables, for convenience:
@@ -658,6 +659,9 @@
   (meep-dft-near2far-save-farfields near2far fname (get-filename-prefix)
                                     where resolution))
 
+(define (output-farflux near2far df where resolution)
+  (meep-dft-near2far-flux near2far df where resolution))
+
 (define (load-near2far fname near2far)
   (if (null? fields) (init-fields))
   (meep-dft-near2far-load-hdf5 near2far fields fname "" (get-filename-prefix)))
@@ -1015,13 +1019,6 @@
 (define harminv-amp vector3-y)
 (define harminv-err vector3-z)
 
-(define-param harminv-spectral-density 1.1)
-(define-param harminv-Q-thresh 50.0)
-(define-param harminv-rel-err-thresh 1e20)
-(define-param harminv-err-thresh 0.01)
-(define-param harminv-rel-amp-thresh -1.0)
-(define-param harminv-amp-thresh -1.0)
-
 (define (analyze-harminv data fcen df maxbands . dt)
   (display-run-data 
    "harminv"
@@ -1030,10 +1027,7 @@
 			   (if (null? dt)
 			       (meep-fields-dt-get fields)
 			       (car dt))
-			   (- fcen (/ df 2)) (+ fcen (/ df 2)) maxbands
-                           harminv-spectral-density harminv-Q-thresh
-                           harminv-rel-err-thresh harminv-err-thresh
-                           harminv-rel-amp-thresh harminv-amp-thresh)))
+			   (- fcen (/ df 2)) (+ fcen (/ df 2)) maxbands)))
     (map (lambda (b) ; b = vector of (freq, amp, error)
 	   (display-run-data 
 	    "harminv"

--- a/libctl/meep.scm.in
+++ b/libctl/meep.scm.in
@@ -1032,9 +1032,9 @@
 			       (meep-fields-dt-get fields)
 			       (car dt))
 			   (- fcen (/ df 2)) (+ fcen (/ df 2)) maxbands
-			   harminv-spectral-density harminv-Q-thresh
-			   harminv-rel-err-thresh harminv-err-thresh
-			   harminv-rel-amp-thresh harminv-amp-thresh)))
+			    harminv-spectral-density harminv-Q-thresh
+			    harminv-rel-err-thresh harminv-err-thresh
+			    harminv-rel-amp-thresh harminv-amp-thresh)))
     (map (lambda (b) ; b = vector of (freq, amp, error)
 	   (display-run-data 
 	    "harminv"

--- a/libctl/meep.scm.in
+++ b/libctl/meep.scm.in
@@ -1032,9 +1032,9 @@
 			       (meep-fields-dt-get fields)
 			       (car dt))
 			   (- fcen (/ df 2)) (+ fcen (/ df 2)) maxbands
-			   harminv-spectral-density harminv-Q-thresh
-			   harminv-rel-err-thresh harminv-err-thresh
-			   harminv-rel-amp-thresh harminv-amp-thresh)))
+                           harminv-spectral-density harminv-Q-thresh
+                           harminv-rel-err-thresh harminv-err-thresh
+                           harminv-rel-amp-thresh harminv-amp-thresh)))
     (map (lambda (b) ; b = vector of (freq, amp, error)
 	   (display-run-data 
 	    "harminv"

--- a/libctl/meep.scm.in
+++ b/libctl/meep.scm.in
@@ -1016,6 +1016,13 @@
 (define harminv-amp vector3-y)
 (define harminv-err vector3-z)
 
+(define-param harminv-spectral-density 1.1)
+(define-param harminv-Q-thresh 50.0)
+(define-param harminv-rel-err-thresh 1e20)
+(define-param harminv-err-thresh 0.01)
+(define-param harminv-rel-amp-thresh -1.0)
+(define-param harminv-amp-thresh -1.0)
+
 (define (analyze-harminv data fcen df maxbands . dt)
   (display-run-data 
    "harminv"
@@ -1024,7 +1031,10 @@
 			   (if (null? dt)
 			       (meep-fields-dt-get fields)
 			       (car dt))
-			   (- fcen (/ df 2)) (+ fcen (/ df 2)) maxbands)))
+			   (- fcen (/ df 2)) (+ fcen (/ df 2)) maxbands
+			   harminv-spectral-density harminv-Q-thresh
+			   harminv-rel-err-thresh harminv-err-thresh
+			   harminv-rel-amp-thresh harminv-amp-thresh)))
     (map (lambda (b) ; b = vector of (freq, amp, error)
 	   (display-run-data 
 	    "harminv"

--- a/libctl/meep.scm.in
+++ b/libctl/meep.scm.in
@@ -659,9 +659,6 @@
   (meep-dft-near2far-save-farfields near2far fname (get-filename-prefix)
                                     where resolution))
 
-(define (output-farflux near2far df where resolution)
-  (meep-dft-near2far-flux near2far df where resolution))
-
 (define (load-near2far fname near2far)
   (if (null? fields) (init-fields))
   (meep-dft-near2far-load-hdf5 near2far fields fname "" (get-filename-prefix)))

--- a/libctl/meep.scm.in
+++ b/libctl/meep.scm.in
@@ -1032,9 +1032,9 @@
 			       (meep-fields-dt-get fields)
 			       (car dt))
 			   (- fcen (/ df 2)) (+ fcen (/ df 2)) maxbands
-			    harminv-spectral-density harminv-Q-thresh
-			    harminv-rel-err-thresh harminv-err-thresh
-			    harminv-rel-amp-thresh harminv-amp-thresh)))
+			   harminv-spectral-density harminv-Q-thresh
+			   harminv-rel-err-thresh harminv-err-thresh
+			   harminv-rel-amp-thresh harminv-amp-thresh)))
     (map (lambda (b) ; b = vector of (freq, amp, error)
 	   (display-run-data 
 	    "harminv"

--- a/libctl/structure.cpp
+++ b/libctl/structure.cpp
@@ -1297,8 +1297,8 @@ static meep::susceptibility *make_multilevel_sus(const multilevel_atom *d) {
   for (int t = 0; t < d->transitions.num_items; ++t) {
     int i = d->transitions.items[t].from_level - minlev;
     int j = d->transitions.items[t].to_level - minlev;
-    Gamma[i*L+i] -= (d->transitions.items[t].transition_rate + d->transitions.items[t].pumping_rate);
-    Gamma[j*L+i] += (d->transitions.items[t].transition_rate + d->transitions.items[t].pumping_rate);
+    Gamma[i*L+i] += (d->transitions.items[t].transition_rate + d->transitions.items[t].pumping_rate);
+    Gamma[j*L+i] -= (d->transitions.items[t].transition_rate + d->transitions.items[t].pumping_rate);
   }
   
   // initial populations of each level

--- a/libctl/structure.cpp
+++ b/libctl/structure.cpp
@@ -1299,18 +1299,10 @@ static meep::susceptibility *make_multilevel_sus(const multilevel_atom *d) {
     int j = d->transitions.items[t].to_level - minlev;
     Gamma[i*L+j+1] -= d->transitions.items[t].transition_rate;
     Gamma[(i-1)*L+j+1] += d->transitions.items[t].transition_rate;
+    Gamma[i*L+i] -= d->transitions.items[t].pumping_rate;
+    Gamma[j*L+i] += d->transitions.items[t].pumping_rate;
   }
   
-  // pumping rate matrix Rp
-  meep::realnum *Rp = new meep::realnum[L * L];
-  memset(Rp, 0, sizeof(meep::realnum) * (L*L));
-  for (int t = 0; t < d->transitions.num_items; ++t) {
-    int i = d->transitions.items[t].from_level - minlev;
-    int j = d->transitions.items[t].to_level - minlev;
-    Rp[i*L+i] -= d->transitions.items[t].pumping_rate;
-    Rp[j*L+i] += d->transitions.items[t].pumping_rate;
-  }
-
   // initial populations of each level
   meep::realnum *N0 = new meep::realnum[L];
   memset(N0, 0, sizeof(meep::realnum) * L);
@@ -1345,14 +1337,13 @@ static meep::susceptibility *make_multilevel_sus(const multilevel_atom *d) {
 
   meep::multilevel_susceptibility *s
     = new meep::multilevel_susceptibility(L, T, Gamma, N0, alpha,
-					  omega, gamma, sigmat, Rp);
+					  omega, gamma, sigmat);
   delete[] Gamma;
   delete[] N0;
   delete[] alpha;
   delete[] omega;
   delete[] gamma;
   delete[] sigmat;
-  delete[] Rp;
 
   return s;
 }

--- a/libctl/structure.cpp
+++ b/libctl/structure.cpp
@@ -1297,10 +1297,8 @@ static meep::susceptibility *make_multilevel_sus(const multilevel_atom *d) {
   for (int t = 0; t < d->transitions.num_items; ++t) {
     int i = d->transitions.items[t].from_level - minlev;
     int j = d->transitions.items[t].to_level - minlev;
-    Gamma[i*L+j+1] -= d->transitions.items[t].transition_rate;
-    Gamma[(i-1)*L+j+1] += d->transitions.items[t].transition_rate;
-    Gamma[i*L+i] -= d->transitions.items[t].pumping_rate;
-    Gamma[j*L+i] += d->transitions.items[t].pumping_rate;
+    Gamma[i*L+i] -= (d->transitions.items[t].transition_rate + d->transitions.items[t].pumping_rate);
+    Gamma[j*L+i] += (d->transitions.items[t].transition_rate + d->transitions.items[t].pumping_rate);
   }
   
   // initial populations of each level

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -220,15 +220,14 @@ protected:
 
 class multilevel_susceptibility : public susceptibility {
 public:
-  multilevel_susceptibility() : L(0), T(0), Gamma(0), N0(0), alpha(0), omega(0), gamma(0), sigmat(0), Rp(0) {}
+  multilevel_susceptibility() : L(0), T(0), Gamma(0), N0(0), alpha(0), omega(0), gamma(0), sigmat(0) {}
   multilevel_susceptibility(int L, int T,
 			    const realnum *Gamma,
 			    const realnum *N0,
 			    const realnum *alpha,
 			    const realnum *omega,
 			    const realnum *gamma,
-			    const realnum *sigmat,
-			    const realnum *Rp);
+			    const realnum *sigmat);
   multilevel_susceptibility(const multilevel_susceptibility &from);
   virtual susceptibility *clone() const { return new multilevel_susceptibility(*this); }
   virtual ~multilevel_susceptibility();
@@ -267,13 +266,12 @@ public:
 protected:
   int L; // number of atom levels
   int T; // number of optical transitions
-  realnum *Gamma; // LxL matrix of relaxation rates Gamma[i*L+j] from i -> j
+  realnum *Gamma; // LxL matrix of non-radiative decay and pumping rates Gamma[i*L+j] from i -> j
   realnum *N0; // L initial populations
   realnum *alpha; // LxT matrix of transition coefficients 1/omega
   realnum *omega; // T transition frequencies
   realnum *gamma; // T optical loss rates
   realnum *sigmat; // 5*T transition-specific sigma-diagonal factors
-  realnum *Rp; // LxL matrix of pumping rates Rp[i*L+j] from i -> j
 };
 
 class grace;

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -220,14 +220,15 @@ protected:
 
 class multilevel_susceptibility : public susceptibility {
 public:
-  multilevel_susceptibility() : L(0), T(0), Gamma(0), N0(0), alpha(0), omega(0), gamma(0) {}
+  multilevel_susceptibility() : L(0), T(0), Gamma(0), N0(0), alpha(0), omega(0), gamma(0), sigmat(0), Rp(0) {}
   multilevel_susceptibility(int L, int T,
 			    const realnum *Gamma,
 			    const realnum *N0,
 			    const realnum *alpha,
 			    const realnum *omega,
 			    const realnum *gamma,
-			    const realnum *sigmat);
+			    const realnum *sigmat,
+			    const realnum *Rp);
   multilevel_susceptibility(const multilevel_susceptibility &from);
   virtual susceptibility *clone() const { return new multilevel_susceptibility(*this); }
   virtual ~multilevel_susceptibility();
@@ -272,6 +273,7 @@ protected:
   realnum *omega; // T transition frequencies
   realnum *gamma; // T optical loss rates
   realnum *sigmat; // 5*T transition-specific sigma-diagonal factors
+  realnum *Rp; // LxL matrix of pumping rates Rp[i*L+j] from i -> j
 };
 
 class grace;
@@ -964,6 +966,9 @@ public:
   /* output far fields on a grid to an HDF5 file */
   void save_farfields(const char *fname, const char *prefix,
                       const volume &where, double resolution);
+
+  /* output Poynting vector of far fields */
+  double *flux(direction df, const volume &where, double resolution);
 
   void save_hdf5(h5file *file, const char *dprefix = 0);
   void load_hdf5(h5file *file, const char *dprefix = 0);

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -967,9 +967,6 @@ public:
   void save_farfields(const char *fname, const char *prefix,
                       const volume &where, double resolution);
 
-  /* output Poynting vector of far fields */
-  double *flux(direction df, const volume &where, double resolution);
-
   void save_hdf5(h5file *file, const char *dprefix = 0);
   void load_hdf5(h5file *file, const char *dprefix = 0);
 


### PR DESCRIPTION
Support for multilevel susceptibility is added to model saturable absorbers and lasing thresholds. This involves solving a generalized form of the Maxwell-Bloch equations using second-order accurate finite differences. The parameters are the non-radiative decay and pumping rates of the atomic level transitions as well as the polarization field which have been added to the libctl interface. Tests for a two-level saturable absorber in 1d have verified the threshold behavior and the equal population densities of the two levels at steady state. Note that the fields will blow up if the "sigma" term of the polarization fields or the initial population-level differences are large relative to the temporal resolution. This is not a bug and is related to numerical instabilities arising from strong coupling between the electric and polarization fields. The workaround is to simply increase the spatial resolution or reduce the Courant factor. An example to include in the test suite is forthcoming.
