### PR TITLE
Build and test python 3.6 in Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,16 @@ tests/two_dimensional
 tests/*.trs
 tests/*.log
 tests/latest_output
+
+# libmeepgeom tests
+libmeepgeom/bend-flux-ll
+libmeepgeom/pw-source-ll
+libmeepgeom/ring-ll
+libmeepgeom/*.log
+libmeepgeom/*.trs
+libmeepgeom/*.h5
+
+# python tests
 python/tests/*.log
 python/tests/*.trs
 python/*.log

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.lo
 *.a
 *.la
+*.so
 *.dylib
 *.dSYM
 *.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,6 @@ script:
   - (CPPFLAGS=-I${HOME}/local/include LDFLAGS=-L${HOME}/local/lib GEN_CTL_IO=${HOME}/local/bin/gen-ctl-io sh autogen.sh --verbose --enable-maintainer-mode --prefix=$HOME/local --with-libctl=$HOME/local/share/libctl)
   - make && make check && make install
   # Build and test pymeep with python 3.6
-  - (CPPFLAGS=-I${HOME}/local/include LDFLAGS=-L${HOME}/local/lib GEN_CTL_IO=${HOME}/local/bin/gen-ctl-io PYTHON=${HOME}/miniconda3/bin sh autogen.sh --verbose --enable-maintainer-mode --prefix=$HOME/local --with-libctl=$HOME/local/share/libctl)
+  - (CPPFLAGS=-I${HOME}/local/include LDFLAGS=-L${HOME}/local/lib GEN_CTL_IO=${HOME}/local/bin/gen-ctl-io PYTHON=${HOME}/miniconda3/bin/python sh autogen.sh --verbose --enable-maintainer-mode --prefix=$HOME/local --with-libctl=$HOME/local/share/libctl)
   - conda install -y numpy
   - cd python && make clean && make && make check && make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ addons:
     - liblapack-dev
     - python-numpy
     - swig
+before_script:
+  - wget https://repo.continuum.io/miniconda/Miniconda3-4.3.14-Linux-x86_64.sh
+  - bash Miniconda3-4.3.14-Linux-x86_64.sh -b -p $HOME/miniconda3
 script:
   - git clone https://github.com/stevengj/libctl libctl-src
   - (cd libctl-src && git checkout master && sh autogen.sh --prefix=$HOME/local --enable-shared && make && make install)
@@ -17,3 +20,8 @@ script:
   - (cd harminv && git checkout c221b2bcbaaa761f683aa5e2c6fa7efbbecdca1f && sh autogen.sh --prefix=$HOME/local --enable-shared && make && make install)
   - (CPPFLAGS=-I${HOME}/local/include LDFLAGS=-L${HOME}/local/lib GEN_CTL_IO=${HOME}/local/bin/gen-ctl-io sh autogen.sh --verbose --enable-maintainer-mode --prefix=$HOME/local --with-libctl=$HOME/local/share/libctl)
   - make && make check && make install
+  # Run tests with python 3
+  - cd python
+  - export PATH=${HOME}/miniconda3/bin:${PATH}
+  - conda install -y numpy
+  - make check

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ addons:
 before_script:
   - wget https://repo.continuum.io/miniconda/Miniconda3-4.3.14-Linux-x86_64.sh
   - bash Miniconda3-4.3.14-Linux-x86_64.sh -b -p ${HOME}/miniconda3
+  - ${HOME}/miniconda3/bin/conda install -y numpy
 script:
   - git clone https://github.com/stevengj/libctl libctl-src
   - (cd libctl-src && git checkout master && sh autogen.sh --prefix=$HOME/local --enable-shared && make && make install)
@@ -22,5 +23,4 @@ script:
   - make && make check && make install
   # Build and test pymeep with python 3.6
   - (CPPFLAGS=-I${HOME}/local/include LDFLAGS=-L${HOME}/local/lib GEN_CTL_IO=${HOME}/local/bin/gen-ctl-io PYTHON=${HOME}/miniconda3/bin/python sh autogen.sh --verbose --enable-maintainer-mode --prefix=$HOME/local --with-libctl=$HOME/local/share/libctl)
-  - conda install -y numpy
   - cd python && make clean && make && make check && make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
     - swig
 before_script:
   - wget https://repo.continuum.io/miniconda/Miniconda3-4.3.14-Linux-x86_64.sh
-  - bash Miniconda3-4.3.14-Linux-x86_64.sh -b -p $HOME/miniconda3
+  - bash Miniconda3-4.3.14-Linux-x86_64.sh -b -p ${HOME}/miniconda3
 script:
   - git clone https://github.com/stevengj/libctl libctl-src
   - (cd libctl-src && git checkout master && sh autogen.sh --prefix=$HOME/local --enable-shared && make && make install)
@@ -20,8 +20,7 @@ script:
   - (cd harminv && git checkout c221b2bcbaaa761f683aa5e2c6fa7efbbecdca1f && sh autogen.sh --prefix=$HOME/local --enable-shared && make && make install)
   - (CPPFLAGS=-I${HOME}/local/include LDFLAGS=-L${HOME}/local/lib GEN_CTL_IO=${HOME}/local/bin/gen-ctl-io sh autogen.sh --verbose --enable-maintainer-mode --prefix=$HOME/local --with-libctl=$HOME/local/share/libctl)
   - make && make check && make install
-  # Run tests with python 3
-  - cd python
-  - export PATH=${HOME}/miniconda3/bin:${PATH}
+  # Build and test pymeep with python 3.6
+  - (CPPFLAGS=-I${HOME}/local/include LDFLAGS=-L${HOME}/local/lib GEN_CTL_IO=${HOME}/local/bin/gen-ctl-io PYTHON=${HOME}/miniconda3/bin sh autogen.sh --verbose --enable-maintainer-mode --prefix=$HOME/local --with-libctl=$HOME/local/share/libctl)
   - conda install -y numpy
-  - make check
+  - cd python && make clean && make && make check && make install


### PR DESCRIPTION
When building locally, autotools will use whichever python it finds first on your PATH.  Also, you can force it to use a python of your choice by adding `PYTHON=/path/to/bin/python` to the environment before running `autogen.sh`.
 
I also added libmeepgeom files that we don't need in source control to `.gitignore`.
@stevengj @oskooi @HomerReid