### PR TITLE
Add working test_physical.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 *.dSYM
 *.zip
 *.native
+*.pyc
 _build
 
 # autotools stuff
@@ -52,11 +53,14 @@ libctl/meep_enum_renames.i
 libctl/meep_renames.i
 libctl/meep_swig_bug_workaround.i
 libctl/meep_wrap.cxx
+libctl/meep_wrap.cxx.orig
 meep-pkgconfig
 meep.pc
 src/sphere-quad.h
 src/sphere_quad
 src/step_generic_stride1.cpp
+python/meep-python.cpp
+python/meep.py
 
 # test programs
 tests/2D_convergence
@@ -84,6 +88,9 @@ tests/two_dimensional
 tests/*.trs
 tests/*.log
 tests/latest_output
+python/tests/*.log
+python/tests/*.trs
+python/*.log
 
 # output files
 examples/*.h5

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -9,6 +9,8 @@ HPPFILES=	                          \
 
 BUILT_SOURCES = meep-python.cpp meep.py
 
+CLEANFILES = $(BUILT_SOURCES) meep-python.h
+
 AM_CPPFLAGS = -I$(top_srcdir)/src                   \
               -I$(top_builddir) # for config.h
 
@@ -16,6 +18,12 @@ _meep_la_SOURCES = meep-python.cpp
 _meep_la_LIBADD = $(top_builddir)/src/libmeep.la $(PYTHON_LIBS)
 _meep_la_LDFLAGS = -module -version-info @SHARED_VERSION_INFO@
 _meep_la_CPPFLAGS = $(PYTHON_INCLUDES) $(AM_CPPFLAGS)
+
+TEST_DIR = tests
+TESTS = $(TEST_DIR)/test_physical.py
+TEST_EXTENSIONS = .py
+PY_LOG_COMPILER = $(PYTHON)
+AM_TESTS_ENVIRONMENT = PYTHONPATH='$(top_srcdir)/python/.libs'; export PYTHONPATH;
 
 if WITH_PYTHON
   python_PYTHON = meep.py

--- a/python/meep.i
+++ b/python/meep.i
@@ -37,8 +37,7 @@ PyObject *py_callback = NULL;
 
 static PyObject* vec2py(const meep::vec &v) {
 
-    PyObject *py_vec;
-    double x = 0, y = 0, z = 0, r = 0;
+    double x = 0, y = 0, z = 0;
 
     switch (v.dim) {
       case meep::D1:
@@ -56,16 +55,11 @@ static PyObject* vec2py(const meep::vec &v) {
       case meep::Dcyl:
         r = v.r();
         z = v.z();
+        return Py_BuildValue("(ddd)", r, z, 0);
         break;
     }
 
-    if(v.dim == meep::Dcyl) {
-        py_vec = Py_BuildValue("(ddd)", r, z, 0);
-    } else {
-        py_vec = Py_BuildValue("(ddd)", x, y, z);
-    }
-
-    return py_vec;
+    return Py_BuildValue("(ddd)", x, y, z);
 }
 
 static double py_callback_wrap(const meep::vec &v) {

--- a/python/meep.i
+++ b/python/meep.i
@@ -15,29 +15,80 @@
  *  Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  */
 
-%module(directors="1") meep
+%module meep
 
 %{
 #define SWIG_FILE_WITH_INIT
 #include "meep/vec.hpp"
 #include "meep.hpp"
+
 using namespace meep;
+
 %}
 
 %include "numpy.i"
-
-%{
-#if NPY_API_VERSION < 0x00000007
-#define NPY_ARRAY_C_CONTIGUOUS NPY_C_CONTIGUOUS
-#define NPY_ARRAY_ALIGNED  NPY_ALIGNED
-#endif
-%}
 
 %init %{
   import_array();
 %}
 
-// TODO: apply necessary numpy typemaps
+%{
+PyObject *py_callback = NULL;
+
+static PyObject* vec2py(const meep::vec &v) {
+
+    PyObject *py_vec;
+    double x = 0, y = 0, z = 0, r = 0;
+
+    switch (v.dim) {
+      case meep::D1:
+        z = v.z();
+        break;
+      case meep::D2:
+        x = v.x();
+        y = v.y();
+        break;
+      case meep::D3:
+        x = v.x();
+        y = v.y();
+        z = v.z();
+        break;
+      case meep::Dcyl:
+        r = v.r();
+        z = v.z();
+        break;
+    }
+
+    if(v.dim == meep::Dcyl) {
+        py_vec = Py_BuildValue("(ddd)", r, z, 0);
+    } else {
+        py_vec = Py_BuildValue("(ddd)", x, y, z);
+    }
+
+    return py_vec;
+}
+
+static double py_callback_wrap(const meep::vec &v) {
+    PyObject *pyv = vec2py(v);
+    PyObject *pyret = PyObject_CallFunctionObjArgs(py_callback, pyv, NULL);
+    Py_XDECREF(pyv);
+    double ret = PyFloat_AsDouble(pyret);
+    Py_XDECREF(pyret);
+    return ret;
+}
+%}
+
+%typemap(in) double (*)(const meep::vec &) {
+  $1 = py_callback_wrap;
+  py_callback = $input;
+  Py_INCREF(py_callback);
+}
+%typemap(freearg) double (*)(const meep::vec &) {
+  Py_XDECREF(py_callback);
+}
+%typecheck(SWIG_TYPECHECK_POINTER) double (*)(const meep::vec &) {
+  $1 = PyCallable_Check($input);
+}
 
 // Rename python builtins
 %rename(br_apply) meep::boundary_region::apply;
@@ -47,53 +98,13 @@ using namespace meep;
 // Operator renaming
 %rename(boundary_region_assign) meep::boundary_region::operator=;
 
-// TODO:  Fix these with a typemap when necesary
+// TODO:  Fix these with a typemap when necessary
 %feature("immutable") meep::fields_chunk::connections;
 %feature("immutable") meep::fields_chunk::num_connections;
 
-%feature("director") meep::Callback;
+%include "vec.i"
 
-// TODO: Ignore with build flags once all have been analyzed and determined benign.
-%warnfilter(509);
-%warnfilter(322,509) meep::component_direction;
-%warnfilter(322,509) meep::direction_component;
-%warnfilter(322,503) meep::zero_vec;
-%warnfilter(322,503) meep::veccyl;
-%warnfilter(322,503) meep::zero_ivec;
-%warnfilter(322,503) meep::one_ivec;
-%warnfilter(322,503) meep::iveccyl;
-%warnfilter(503) meep::one_vec;
-%warnfilter(503) meep::volcyl;
-%warnfilter(503) meep::volone;
-%warnfilter(503) meep::vol1d;
-%warnfilter(503) meep::voltwo;
-%warnfilter(503) meep::vol2d;
-%warnfilter(503) meep::vol3d;
-%warnfilter(503) meep::identity;
-%warnfilter(503) meep::rotate4;
-%warnfilter(503) meep::rotate2;
-%warnfilter(503) meep::mirror;
-%warnfilter(503) meep::r_to_minus_r_symmetry;
-%warnfilter(509) meep::component_name;
-%warnfilter(509) meep::coordinate_mismatch;
-%warnfilter(509) meep::ivec::ivec;
-%warnfilter(509) meep::symmetry::transform;
-%warnfilter(509) meep::symmetry::phase_shift;
-
-
-// Renaming python builtins
-%rename(ftype) meep::type;
-%rename(vec_abs) meep::abs;
-%rename(vec_max) meep::max;
-%rename(vec_min) meep::min;
-%rename(print_grid_volume) meep::grid_volume::print;
-%rename(symmetry_reduce) meep::symmetry::reduce;
-
-// Operator renaming
-%rename(volume_and) meep::volume::operator&&;
-%rename(grid_volume_getitem) meep::grid_volume::operator[];
-%rename(symmetry_assign) meep::symmetry::operator=;
-
-
-%include "meep/vec.hpp"
 %include "meep.hpp"
+
+%ignore eps_func;
+%ignore inveps_func;

--- a/python/meep.i
+++ b/python/meep.i
@@ -53,10 +53,7 @@ static PyObject* vec2py(const meep::vec &v) {
         z = v.z();
         break;
       case meep::Dcyl:
-        r = v.r();
-        z = v.z();
-        return Py_BuildValue("(ddd)", r, z, 0);
-        break;
+        return Py_BuildValue("(ddd)", v.r(), v.z(), 0);
     }
 
     return Py_BuildValue("(ddd)", x, y, z);

--- a/python/tests/test_physical.py
+++ b/python/tests/test_physical.py
@@ -1,0 +1,99 @@
+# Copyright (C) 2005-2017 Massachusetts Institute of Technology
+#
+#  This program is free software you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation either version 2, or (at your option)
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program if not, write to the Free Software Foundation,
+#  Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+import os
+import sys
+import unittest
+
+mod_dir = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(mod_dir, '..'))
+import meep as mp
+
+
+def one(vec):
+    return 1.0
+
+
+class TestPhysical(unittest.TestCase):
+
+    a = 10.0
+    ymax = 3.0
+    dx = 2.0
+
+    def radiating_base(self, sq_ratio, solve_cw=True):
+
+        w = 0.30
+
+        s = mp.structure(self.gv, one, mp.pml(self.ymax / 3.0))
+
+        f = mp.fields(s)
+
+        src = mp.continuous_src_time(w)
+        f.add_point_source(mp.Ez, src, self.pnt_src_vec)
+
+        # let the source reach steady state
+        if solve_cw:
+            f.solve_cw(1e-6)
+        else:
+            while f.time() < 400:
+                f.step()
+
+        # amp1 and amp2 are of type complex
+        amp1 = f.get_field(mp.Ez, self.p1)
+        amp2 = f.get_field(mp.Ez, self.p2)
+
+        ratio = abs(amp1) / abs(amp2)
+        if self.gv.dim == mp.D2:
+            ratio = ratio ** 2  # in 2d, decay is ~1/sqrt(r), so square to get 1/r
+
+        print("Ratio is {} from ({} {}) and ({} {})".format(
+            ratio, amp1.real, amp1, amp2.real, amp2
+        ))
+
+        fail_fmt = "Failed: amp1 = ({}, {}), amp2 = ({}, {})\nabs(amp1/amp2){} = {}, too far from 2.0"
+        fail_msg = fail_fmt.format(amp1.real, amp1, amp2.real, amp2, "^2" if sq_ratio else "", ratio)
+
+        self.assertTrue(ratio <= 2.12 and ratio >= 1.88, fail_msg)
+
+    def test_radiating_2d(self):
+
+        xmax = 8.0
+
+        # grid_volume
+        self.gv = mp.voltwo(xmax, self.ymax, self.a)
+
+        self.pnt_src_vec = mp.vec(xmax / 2 - self.dx, self.ymax / 2)
+        self.p1 = mp.vec(xmax / 2 + 0 * self.dx, self.ymax / 2)
+        self.p2 = mp.vec(xmax / 2 + 1 * self.dx, self.ymax / 2)
+
+        self.radiating_base(True)
+
+    def test_radiating_3d(self):
+
+        xmax = 7.0
+
+        # grid_volume
+        self.gv = mp.vol3d(xmax, self.ymax, self.ymax, self.a)
+
+        self.pnt_src_vec = mp.vec(xmax / 2.0 - self.dx, self.ymax / 2.0, self.ymax / 2.0)
+        self.p1 = mp.vec(xmax / 2.0 + 0 * self.dx, self.ymax / 2.0, self.ymax / 2.0)
+        self.p2 = mp.vec(xmax / 2.0 + 1 * self.dx, self.ymax / 2.0, self.ymax / 2.0)
+
+        self.radiating_base(False)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/vec.i
+++ b/python/vec.i
@@ -18,7 +18,8 @@
 
 // 322:  Redundant declarations are ok. The wrappers are created correctly.
 // 503:  We don't need to create class-specific wrappers for friend functions
-// TODO: Check all 509's individually
+// TODO: Check all 509's individually.
+// TODO: Move warnfilters to separate 'warnings.i' file.
 %warnfilter(509);
 %warnfilter(322,509) meep::component_direction;
 %warnfilter(322,509) meep::direction_component;
@@ -47,7 +48,7 @@
 
 
 // Renaming python builtins
-%rename(ftype) meep::type;
+%rename(meep_type) meep::type;
 %rename(vec_abs) meep::abs;
 %rename(vec_max) meep::max;
 %rename(vec_min) meep::min;
@@ -55,9 +56,9 @@
 %rename(symmetry_reduce) meep::symmetry::reduce;
 
 // Operator renaming
+// TODO: Test these
 %rename(volume_and) meep::volume::operator&&;
 %rename(grid_volume_getitem) meep::grid_volume::operator[];
 %rename(symmetry_assign) meep::symmetry::operator=;
-
 
 %include "meep/vec.hpp"


### PR DESCRIPTION
* Updates for python user callbacks
* Split vec.i to separate file
* Run python tests from python directory with 'make check'
* Add test_physical.py unit test
* Ignore some python specific files

I've verified that the tests in `test_physical.py` pass, but Travis never gets to run `make check` in the python directory because `near2far` fails.  I noticed the following line in the configure output on Travis:
```
checking for gsl_sf_bessel_Jn in -lgsl... no
configure: WARNING: Missing GNU GSL library...Bessel-function field initialization will not be supported.
```
and `near2far` fails with a message about not being able to find a GSL function.  I was able to fix this on my system (Ubuntu 16.04) by installing `libgsl-dev` (as opposed to `libgsl0-dev`), but Travis uses Ubuntu 12.04, and only `libgsl0-dev` is available. 

@stevengj @oskooi @HomerReid 