### PR TITLE
Fix syntax error in scheme example

### DIFF
--- a/examples/holey-wvg-cavity.ctl
+++ b/examples/holey-wvg-cavity.ctl
@@ -43,6 +43,7 @@
 
 ; false = transmission spectrum, true = resonant modes:
 (define-param compute-mode? false)
+(define trans '())
 
 (if compute-mode?
     (begin
@@ -70,7 +71,7 @@
 
       (set! symmetries (list (make mirror-sym (direction Y) (phase -1))))
       
-      (define trans ; transmitted flux
+      (set! trans ; transmitted flux
 	(add-flux fcen df nfreq
 		  (make flux-region
 		    (center (- (* 0.5 sx) dpml 0.5) 0) (size 0 (* w 2)))))

--- a/examples/holey-wvg-cavity.ctl
+++ b/examples/holey-wvg-cavity.ctl
@@ -71,18 +71,18 @@
       (set! symmetries (list (make mirror-sym (direction Y) (phase -1))))
       
       (let ((trans ; transmitted flux
-	(add-flux fcen df nfreq
-		  (make flux-region
-		    (center (- (* 0.5 sx) dpml 0.5) 0) (size 0 (* w 2))))))
+	      (add-flux fcen df nfreq
+		        (make flux-region
+		          (center (- (* 0.5 sx) dpml 0.5) 0) (size 0 (* w 2))))))
       
-      (run-sources+ (stop-when-fields-decayed 
-		     50 Ey
-		     (vector3 (- (* 0.5 sx) dpml 0.5) 0)
-		     1e-3)
-		    (at-beginning output-epsilon)
-		    (during-sources
-                     (in-volume (volume (center 0 0) (size sx 0))
-                     (to-appended "hz-slice" (at-every 0.4 output-hfield-z)))))
+          (run-sources+ (stop-when-fields-decayed
+		        50 Ey
+		        (vector3 (- (* 0.5 sx) dpml 0.5) 0)
+		        1e-3)
+		        (at-beginning output-epsilon)
+		        (during-sources
+                        (in-volume (volume (center 0 0) (size sx 0))
+                                   (to-appended "hz-slice" (at-every 0.4 output-hfield-z)))))
       
-      (display-fluxes trans) ; print out the flux spectrum
+          (display-fluxes trans) ; print out the flux spectrum
       )))

--- a/examples/holey-wvg-cavity.ctl
+++ b/examples/holey-wvg-cavity.ctl
@@ -43,7 +43,6 @@
 
 ; false = transmission spectrum, true = resonant modes:
 (define-param compute-mode? false)
-(define trans '())
 
 (if compute-mode?
     (begin
@@ -71,10 +70,10 @@
 
       (set! symmetries (list (make mirror-sym (direction Y) (phase -1))))
       
-      (set! trans ; transmitted flux
+      (let ((trans ; transmitted flux
 	(add-flux fcen df nfreq
 		  (make flux-region
-		    (center (- (* 0.5 sx) dpml 0.5) 0) (size 0 (* w 2)))))
+		    (center (- (* 0.5 sx) dpml 0.5) 0) (size 0 (* w 2))))))
       
       (run-sources+ (stop-when-fields-decayed 
 		     50 Ey
@@ -86,4 +85,4 @@
                      (to-appended "hz-slice" (at-every 0.4 output-hfield-z)))))
       
       (display-fluxes trans) ; print out the flux spectrum
-      ))
+      )))


### PR DESCRIPTION
When I run `examples/holey-wvg-cavity.ctl` I get this error:
```
chris@ubuntu:$ ./meep ../../examples/holey-wvg-cavity.ctl 
ice-9/psyntax.scm:1274:12: In procedure dobody:
ice-9/psyntax.scm:1274:12: Syntax error:
../../examples/holey-wvg-cavity.ctl:73:6: definition in expression context,
where definitions are not, in form (define trans (add-flux fcen df nfreq 
(make flux-region (center (- (* 0.5 sx) dpml 0.5) 0) (size 0 (* w 2)))))
```
This PR fixes that.

Guile version:
```
chris@ubuntu: $ guile -v
guile (GNU Guile) 2.0.11
Packaged by Debian (2.0.11-deb+1-10)
Copyright (C) 2014 Free Software Foundation, Inc.
```
@stevengj @oskooi @HomerReid 