### PR TITLE
small bug in dft-ldos domega

### DIFF
--- a/src/dft_ldos.cpp
+++ b/src/dft_ldos.cpp
@@ -31,7 +31,7 @@ dft_ldos::dft_ldos(double freq_min, double freq_max, int Nfreq)
   }
   else {
     omega_min = freq_min * 2*pi;
-    domega = (freq_max - freq_min) * 2*pi / Nfreq;
+    domega = (freq_max - freq_min) * 2*pi / (Nfreq - 1);
     Nomega = Nfreq;
   }
   Fdft = new complex<realnum>[Nomega];


### PR DESCRIPTION
A minor correction to the 'domega' member of the dft_ldos class so that it is consistent with its corresponding member in add_dft (see src/dft.cpp:179). Thanks to Erik Shipton for the bug report.