### PR TITLE
Fix incorrect exit status of autogen.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,3 @@ script:
   - (cd harminv && git checkout c221b2bcbaaa761f683aa5e2c6fa7efbbecdca1f && sh autogen.sh --prefix=$HOME/local --enable-shared && make && make install)
   - (CPPFLAGS=-I${HOME}/local/include LDFLAGS=-L${HOME}/local/lib GEN_CTL_IO=${HOME}/local/bin/gen-ctl-io sh autogen.sh --verbose --enable-maintainer-mode --prefix=$HOME/local --with-libctl=$HOME/local/share/libctl)
   - make && make check && make install
-  - exit 0

--- a/autogen.sh
+++ b/autogen.sh
@@ -28,4 +28,4 @@ if test x$verbose = xyes; then
     cat config.log
 fi
 
-test $config = bad && exit 1
+test $config = good || exit 1


### PR DESCRIPTION
## The Problem

`autogen.sh` always exits with 1, even when configure exits with 0.  To work around this, we included `exit 0` at the end of the travis build script, but this renders our CI useless, essentially making every build green. You can see this behavior in the log of any build:
```
configure: exit 0

The command "(CPPFLAGS=-I${HOME}/local/include LDFLAGS=-L${HOME}/local/lib GEN_CTL_IO=${HOME}/local/bin/gen-ctl-io sh autogen.sh --verbose --enable-maintainer-mode --prefix=$HOME/local --with-libctl=$HOME/local/share/libctl)" exited with 1
```

## The Cause

A bash script exits with the exit code of the last command run, in our case, `test $config = bad && exit 1`.  If `config = good`, the test fails, meaning it exits with 1 (even though it doesn't run `&& exit 1`), and since that is the last command run, the shell implicitly exits with 1.  You can reproduce this on the command line by running:
```bash
test good = bad && exit 1
echo $?
>>> 1
```

## The Solution

Reverse the logic so that the last command exits with 0 when configure succeeds: `test $config = good || exit 1`.  `test $config = good`, and hence, the script itself, will exit with 0 when configure succeeds, and will exit 1 when config = bad. 
```bash
test good = good || exit 1
echo $?
>>> 0
```
@stevengj @HomerReid @oskooi 