### PR TITLE
Improve python package structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ libctl/meep_wrap.cxx
 libctl/meep_wrap.cxx.orig
 meep-pkgconfig
 meep.pc
+build/
 src/sphere-quad.h
 src/sphere_quad
 src/step_generic_stride1.cpp

--- a/.gitignore
+++ b/.gitignore
@@ -60,8 +60,10 @@ meep.pc
 src/sphere-quad.h
 src/sphere_quad
 src/step_generic_stride1.cpp
+python/meep/
 python/meep-python.cpp
 python/meep.py
+python/__init__.py
 
 # test programs
 tests/2D_convergence

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,7 @@ script:
   - (CPPFLAGS=-I${HOME}/local/include LDFLAGS=-L${HOME}/local/lib GEN_CTL_IO=${HOME}/local/bin/gen-ctl-io ../configure --enable-maintainer-mode --prefix=$HOME/local --with-libctl=$HOME/local/share/libctl)
   - make && make install
   # - make && make check && make install
-  - echo "CWD" `pwd`
-  - make check
-  - cat tests/test_geom.log
+  - cd python && make check
   # Build and test pymeep with python 3.6
   - (CPPFLAGS=-I${HOME}/local/include LDFLAGS=-L${HOME}/local/lib GEN_CTL_IO=${HOME}/local/bin/gen-ctl-io PYTHON=${HOME}/miniconda3/bin/python sh autogen.sh --verbose --enable-maintainer-mode --prefix=$HOME/local --with-libctl=$HOME/local/share/libctl)
   - pushd python && make clean && make && make check && make install && popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,11 @@ script:
   - (CPPFLAGS=-I${HOME}/local/include LDFLAGS=-L${HOME}/local/lib GEN_CTL_IO=${HOME}/local/bin/gen-ctl-io sh autogen.sh --verbose --enable-maintainer-mode --prefix=$HOME/local --with-libctl=$HOME/local/share/libctl)
   - mkdir build && pushd build
   - (CPPFLAGS=-I${HOME}/local/include LDFLAGS=-L${HOME}/local/lib GEN_CTL_IO=${HOME}/local/bin/gen-ctl-io ../configure --enable-maintainer-mode --prefix=$HOME/local --with-libctl=$HOME/local/share/libctl)
-  - make && make check && make install
+  - make && make install
+  # - make && make check && make install
+  - echo "CWD" `pwd`
+  - make check
+  - cat tests/test_geom.log
   # Build and test pymeep with python 3.6
   - (CPPFLAGS=-I${HOME}/local/include LDFLAGS=-L${HOME}/local/lib GEN_CTL_IO=${HOME}/local/bin/gen-ctl-io PYTHON=${HOME}/miniconda3/bin/python sh autogen.sh --verbose --enable-maintainer-mode --prefix=$HOME/local --with-libctl=$HOME/local/share/libctl)
   - pushd python && make clean && make && make check && make install && popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ script:
   - mkdir build && pushd build
   - (CPPFLAGS=-I${HOME}/local/include LDFLAGS=-L${HOME}/local/lib GEN_CTL_IO=${HOME}/local/bin/gen-ctl-io ../configure --enable-maintainer-mode --prefix=$HOME/local --with-libctl=$HOME/local/share/libctl && make && make check && make install)
   # Build and test pymeep with python 3.6
-  - (CPPFLAGS=-I${HOME}/local/include LDFLAGS=-L${HOME}/local/lib GEN_CTL_IO=${HOME}/local/bin/gen-ctl-io PYTHON=${HOME}/miniconda3/bin/python sh autogen.sh --verbose --enable-maintainer-mode --prefix=$HOME/local --with-libctl=$HOME/local/share/libctl)
+  - (CPPFLAGS=-I${HOME}/local/include LDFLAGS=-L${HOME}/local/lib GEN_CTL_IO=${HOME}/local/bin/gen-ctl-io PYTHON=${HOME}/miniconda3/bin/python ../configure --enable-maintainer-mode --prefix=$HOME/local --with-libctl=$HOME/local/share/libctl)
   - pushd python && make clean && make && make check && make install && popd
 
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ script:
   - git clone https://github.com/stevengj/harminv
   - (cd harminv && git checkout c221b2bcbaaa761f683aa5e2c6fa7efbbecdca1f && sh autogen.sh --prefix=$HOME/local --enable-shared && make && make install)
   - (CPPFLAGS=-I${HOME}/local/include LDFLAGS=-L${HOME}/local/lib GEN_CTL_IO=${HOME}/local/bin/gen-ctl-io sh autogen.sh --verbose --enable-maintainer-mode --prefix=$HOME/local --with-libctl=$HOME/local/share/libctl)
+  - mkdir build && pushd build
+  - (CPPFLAGS=-I${HOME}/local/include LDFLAGS=-L${HOME}/local/lib GEN_CTL_IO=${HOME}/local/bin/gen-ctl-io ../configure --enable-maintainer-mode --prefix=$HOME/local --with-libctl=$HOME/local/share/libctl)
   - make && make check && make install
   # Build and test pymeep with python 3.6
   - (CPPFLAGS=-I${HOME}/local/include LDFLAGS=-L${HOME}/local/lib GEN_CTL_IO=${HOME}/local/bin/gen-ctl-io PYTHON=${HOME}/miniconda3/bin/python sh autogen.sh --verbose --enable-maintainer-mode --prefix=$HOME/local --with-libctl=$HOME/local/share/libctl)

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,9 @@ script:
   - git clone https://github.com/stevengj/harminv
   - (cd harminv && git checkout c221b2bcbaaa761f683aa5e2c6fa7efbbecdca1f && sh autogen.sh --prefix=$HOME/local --enable-shared && make && make install)
   - (CPPFLAGS=-I${HOME}/local/include LDFLAGS=-L${HOME}/local/lib GEN_CTL_IO=${HOME}/local/bin/gen-ctl-io sh autogen.sh --verbose --enable-maintainer-mode --prefix=$HOME/local --with-libctl=$HOME/local/share/libctl)
+  - make distclean
   - mkdir build && pushd build
-  - (CPPFLAGS=-I${HOME}/local/include LDFLAGS=-L${HOME}/local/lib GEN_CTL_IO=${HOME}/local/bin/gen-ctl-io ../configure --enable-maintainer-mode --prefix=$HOME/local --with-libctl=$HOME/local/share/libctl)
-  - make && make install
-  # - make && make check && make install
-  - cd python && make check
+  - (CPPFLAGS=-I${HOME}/local/include LDFLAGS=-L${HOME}/local/lib GEN_CTL_IO=${HOME}/local/bin/gen-ctl-io ../configure --enable-maintainer-mode --prefix=$HOME/local --with-libctl=$HOME/local/share/libctl && make && make check && make install)
   # Build and test pymeep with python 3.6
   - (CPPFLAGS=-I${HOME}/local/include LDFLAGS=-L${HOME}/local/lib GEN_CTL_IO=${HOME}/local/bin/gen-ctl-io PYTHON=${HOME}/miniconda3/bin/python sh autogen.sh --verbose --enable-maintainer-mode --prefix=$HOME/local --with-libctl=$HOME/local/share/libctl)
   - pushd python && make clean && make && make check && make install && popd

--- a/libctl/Makefile.am
+++ b/libctl/Makefile.am
@@ -23,7 +23,7 @@ meep_wrap.o: meep_wrap.cxx $(srcdir)/meep-ctl-swig.hpp $(CTLHDRS)
 if WITH_LIBCTL
 if MAINTAINER_MODE
 meep_wrap.cxx: meep.i meep_op_renames.i meep_enum_renames.i meep_renames.i ctl-io.i meep-ctl-swig.hpp meep_swig_bug_workaround.i $(LIBHDRS)
-	swig -I$(top_srcdir)/src -c++ -guile -o $@ meep.i
+	swig -I$(top_srcdir)/src -c++ -guile -o $@ $(srcdir)/meep.i
 	patch -p0 $@ < $(srcdir)/meep_wrap.patch
 else
 meep_wrap.cxx:

--- a/libmeepgeom/Makefile.am
+++ b/libmeepgeom/Makefile.am
@@ -6,7 +6,7 @@ lib_LTLIBRARIES = libmeepgeom.la
 pkginclude_HEADERS = meepgeom.hpp material_data.hpp
 
 #AM_CPPFLAGS = -I$(top_srcdir)/src -std=c++11
-AM_CPPFLAGS = -I$(top_srcdir)/src 
+AM_CPPFLAGS = -I$(top_srcdir)/src -DDATADIR=\"$(srcdir)/\"
 
 libmeepgeom_la_SOURCES = \
  meepgeom.cpp meepgeom.hpp material_data.hpp

--- a/libmeepgeom/cyl-ellipsoid-ll.cpp
+++ b/libmeepgeom/cyl-ellipsoid-ll.cpp
@@ -3,6 +3,7 @@
 /***************************************************************/
 #include <stdio.h>
 #include <stdlib.h>
+#include <string>
 #include <complex>
 
 #include "meep.hpp"
@@ -11,6 +12,10 @@
 #include "ctlgeom.h"
 
 #include "meepgeom.hpp"
+
+#ifndef DATADIR
+  #define DATADIR "./"
+#endif
 
 using namespace meep;
 
@@ -72,7 +77,7 @@ int main(int argc, char *argv[])
 
   // simple argument parsing 
   meep::component src_cmpt=Ez;
-  char *eps_ref_file=const_cast<char *>("cyl-ellipsoid-eps-ref.h5");
+  std::string eps_ref_file = "cyl-ellipsoid-eps-ref.h5";
   for(int narg=1; narg<argc; narg++)
    { 
      if ( argv[narg] && !strcmp(argv[narg],"--polarization") )
@@ -95,6 +100,9 @@ int main(int argc, char *argv[])
      else
       meep::abort("unrecognized command-line option %s",argv[narg]);
    };
+
+   std::string eps_ref_path = DATADIR + eps_ref_file;
+
 
   //(set-param! resolution 100)
   double resolution = 100.0; 
@@ -152,7 +160,7 @@ int main(int argc, char *argv[])
    { 
      f.output_hdf5(Dielectric, f.total_volume());
      bool status=compare_hdf5_datasets("eps-000000000.h5", "eps",
-                                        eps_ref_file,      "eps");
+                                        eps_ref_path.c_str(), "eps");
      if (status)
       master_printf("Dielectric output test successful.\n");
      else

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -49,7 +49,7 @@ __init__.py: meep.py
 
 pymeep: .libs/_meep.so __init__.py
 	test -d meep || mkdir meep
-	cp __init__.py geom.py .libs/_meep.so meep
+	cp __init__.py $(srcdir)/geom.py .libs/_meep.so meep
 
 all-local: pymeep
 

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -30,7 +30,9 @@ TESTS =                               \
 
 TEST_EXTENSIONS = .py
 PY_LOG_COMPILER = $(PYTHON)
-AM_TESTS_ENVIRONMENT = PYTHONPATH=$(abs_top_builddir)/python:$PYTHONPATH; export PYTHONPATH;
+AM_TESTS_ENVIRONMENT =
+    PYTHONPATH=$(abs_top_builddir)/python:$$PYTHONPATH \
+    export PYTHONPATH;
 
 if WITH_PYTHON
   pkgpython_PYTHON = geom.py __init__.py

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -30,7 +30,7 @@ TESTS =                               \
 
 TEST_EXTENSIONS = .py
 PY_LOG_COMPILER = $(PYTHON)
-AM_TESTS_ENVIRONMENT = PYTHONPATH="$(abs_builddir)"; export PYTHONPATH;
+AM_TESTS_ENVIRONMENT = PYTHONPATH=$(abs_top_builddir)/python:$PYTHONPATH; export PYTHONPATH;
 
 if WITH_PYTHON
   pkgpython_PYTHON = geom.py __init__.py

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -30,7 +30,7 @@ TESTS =                               \
 
 TEST_EXTENSIONS = .py
 PY_LOG_COMPILER = $(PYTHON)
-AM_TESTS_ENVIRONMENT = PYTHONPATH='$(top_srcdir)/python/.libs'; export PYTHONPATH;
+AM_TESTS_ENVIRONMENT = PYTHONPATH="$(abs_builddir)"; export PYTHONPATH;
 
 if WITH_PYTHON
   pkgpython_PYTHON = geom.py __init__.py

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -8,7 +8,7 @@ HPPFILES=                                    \
  $(top_srcdir)/libmeepgeom/meepgeom.hpp      \
  $(top_srcdir)/libmeepgeom/material_data.hpp 
 
-BUILT_SOURCES = meep-python.cpp meep.py
+BUILT_SOURCES = meep-python.cpp meep.py __init__.py
 
 CLEANFILES = $(BUILT_SOURCES) meep-python.h
 
@@ -33,16 +33,28 @@ PY_LOG_COMPILER = $(PYTHON)
 AM_TESTS_ENVIRONMENT = PYTHONPATH='$(top_srcdir)/python/.libs'; export PYTHONPATH;
 
 if WITH_PYTHON
-  python_PYTHON = meep.py
-  pyexec_LTLIBRARIES = _meep.la
+  pkgpython_PYTHON = geom.py __init__.py
+  pkgpyexec_LTLIBRARIES = _meep.la
 endif
 
 if MAINTAINER_MODE
 
-meep-python.cpp:	$(SWIG_SRC) $(HPPFILES)
+meep-python.cpp: $(SWIG_SRC) $(HPPFILES)
 	swig -Wextra $(AM_CPPFLAGS) -outdir $(builddir) -c++ -python -o $@ $(srcdir)/meep.i
 
-meep.py:       		meep-python.cpp
+meep.py: meep-python.cpp
+
+__init__.py: meep.py
+	cp $< $@
+
+pymeep: .libs/_meep.so __init__.py
+	test -d meep || mkdir meep
+	cp __init__.py geom.py .libs/_meep.so meep
+
+all-local: pymeep
+
+clean-local:
+	rm -rf meep
 
 endif # MAINTAINER_MODE
 

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -30,9 +30,7 @@ TESTS =                               \
 
 TEST_EXTENSIONS = .py
 PY_LOG_COMPILER = $(PYTHON)
-AM_TESTS_ENVIRONMENT =
-    PYTHONPATH=$(abs_top_builddir)/python:$$PYTHONPATH \
-    export PYTHONPATH;
+TESTS_ENVIRONMENT = export PYTHONPATH=$(abs_top_builddir)/python:$$PYTHONPATH;
 
 if WITH_PYTHON
   pkgpython_PYTHON = geom.py __init__.py


### PR DESCRIPTION
Currently all the python files get installed into `site-packages`, but they should be contained in their own `meep` package.  The structure should be
```
site-packages/
    meep/
        __init__.py
        geom.py
        _meep.so
```
This way, any `meep` class can be accessed like
```python
from meep import vec as vec
from meep.geom import Sphere as Sphere
```
or
```python
import meep as mp
import meep.geom as gm
mp.vec()
gm.Sphere()
```
The extra targets in `Makefile.am` are so local builds have the same directory structure as the installed library.  There's probably a better "automake" way of doing this that I'm unaware of.

@stevengj @HomerReid @oskooi 