### PR TITLE
Add missing 'x' to test for have_harminv

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -166,7 +166,7 @@ fi
 AC_CHECK_HEADER(mpb.h, [have_mpb=maybe], [have_mpb=no])
 
 if test $have_mpb = maybe; then
-  if test "x$acx_lapack_ok" = x -a "$have_harminv" = xno; then
+  if test "x$acx_lapack_ok" = x -a "x$have_harminv" = xno; then
 	ACX_BLAS
 	ACX_LAPACK([], [AC_MSG_WARN([BLAS/LAPACK needed for MPB])])
         LIBS="$LAPACK_LIBS $BLAS_LIBS $LIBS $FLIBS"


### PR DESCRIPTION
We discussed this during a meeting.  `$have_harminv` would never equal `xno` because the "x" was missing.
@stevengj 