### PR TITLE
Add python source classes

### DIFF
--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -26,18 +26,25 @@ TESTS =                               \
     $(TEST_DIR)/test_cyl_ellipsoid.py \
     $(TEST_DIR)/test_geom.py          \
     $(TEST_DIR)/test_physical.py      \
-    $(TEST_DIR)/test_ring.py
+    $(TEST_DIR)/test_ring.py          \
+    $(TEST_DIR)/test_source.py
 
 TEST_EXTENSIONS = .py
 PY_LOG_COMPILER = $(PYTHON)
 TESTS_ENVIRONMENT = export PYTHONPATH=$(abs_top_builddir)/python:$$PYTHONPATH;
 
 if WITH_PYTHON
-  pkgpython_PYTHON = geom.py __init__.py
+  pkgpython_PYTHON = geom.py __init__.py source.py
   pkgpyexec_LTLIBRARIES = _meep.la
 endif
 
 if MAINTAINER_MODE
+
+PY_PKG_FILES =               \
+    __init__.py              \
+    $(srcdir)/geom.py        \
+    $(srcdir)/source.py      \
+    .libs/_meep.so
 
 meep-python.cpp: $(SWIG_SRC) $(HPPFILES)
 	swig -Wextra $(AM_CPPFLAGS) -outdir $(builddir) -c++ -python -o $@ $(srcdir)/meep.i
@@ -49,7 +56,7 @@ __init__.py: meep.py
 
 pymeep: .libs/_meep.so __init__.py
 	test -d meep || mkdir meep
-	cp __init__.py $(srcdir)/geom.py .libs/_meep.so meep
+	cp $(PY_PKG_FILES) meep
 
 all-local: pymeep
 

--- a/python/source.py
+++ b/python/source.py
@@ -1,0 +1,136 @@
+import meep as mp
+from meep.geom import Vector3, check_nonnegative
+
+
+def check_positive(prop, val):
+    if val > 0:
+        return val
+    else:
+        raise ValueError("{} must be positive. Got {}".format(prop, val))
+
+
+class Source(object):
+
+    def __init__(self, src, component, center, size=Vector3(), amplitude=1.0, amp_func=None):
+        self.src = src
+        self.component = component
+        self.center = center
+        self.size = size
+        self.amplitude = amplitude
+        self.amp_func = amp_func
+
+
+class SourceTime(object):
+
+    def __init__(self, is_integrated=False):
+        self.is_integrated = is_integrated
+
+
+class ContinuousSource(SourceTime):
+
+    def __init__(self, frequency, start_time=0, end_time=float('inf'), width=0, cutoff=3.0):
+        super(ContinuousSource, self).__init__()
+        self.frequency = frequency
+        self.start_time = start_time
+        self.end_time = end_time
+        self.width = width
+        self.cutoff = cutoff
+        self.swigobj = mp.continuous_src_time(frequency, width, start_time, end_time, cutoff)
+        self.swigobj.is_integrated = self.is_integrated
+
+
+class GaussianSource(SourceTime):
+
+    def __init__(self, frequency, width, start_time=0, cutoff=5.0):
+        super(GaussianSource, self).__init__()
+        self.frequency = frequency
+        self.width = width
+        self.start_time = 0
+        self.cutoff = cutoff
+        self.swigobj = mp.gaussian_src_time(frequency, width, start_time, start_time + 2 * width * cutoff)
+        self.swigobj.is_integrated = self.is_integrated
+
+
+class CustomSource(SourceTime):
+
+    def __init__(self, src_func, start_time=float('-inf'), end_time=float('inf')):
+        super(CustomSource, self).__init__()
+        self.src_func = src_func
+        self.start_time = start_time
+        self.end_time = end_time
+        self.swigobj = mp.custom_src_time(src_func, start_time, end_time)
+        self.swigobj.is_integrated = self.is_integrated
+
+
+class EigenModeSource(Source):
+
+    def __init__(self, src, center,
+                 eig_lattice_size=None,
+                 eig_lattice_center=None,
+                 component=mp.Dielectric,
+                 direction=-1,
+                 eig_band=1,
+                 eig_kpoint=Vector3(),
+                 eig_match_freq=True,
+                 eig_parity=0,
+                 eig_resolution=0,
+                 eig_tolerence=1e-7,
+                 **kwargs):
+
+        super(EigenModeSource, self).__init__(src, component, center, **kwargs)
+        self.eig_lattice_size = eig_lattice_size
+        self.eig_lattice_center = eig_lattice_center
+        self.component = component
+        self.direction = direction
+        self.eig_band = eig_band
+        self.eig_kpoint = eig_kpoint
+        self.eig_match_freq = eig_match_freq
+        self.eig_parity = eig_parity
+        self.eig_resolution = eig_resolution
+        self.eig_tolerence = eig_tolerence
+
+    @property
+    def eig_lattice_size(self):
+        return self._eig_lattice_size
+
+    @eig_lattice_size.setter
+    def eig_lattice_size(self, val):
+        if val is None:
+            self._eig_lattice_size = self.size
+        else:
+            self._eig_lattice_size = val
+
+    @property
+    def eig_lattice_center(self):
+        return self._eig_lattice_center
+
+    @eig_lattice_center.setter
+    def eig_lattice_center(self, val):
+        if val is None:
+            self._eig_lattice_center = self.center
+        else:
+            self._eig_lattice_center = val
+
+    @property
+    def eig_band(self):
+        return self._eig_band
+
+    @eig_band.setter
+    def eig_band(self, val):
+        self._eig_band = check_positive('EigenModeSource.eig_band', val)
+
+    @property
+    def eig_resolution(self):
+        return self._eig_resolution
+
+    @eig_resolution.setter
+    def eig_resolution(self, val):
+        self._eig_resolution = check_nonnegative('EigenModeSource.eig_resolution', val)
+
+    @property
+    def eig_tolerence(self):
+        return self._eig_tolerence
+
+    @eig_tolerence.setter
+    def eig_tolerence(self, val):
+        self._eig_tolerence = check_positive('EigenModeSource.eig_tolerence', val)

--- a/python/tests/test_bend_flux.py
+++ b/python/tests/test_bend_flux.py
@@ -2,12 +2,9 @@
 # From the Meep tutorial: transmission around a 90-degree waveguide bend in 2d.
 from __future__ import division
 
-import os
-import sys
-
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import meep as mp
-import geom as gm
+import meep.geom as gm
+from meep.source import GaussianSource
 
 
 # dummy material function needed to pass to structure()
@@ -57,9 +54,9 @@ def bend_flux(no_bend):
 
     fcen = 0.15  # pulse center frequency
     df = 0.1
-    src = mp.gaussian_src_time(fcen, df)
+    src = GaussianSource(fcen, df)
     v = mp.volume(mp.vec(1.0 - 0.5 * sx, wvg_ycen), mp.vec(0.0, w))
-    f.add_volume_source(mp.Ez, src, v)
+    f.add_volume_source(mp.Ez, src.swigobj, v)
 
     f_start = fcen - 0.5 * df
     f_end = fcen + 0.5 * df

--- a/python/tests/test_cyl_ellipsoid.py
+++ b/python/tests/test_cyl_ellipsoid.py
@@ -1,12 +1,11 @@
 from __future__ import division
 
 import argparse
-import os
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import meep as mp
-import geom as gm
+import meep.geom as gm
+from meep.source import GaussianSource
 
 
 # Simple test for libmeepgeom, modeled after meep_test.ctl
@@ -53,10 +52,10 @@ def main(args):
     f = mp.fields(the_structure)
     fcen = 1.0
     df = 0.1
-    src = mp.gaussian_src_time(fcen, df)
+    src = GaussianSource(fcen, df)
     src_point = mp.vec(0.0, 0.0)
     src_size = mp.vec(10.0, 10.0)
-    f.add_volume_source(src_cmpt, src, mp.volume(src_point, src_size))
+    f.add_volume_source(src_cmpt, src.swigobj, mp.volume(src_point, src_size))
 
     f.output_hdf5(mp.Dielectric, f.total_volume())
     stop_time = 23.0

--- a/python/tests/test_geom.py
+++ b/python/tests/test_geom.py
@@ -1,9 +1,6 @@
-import os
-import sys
 import unittest
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-import geom as gm
+import meep.geom as gm
 
 
 def zeros():

--- a/python/tests/test_physical.py
+++ b/python/tests/test_physical.py
@@ -14,13 +14,10 @@
 #  along with this program if not, write to the Free Software Foundation,
 #  Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
-import os
-import sys
 import unittest
 
-mod_dir = os.path.dirname(os.path.abspath(__file__))
-sys.path.insert(0, os.path.join(mod_dir, '..'))
 import meep as mp
+from meep.source import ContinuousSource
 
 
 def one(vec):
@@ -41,8 +38,8 @@ class TestPhysical(unittest.TestCase):
 
         f = mp.fields(s)
 
-        src = mp.continuous_src_time(w)
-        f.add_point_source(mp.Ez, src, self.pnt_src_vec)
+        src = ContinuousSource(w)
+        f.add_point_source(mp.Ez, src.swigobj, self.pnt_src_vec)
 
         # let the source reach steady state
         if solve_cw:

--- a/python/tests/test_ring.py
+++ b/python/tests/test_ring.py
@@ -2,12 +2,11 @@
 # Calculating 2d ring-resonator modes, from the Meep tutorial.
 from __future__ import division
 
-import os
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import meep as mp
-import geom as gm
+import meep.geom as gm
+from meep.source import GaussianSource
 
 
 # dummy material function needed to pass to structure( )
@@ -56,9 +55,9 @@ def main(args):
     # arbitrary direction.  We will only look for TM modes (E out of the plane).
     fcen = 0.15  # pulse center frequency
     df = 0.1
-    src = mp.gaussian_src_time(fcen, df)
+    src = GaussianSource(fcen, df)
     v = mp.volume(mp.vec(r + 0.1, 0.0), mp.vec(0.0, 0.0))
-    f.add_volume_source(mp.Ez, src, v)
+    f.add_volume_source(mp.Ez, src.swigobj, v)
 
     T = 300.0
     stop_time = f.last_source_time() + T

--- a/python/tests/test_source.py
+++ b/python/tests/test_source.py
@@ -1,0 +1,25 @@
+import unittest
+
+from meep.geom import Vector3
+from meep.source import EigenModeSource, ContinuousSource
+
+
+class TestEigenModeSource(unittest.TestCase):
+
+    def test_eig_lattice_defaults(self):
+        src = ContinuousSource(5.0)
+        center = Vector3()
+
+        default_lattice = EigenModeSource(src, center)
+        self.assertEqual(default_lattice.eig_lattice_size, Vector3())
+        self.assertEqual(default_lattice.eig_lattice_center, Vector3())
+
+        elc = Vector3(1, 1, 1)
+        els = Vector3(1, 1, 1)
+        custom_lattice = EigenModeSource(src, center, eig_lattice_center=elc, eig_lattice_size=els)
+        self.assertEqual(custom_lattice.eig_lattice_size, els)
+        self.assertEqual(custom_lattice.eig_lattice_center, elc)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
* Once we have `Simulation.add_source` it will hide `src.swigobj` from the user.
* `check_positive` should be in the same place as `check_nonnegative`, but I'm waiting to see if we have enough utility functions for a `utils.py`.  Depending on the size of the pure python interface, we might want to collapse everything into the `meep` package anyway instead of bothering with `meep.geom`, `meep.source`, etc.
@stevengj @HomerReid @oskooi 