### PR TITLE
point_in_objectp working

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
     - swig
 script:
   - git clone https://github.com/stevengj/libctl libctl-src
-  - (cd libctl-src && git checkout 7d51710e63952d343ce8f241cf92b5cbfd5f1ada && sh autogen.sh --prefix=$HOME/local --enable-shared && make && make install)
+  - (cd libctl-src && git checkout 2c36ab9e3f382b9d06ddfc32921d24279c79b095 && sh autogen.sh --prefix=$HOME/local --enable-shared && make && make install)
   - git clone https://github.com/stevengj/harminv
   - (cd harminv && git checkout c221b2bcbaaa761f683aa5e2c6fa7efbbecdca1f && sh autogen.sh --prefix=$HOME/local --enable-shared && make && make install)
   - (CPPFLAGS=-I${HOME}/local/include LDFLAGS=-L${HOME}/local/lib GEN_CTL_IO=${HOME}/local/bin/gen-ctl-io sh autogen.sh --verbose --enable-maintainer-mode --prefix=$HOME/local --with-libctl=$HOME/local/share/libctl)

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -21,8 +21,8 @@ _meep_la_CPPFLAGS = $(PYTHON_INCLUDES) $(AM_CPPFLAGS)
 
 TEST_DIR = tests
 TESTS =                           \
-	$(TEST_DIR)/test_geom.py      \
-	$(TEST_DIR)/test_physical.py
+    $(TEST_DIR)/test_geom.py      \
+    $(TEST_DIR)/test_physical.py
 TEST_EXTENSIONS = .py
 PY_LOG_COMPILER = $(PYTHON)
 AM_TESTS_ENVIRONMENT = PYTHONPATH='$(top_srcdir)/python/.libs'; export PYTHONPATH;

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -15,7 +15,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/src                   \
               -I$(top_builddir) # for config.h
 
 _meep_la_SOURCES = meep-python.cpp
-_meep_la_LIBADD = $(top_builddir)/src/libmeep.la $(PYTHON_LIBS)
+_meep_la_LIBADD = $(top_builddir)/src/libmeep.la $(PYTHON_LIBS) -lctlgeom
 _meep_la_LDFLAGS = -module -version-info @SHARED_VERSION_INFO@
 _meep_la_CPPFLAGS = $(PYTHON_INCLUDES) $(AM_CPPFLAGS)
 

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -20,7 +20,9 @@ _meep_la_LDFLAGS = -module -version-info @SHARED_VERSION_INFO@
 _meep_la_CPPFLAGS = $(PYTHON_INCLUDES) $(AM_CPPFLAGS)
 
 TEST_DIR = tests
-TESTS = $(TEST_DIR)/test_physical.py
+TESTS =                           \
+	$(TEST_DIR)/test_geom.py      \
+	$(TEST_DIR)/test_physical.py
 TEST_EXTENSIONS = .py
 PY_LOG_COMPILER = $(PYTHON)
 AM_TESTS_ENVIRONMENT = PYTHONPATH='$(top_srcdir)/python/.libs'; export PYTHONPATH;
@@ -33,7 +35,7 @@ endif
 if MAINTAINER_MODE
 
 meep-python.cpp:	$(SWIG_SRC) $(HPPFILES)
-	swig -Wall $(AM_CPPFLAGS) -outdir $(builddir) -c++ -python -o $@ $(srcdir)/meep.i
+	swig -Wextra $(AM_CPPFLAGS) -outdir $(builddir) -c++ -python -o $@ $(srcdir)/meep.i
 
 meep.py:       		meep-python.cpp
 

--- a/python/geom.py
+++ b/python/geom.py
@@ -1,0 +1,47 @@
+import meep as mp
+
+
+def non_negative(x):
+    return x >= 0
+
+
+class Vector3(object):
+
+    def __init__(self, x=0.0, y=0.0, z=0.0):
+        self.x = float(x)
+        self.y = float(y)
+        self.z = float(z)
+
+
+class MaterialType(object):
+
+    def __init__(self, data=None):
+        self.data = data
+
+
+class GeometricObject(object):
+
+    def __init__(self, material=MaterialType(), center=None):
+        self.material = material
+        self.center = center
+
+    def __contains__(self, point):
+        return mp.point_in_objectp(point, self)
+
+
+class Sphere(GeometricObject):
+
+    def __init__(self, radius=None, **kwargs):
+        self.radius = radius
+        super(Sphere, self).__init__(**kwargs)
+
+    @property
+    def radius(self):
+        return self._radius
+
+    @radius.setter
+    def radius(self, val):
+        if not val or non_negative(val):
+            self._radius = val
+        else:
+            raise ValueError("Radius cannot be negative. Got {}".format(val))

--- a/python/tests/test_geom.py
+++ b/python/tests/test_geom.py
@@ -1,0 +1,58 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import geom as gm
+
+
+class TestSphere(unittest.TestCase):
+
+    def test_kwargs_passed_to_parent(self):
+        s = gm.Sphere()
+        self.assertEqual(s.material.data, None)
+        self.assertEqual(s.center, None)
+        self.assertEqual(s.radius, None)
+
+        s = gm.Sphere(radius=1.0)
+        self.assertEqual(s.material.data, None)
+        self.assertEqual(s.center, None)
+        self.assertEqual(s.radius, 1.0)
+
+        s = gm.Sphere(center=(1, 1, 1))
+        self.assertEqual(s.material.data, None)
+        self.assertEqual(s.center, (1, 1, 1))
+        self.assertEqual(s.radius, None)
+
+    def test_invalid_kwarg_raises_exception(self):
+        with self.assertRaises(TypeError):
+            gm.Sphere(invalid='This is not allowed')
+        with self.assertRaises(TypeError):
+            gm.Sphere(radius=1.0, oops='Nope')
+
+    def test_non_neg_radius_constructor(self):
+        gm.Sphere(radius=0.0)
+        gm.Sphere(radius=1.0)
+
+        with self.assertRaises(ValueError) as ctx:
+            gm.Sphere(radius=-1)
+            self.assertIn("Got -1", ctx.exception)
+
+    def test_non_neg_radius_setter(self):
+        s = gm.Sphere(radius=0.0)
+        s.radius = 1.0
+
+        with self.assertRaises(ValueError) as ctx:
+            s.radius = -1.0
+            self.assertIn("Got -1.0", ctx.exception)
+
+    def test_contains_point(self):
+        s = gm.Sphere(center=gm.Vector3(0, 0, 0), radius=2.0)
+        point = gm.Vector3(1, 1, 1)
+        self.assertTrue(point in s)
+        self.assertIn(point, s)
+        self.assertFalse(gm.Vector3(10, 10, 10) in s)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/tests/test_typemaps.py
+++ b/python/tests/test_typemaps.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import unittest
+
+# import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import meep as mp
+import geom as gm
+
+
+class TestTypemaps(unittest.TestCase):
+
+    def test_point_in_objectp(self):
+        s = gm.Sphere(center=gm.Vector3(0, 0, 0), radius=2.0)
+
+        # Accepts Vector3
+        self.assertTrue(mp.point_in_objectp(gm.Vector3(0, 0, 0), s))
+        self.assertFalse(mp.point_in_objectp(gm.Vector3(10, 10, 10), s))
+
+        # # Accepts tuple
+        # self.assertTrue(mp.point_in_objectp((0, 0, 0), s))
+        # self.assertFalse(mp.point_in_objectp((10, 10, 10), s))
+
+        # # Accepts list
+        # self.assertTrue(mp.point_in_objectp([0, 0, 0], s))
+        # self.assertFalse(mp.point_in_objectp([10, 10, 10], s))
+
+        # # Accepts numpy array
+        # self.assertTrue(mp.point_in_objectp(np.array([0, 0, 0]), s))
+        # self.assertFalse(mp.point_in_objectp(np.array([10, 10, 10]), s))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR isn't to merge, but to request feedback for the path I'm taking. I can successfully write
```python
some_point in some_sphere
```
in python and it will call `point_in_objectp(some_point, some_object)`, returning the correct result, but something seems off about this approach.  Does it make sense to build up a pure python `Sphere` just to tear it apart in the typemap?  It seems like we should just wrap `ctlgeom-types.h` and then do something like
```
point_in_objectp(meep.vector3(0, 0, 0), meep.sphere(center=meep.vector3(0, 0, 0), radius=2))
```
Then we wouldn't even need a typemap because the python objects would be SWIG proxy objects with types that correspond to the C types.  I think I'm still unclear on exactly which header files we want to create python wrappers for.

@stevengj @HomerReid @oskooi 