### PR TITLE
Add holey-wvg-cavity.py example and test

### DIFF
--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -26,6 +26,7 @@ TESTS =                                    \
     $(TEST_DIR)/cyl_ellipsoid.py      \
     $(TEST_DIR)/geom.py               \
     $(TEST_DIR)/holey_wvg_bands.py    \
+    $(TEST_DIR)/holey_wvg_cavity.py   \
     $(TEST_DIR)/physical.py           \
     $(TEST_DIR)/ring.py               \
     $(TEST_DIR)/simulation.py         \

--- a/python/examples/holey-wvg-cavity.py
+++ b/python/examples/holey-wvg-cavity.py
@@ -1,0 +1,95 @@
+# Meep Tutorial: TE transmission and reflection through a cavity
+# formed by a periodic sequence of holes in a dielectric waveguide,
+# with a defect formed by a larger spacing between one pair of holes.
+
+# This structure is based on one analyzed in:
+#    S. Fan, J. N. Winn, A. Devenyi, J. C. Chen, R. D. Meade, and
+#    J. D. Joannopoulos, "Guided and defect modes in periodic dielectric
+#    waveguides," J. Opt. Soc. Am. B, 12 (7), 1267-1272 (1995).
+from __future__ import division
+
+import argparse
+import meep as mp
+
+
+def main(args):
+    # Some parameters to describe the geometry:
+    eps = 13  # dielectric constant of waveguide
+    w = 1.2  # width of waveguide
+    r = 0.36  # radius of holes
+    d = 1.4  # defect spacing (ordinary spacing = 1)
+    N = 3  # number of holes on either side of defect
+
+    # The cell dimensions
+    sy = 6  # size of cell in y direction (perpendicular to wvg.)
+    pad = 2  # padding between last hole and PML edge
+    dpml = 1  # PML thickness
+
+    sx = (2 * (pad + dpml + N)) + d - 1  # size of cell in x direction
+
+    cell = mp.Vector3(sx, sy, 0)
+
+    blk = mp.Block(size=mp.Vector3(1e20, w, 1e20),
+                   material=mp.Medium(epsilon=eps))
+
+    geometry = [blk]
+
+    for i in range(3):
+        geometry.append(mp.Cylinder(r, center=mp.Vector3(d / 2 + i)))
+
+    for i in range(3):
+        geometry.append(mp.Cylinder(r, center=mp.Vector3(d / -2 - i)))
+
+    fcen = 0.25  # pulse center frequency
+    df = 0.2  # pulse width (in frequency)
+
+    nfreq = 500  # number of frequencies at which to compute flux
+
+    sim = mp.Simulation(cell_size=cell,
+                        geometry=geometry,
+                        sources=[],
+                        boundary_layers=[mp.Pml(dpml)],
+                        resolution=20)
+
+    if args.resonant_modes:
+        sim.sources.append(mp.Source(mp.GaussianSource(fcen, fwidth=df), mp.Hz, mp.Vector3()))
+
+        sim.symmetries.append(mp.Mirror(mp.Y, phase=-1))
+        sim.symmetries.append(mp.Mirror(mp.X, phase=-1))
+
+        sim.run(mp.at_beginning(mp.output_epsilon),
+                mp.after_sources(mp.Harminv(mp.Hz, mp.Vector3(), fcen, df)),
+                until_after_sources=400)
+
+        sim.run(mp.at_every(1 / fcen / 20, mp.output_hfield_z), until=1 / fcen)
+
+    else:
+        sim.sources.append(mp.Source(mp.GaussianSource(fcen, fwidth=df), mp.Ey,
+                           mp.Vector3(dpml + (-0.5 * sx)), size=mp.Vector3(0, w)))
+
+        sim.symmetries.append(mp.Mirror(mp.Y, phase=-1))
+
+        freg = mp.FluxRegion(center=mp.Vector3((0.5 * sx) - dpml - 0.5),
+                             size=mp.Vector3(0, 2 * w))
+
+        # transmitted flux
+        trans = sim.add_flux(fcen, df, nfreq, freg)
+
+        vol = mp.Volume(mp.Vector3(), size=mp.Vector3(sx))
+
+        sim.run(
+            mp.at_beginning(mp.output_epsilon),
+            mp.during_sources(
+                mp.in_volume(vol, mp.to_appended("hz-slice", mp.at_every(0.4, mp.output_hfield_z)))),
+            until_after_sources=mp.stop_when_fields_decayed(50, mp.Ey, mp.Vector3((0.5 * sx) - dpml - 0.5, 0), 1e-3)
+        )
+
+        sim.display_fluxes(trans)  # print out the flux spectrum
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-r', '--resonant_modes', action='store_true', default=False,
+                        help="Compute resonant modes. Default is transmission spectrum.")
+    args = parser.parse_args()
+    main(args)

--- a/python/examples/ring.py
+++ b/python/examples/ring.py
@@ -15,11 +15,9 @@ def main():
     # Create a ring waveguide by two overlapping cylinders - later objects
     # take precedence over earlier objects, so we put the outer cylinder first.
     # and the inner (air) cylinder second.
-    dielectric = mp.Medium(epsilon=n * n)
-    air = mp.Medium()
 
-    c1 = mp.Cylinder(radius=r + w, material=dielectric)
-    c2 = mp.Cylinder(radius=r, material=air)
+    c1 = mp.Cylinder(radius=r + w, material=mp.Medium(index=n))
+    c2 = mp.Cylinder(radius=r)
 
     # If we don't want to excite a specific mode symmetry, we can just
     # put a single point source at some arbitrary place, pointing in some

--- a/python/geom.py
+++ b/python/geom.py
@@ -20,18 +20,18 @@ class Vector3(object):
         return self.x == other.x and self.y == other.y and self.z == other.z
 
     def __add__(self, other):
-        self.x += other.x
-        self.y += other.y
-        self.z += other.z
+        x = self.x + other.x
+        y = self.y + other.y
+        z = self.z + other.z
 
-        return self
+        return Vector3(x, y, z)
 
     def __sub__(self, other):
-        self.x -= other.x
-        self.y -= other.y
-        self.z -= other.z
+        x = self.x - other.x
+        y = self.y - other.y
+        z = self.z - other.z
 
-        return self
+        return Vector3(x, y, z)
 
     def __getitem__(self, i):
         if i == 0:
@@ -47,11 +47,11 @@ class Vector3(object):
         return "<{}, {}, {}>".format(self.x, self.y, self.z)
 
     def scale(self, s):
-        self.x *= s
-        self.y *= s
-        self.z *= s
+        x = self.x * s
+        y = self.y * s
+        z = self.z * s
 
-        return self
+        return Vector3(x, y, z)
 
 
 class Medium(object):

--- a/python/meep.i
+++ b/python/meep.i
@@ -272,6 +272,18 @@ PyObject *py_do_harminv(PyObject *vals, double dt, double f_min, double f_max, i
     $1 = (void*)$input;
 }
 
+// Typemap suite for dtf_flux
+
+%typemap(out) double* flux {
+    int size = arg1->Nfreq;
+    $result = PyList_New(size);
+    for(int i = 0; i < size; i++) {
+        PyList_SetItem($result, i, PyFloat_FromDouble($1[i]));
+    }
+
+  delete $1;
+}
+
 // Rename python builtins
 %rename(br_apply) meep::boundary_region::apply;
 %rename(_is) meep::dft_chunk::is;
@@ -315,6 +327,7 @@ extern boolean point_in_objectp(vector3 p, GEOMETRIC_OBJECT o);
     )
     from .simulation import (
         Absorber,
+        FluxRegion,
         Harminv,
         Identity,
         Mirror,
@@ -326,14 +339,22 @@ extern boolean point_in_objectp(vector3 p, GEOMETRIC_OBJECT o);
         Volume,
         after_sources,
         after_time,
+        arith_sequence,
         at_beginning,
         at_end,
         at_every,
+        during_sources,
         display_progress,
-        output_epsilon,
-        output_efield_z,
+        get_flux_freqs,
+        get_fluxes,
+        in_volume,
         interpolate,
+        output_epsilon,
+        output_hfield_z,
+        output_efield_z,
         py_v3_to_vec,
+        stop_when_fields_decayed,
+        to_appended
     )
     from .source import (
         ContinuousSource,

--- a/python/meep.i
+++ b/python/meep.i
@@ -339,7 +339,6 @@ extern boolean point_in_objectp(vector3 p, GEOMETRIC_OBJECT o);
         Volume,
         after_sources,
         after_time,
-        arith_sequence,
         at_beginning,
         at_end,
         at_every,

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -871,7 +871,7 @@ def output_efield_z(sim):
 
 
 def get_flux_freqs(f):
-    return arith_sequence(f.freq_min, f.dfreq, f.Nfreq)
+    return np.linspace(f.freq_min, f.freq_min + f.dfreq * f.Nfreq, num=f.Nfreq, endpoint=False).tolist()
 
 
 def get_fluxes(f):
@@ -893,7 +893,3 @@ def interpolate(n, nums):
             res.extend(np.linspace(low, high, n + 1, endpoint=False).tolist())
 
     return res + [nums[-1]]
-
-
-def arith_sequence(start, step, n):
-    return np.linspace(start, start + step * n, num=n, endpoint=False).tolist()

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -213,7 +213,8 @@ class Harminv(object):
 class Simulation(object):
 
     def __init__(self, cell_size, geometry, sources, resolution, eps_averaging=True,
-                 dimensions=2, boundary_layers=[], symmetries=[], verbose=False):
+                 dimensions=2, boundary_layers=[], symmetries=[], verbose=False,
+                 force_complex_fields=False):
         self.cell_size = cell_size
         self.geometry = geometry
         self.sources = sources
@@ -239,7 +240,7 @@ class Simulation(object):
         self.structure = None
         self.accurate_fields_near_cylorigin = False
         self.m = 0
-        self.force_complex_fields = False
+        self.force_complex_fields = force_complex_fields
         self.verbose = verbose
         self.progress_interval = 4
         self.init_fields_hooks = []

--- a/python/tests/holey_wvg_cavity.py
+++ b/python/tests/holey_wvg_cavity.py
@@ -1,0 +1,140 @@
+import unittest
+import meep as mp
+import numpy as np
+
+
+class TestHoleyWvgCavity(unittest.TestCase):
+
+    def setUp(self):
+        eps = 13
+        self.w = 1.2
+        r = 0.36
+        d = 1.4
+        N = 3
+        sy = 6
+        pad = 2
+        self.dpml = 1
+        self.sx = (2 * (pad + self.dpml + N)) + d - 1
+        self.fcen = 0.25
+        self.df = 0.2
+        self.nfreq = 500
+
+        cell = mp.Vector3(self.sx, sy, 0)
+
+        blk = mp.Block(size=mp.Vector3(1e20, self.w, 1e20),
+                       material=mp.Medium(epsilon=eps))
+
+        geometry = [blk]
+
+        for i in range(3):
+            geometry.append(mp.Cylinder(r, center=mp.Vector3(d / 2 + i)))
+
+        for i in range(3):
+            geometry.append(mp.Cylinder(r, center=mp.Vector3(d / -2 - i)))
+
+        self.sim = mp.Simulation(cell_size=cell,
+                                 geometry=geometry,
+                                 sources=[],
+                                 boundary_layers=[mp.Pml(self.dpml)],
+                                 resolution=20)
+
+    def test_resonant_modes(self):
+        self.sim.sources = [mp.Source(mp.GaussianSource(self.fcen, fwidth=self.df),
+                                      mp.Hz, mp.Vector3())]
+
+        self.sim.symmetries = [mp.Mirror(mp.Y, phase=-1),
+                               mp.Mirror(mp.X, phase=-1)]
+
+        h = mp.Harminv(mp.Hz, mp.Vector3(), self.fcen, self.df)
+        self.sim.run(mp.at_beginning(mp.output_epsilon),
+                     mp.after_sources(h),
+                     until_after_sources=400)
+
+        expected = [
+            0.23445415346009466,
+            -3.147812367338531e-4,
+            372.40808234438254,
+            5.8121430334347135,
+            -3.763107485715599,
+            -4.429450156854109,
+        ]
+
+        m = h.modes[0]
+        res = [m.freq, m.decay, m.Q, abs(m.amp), m.amp.real, m.amp.imag]
+
+        np.testing.assert_allclose(expected, res)
+
+    def test_transmission_spectrum(self):
+        expected = [
+            (0.15, 7.218492264696595e-6),
+            (0.1504008016032064, 6.445696315927592e-6),
+            (0.1508016032064128, 5.140949243632777e-6),
+            (0.15120240480961922, 3.6159747936427164e-6),
+            (0.15160320641282563, 2.263940553705969e-6),
+            (0.15200400801603203, 1.4757165844336744e-6),
+            (0.15240480961923844, 1.5491803919142815e-6),
+            (0.15280561122244485, 2.612053246626972e-6),
+            (0.15320641282565126, 4.577504371188737e-6),
+            (0.15360721442885766, 7.1459089162998185e-6),
+            (0.15400801603206407, 9.856622013418823e-6),
+            (0.15440881763527048, 1.2182309227954296e-5),
+            (0.1548096192384769, 1.3647726444709649e-5),
+            (0.1552104208416833, 1.3947420613633674e-5),
+            (0.1556112224448897, 1.303466755716231e-5),
+            (0.1560120240480961, 1.115807915037775e-5),
+            (0.15641282565130252, 8.832335196969796e-6),
+            (0.15681362725450892, 6.743645773127985e-6),
+            (0.15721442885771533, 5.605913756087576e-6),
+            (0.15761523046092174, 5.996668564026961e-6),
+            (0.15801603206412815, 8.209400611614078e-6),
+            (0.15841683366733456, 1.2158641936828497e-5),
+            (0.15881763527054096, 1.73653230513453e-5),
+            (0.15921843687374737, 2.303382576477893e-5),
+            (0.15961923847695378, 2.821180350795834e-5),
+            (0.1600200400801602, 3.200359292911769e-5),
+            (0.1604208416833666, 3.3792624373001934e-5),
+            (0.160821643286573, 3.342171394788991e-5),
+            (0.1612224448897794, 3.1284866146526904e-5),
+            (0.16162324649298582, 2.830022088581398e-5),
+            (0.16202404809619222, 2.5758413657344014e-5),
+            (0.16242484969939863, 2.506899997971769e-5),
+            (0.16282565130260504, 2.7453508915303887e-5),
+            (0.16322645290581145, 3.365089813497114e-5),
+            (0.16362725450901786, 4.370486834112e-5),
+            (0.16402805611222426, 5.689050715055283e-5),
+            (0.16442885771543067, 7.181133157470506e-5),
+            (0.16482965931863708, 8.666168027415369e-5),
+            (0.16523046092184349, 9.961094123261317e-5),
+            (0.1656312625250499, 1.0923388232657953e-4),
+            (0.1660320641282563, 1.1489334204708105e-4),
+            (0.1664328657314627, 1.1698318060032011e-4),
+            (0.16683366733466912, 1.169621456132733e-4),
+            (0.16723446893787552, 1.1714995241571987e-4),
+            (0.16763527054108193, 1.2030783847222252e-4),
+            (0.16803607214428834, 1.2907652919660887e-4),
+        ]
+
+        self.sim.sources = [
+            mp.Source(mp.GaussianSource(self.fcen, fwidth=self.df), mp.Ey,
+                      mp.Vector3(self.dpml + (-0.5 * self.sx)), size=mp.Vector3(0, self.w))
+        ]
+
+        self.sim.symmetries = [mp.Mirror(mp.Y, phase=-1)]
+
+        freg = mp.FluxRegion(center=mp.Vector3((0.5 * self.sx) - self.dpml - 0.5),
+                             size=mp.Vector3(0, 2 * self.w))
+
+        trans = self.sim.add_flux(self.fcen, self.df, self.nfreq, freg)
+
+        self.sim.run(
+            until_after_sources=mp.stop_when_fields_decayed(
+                50, mp.Ey, mp.Vector3((0.5 * self.sx) - self.dpml - 0.5, 0), 1e-1)
+        )
+
+        res = zip(mp.get_flux_freqs(trans), mp.get_fluxes(trans))
+
+        for e, r in zip(expected, res):
+            np.testing.assert_allclose(e, r)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/tests/simulation.py
+++ b/python/tests/simulation.py
@@ -72,7 +72,7 @@ class TestSimulation(unittest.TestCase):
             0.15360721442885392
         ]
 
-        res = mp.arith_sequence(0.15, 0.000400801603206, 10)
+        res = np.linspace(0.15, 0.15 + 0.000400801603206 * 10, num=10, endpoint=False)
 
         self.assertEqual(len(expected), len(res))
         np.testing.assert_allclose(expected, res)

--- a/python/tests/simulation.py
+++ b/python/tests/simulation.py
@@ -57,6 +57,26 @@ class TestSimulation(unittest.TestCase):
         np.testing.assert_allclose([v.y for v in expected], [v.y for v in res])
         np.testing.assert_allclose([v.z for v in expected], [v.z for v in res])
 
+    def test_arith_sequence(self):
+
+        expected = [
+            0.15,
+            0.15040080160320599,
+            0.15080160320641198,
+            0.15120240480961797,
+            0.15160320641282396,
+            0.15200400801602995,
+            0.15240480961923594,
+            0.15280561122244193,
+            0.15320641282564793,
+            0.15360721442885392
+        ]
+
+        res = mp.arith_sequence(0.15, 0.000400801603206, 10)
+
+        self.assertEqual(len(expected), len(res))
+        np.testing.assert_allclose(expected, res)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This includes everything necessary for `holey-wvg-cavity.py` to run correctly.

I observed an inconsistency with the tutorial and my local results.  When I run the python **and scheme** versions of `holey-wvg-cavity`, followed by `h5topng -Zc dkbluered holey-wvg-cavity-hz-slice.h5`, the result is this image
![holey-wvg-cavity-hz-slice](https://user-images.githubusercontent.com/14114829/30241656-66e63d2c-954d-11e7-94d5-cbae4e5a6ec9.png)
However, the tutorial shows this image
![holey-wvg-cavity-hz-slice](http://meep.readthedocs.io/en/latest/images/Holey-wvg-cavity-hz-slice.png)
Maybe something in the scheme example changed and uploading the new image was overlooked?

@stevengj @oskooi @HomerReid 