### PR TITLE
Update to Ubuntu 14.04 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: cpp
+dist: trusty
+sudo: false
 addons:
   apt:
     packages:


### PR DESCRIPTION
We're currently running on Ubuntu 12.04 in Travis, which is very outdated.  If this change is seamless, it would be good to update to 14.04.  `sudo: false` means it will run in a docker container instead of a VM, which should make the builds faster.
@stevengj @oskooi @HomerReid 