### PR TITLE
Add 3rd-harm-1d.py example and test

### DIFF
--- a/libmeepgeom/absorber-1d-ll.cpp
+++ b/libmeepgeom/absorber-1d-ll.cpp
@@ -73,6 +73,7 @@ int main(int argc, char *argv[])
 	  	                         DEFAULT_SUBPIXEL_MAXEVAL, // maxeval
                                          false,                    // ensure_periodicity
                                          false,                    // verbose
+                                         meep_geom::vacuum,
                                          alist);
 
   if (alist)

--- a/libmeepgeom/meepgeom.cpp
+++ b/libmeepgeom/meepgeom.cpp
@@ -1528,13 +1528,15 @@ void set_materials_from_geometry(meep::structure *s,
                                  double tol,
                                  int maxeval,
                                  bool _ensure_periodicity,
-                                 bool verbose, absorber_list alist)
+                                 bool verbose,
+                                 material_type _default_material,
+                                 absorber_list alist)
 {
   geom_epsilon::verbose=verbose;
 
   // set global variables in libctlgeom based on data fields in s
   geom_initialize();
-  default_material     = vacuum;
+  default_material     = _default_material;
   ensure_periodicity   = _ensure_periodicity;
   meep::grid_volume gv = s->gv;
   double resolution    = gv.a;

--- a/libmeepgeom/meepgeom.hpp
+++ b/libmeepgeom/meepgeom.hpp
@@ -89,6 +89,7 @@ void set_materials_from_geometry(meep::structure *s,
                                  int maxeval=DEFAULT_SUBPIXEL_MAXEVAL,
                                  bool ensure_periodicity=false,
                                  bool verbose=false,
+                                 material_type _default_material=vacuum,
                                  absorber_list alist=0);
 
 material_type make_dielectric(double epsilon);

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -23,6 +23,7 @@ _meep_la_CPPFLAGS = $(PYTHON_INCLUDES) $(AM_CPPFLAGS)
 
 TEST_DIR = tests
 TESTS =                                    \
+    $(TEST_DIR)/3rd_harm_1d.py        \
     $(TEST_DIR)/bend_flux.py          \
     $(TEST_DIR)/cyl_ellipsoid.py      \
     $(TEST_DIR)/geom.py               \

--- a/python/examples/3rd-harm-1d.py
+++ b/python/examples/3rd-harm-1d.py
@@ -1,0 +1,60 @@
+# 1d simulation of a plane wave propagating through a Kerr medium
+# and generating the third-harmonic frequency component.
+
+from __future__ import division
+
+import meep as mp
+
+
+sz = 100  # size of cell in z direction
+fcen = 1 / 3.0  # center frequency of source
+df = fcen / 20.0  # frequency width of source
+amp = 1.0  # amplitude of source
+k = 1e-2  # Kerr susceptibility
+
+dpml = 1.0  # PML layer thickness
+
+# We'll use an explicitly 1d simulation.  Setting dimensions=1 will actually
+# result in faster execution than just using two no-size dimensions.  However,
+# in this case Meep requires us to use E in the x direction (and H in y),
+# and our one no-size dimension must be z.
+dimensions = 1
+cell = mp.Vector3(0, 0, sz)
+
+# to put the same material in all space, we can just set the default material
+# and pass it to the Simulation constructor
+default_material = mp.Medium(index=1, chi3=k)
+
+pml_layers = mp.Pml(dpml)
+
+sources = mp.Source(mp.GaussianSource(fcen, fwidth=df), component=mp.Ex,
+                    center=mp.Vector3(0, 0, (-0.5 * sz) + dpml), amplitude=amp)
+
+# frequency range for flux calculation
+nfreq = 400
+fmin = fcen / 2.0
+fmax = fcen * 4
+
+sim = mp.Simulation(cell_size=cell,
+                    geometry=[],
+                    sources=[sources],
+                    boundary_layers=[pml_layers],
+                    default_material=default_material,
+                    resolution=20,
+                    dimensions=dimensions)
+
+trans = sim.add_flux(0.5 * (fmin + fmax), fmax - fmin, nfreq,
+                     mp.FluxRegion(mp.Vector3(0, 0, (0.5 * sz) - dpml - 0.5)))
+trans1 = sim.add_flux(fcen, 0, 1,
+                      mp.FluxRegion(mp.Vector3(0, 0, (0.5 * sz) - dpml - 0.5)))
+trans3 = sim.add_flux(3 * fcen, 0, 1,
+                      mp.FluxRegion(mp.Vector3(0, 0, (0.5 * sz) - dpml - 0.5)))
+
+sim.run(
+    until_after_sources=mp.stop_when_fields_decayed(
+        50, mp.Ex, mp.Vector3(0, 0, (0.5 * sz) - dpml - 0.5), 1e-6
+    )
+)
+
+sim.display_fluxes(trans)
+print("harmonics:, {}, {}, {}, {}".format(k, amp, mp.get_fluxes(trans1)[0], mp.get_fluxes(trans3)[0]))

--- a/python/examples/3rd-harm-1d.py
+++ b/python/examples/3rd-harm-1d.py
@@ -25,7 +25,7 @@ cell = mp.Vector3(0, 0, sz)
 # and pass it to the Simulation constructor
 default_material = mp.Medium(index=1, chi3=k)
 
-pml_layers = mp.PML(dpml)
+pml_layers = mp.pml(dpml)
 
 sources = mp.Source(mp.GaussianSource(fcen, fwidth=df), component=mp.Ex,
                     center=mp.Vector3(0, 0, (-0.5 * sz) + dpml), amplitude=amp)

--- a/python/examples/3rd-harm-1d.py
+++ b/python/examples/3rd-harm-1d.py
@@ -25,7 +25,7 @@ cell = mp.Vector3(0, 0, sz)
 # and pass it to the Simulation constructor
 default_material = mp.Medium(index=1, chi3=k)
 
-pml_layers = mp.Pml(dpml)
+pml_layers = mp.PML(dpml)
 
 sources = mp.Source(mp.GaussianSource(fcen, fwidth=df), component=mp.Ex,
                     center=mp.Vector3(0, 0, (-0.5 * sz) + dpml), amplitude=amp)

--- a/python/examples/bend-flux.py
+++ b/python/examples/bend-flux.py
@@ -31,7 +31,7 @@ def main(args):
     sources = [mp.Source(mp.GaussianSource(fcen, fwidth=df), component=mp.Ez,
                          center=mp.Vector3(1 + (-0.5 * sx), wvg_ycen), size=mp.Vector3(0, w))]
 
-    pml_layers = [mp.Pml(1.0)]
+    pml_layers = [mp.PML(1.0)]
     resolution = 10
 
     nfreq = 100  # number of frequencies at which to compute flux

--- a/python/examples/bend-flux.py
+++ b/python/examples/bend-flux.py
@@ -31,7 +31,7 @@ def main(args):
     sources = [mp.Source(mp.GaussianSource(fcen, fwidth=df), component=mp.Ez,
                          center=mp.Vector3(1 + (-0.5 * sx), wvg_ycen), size=mp.Vector3(0, w))]
 
-    pml_layers = [mp.PML(1.0)]
+    pml_layers = [mp.pml(1.0)]
     resolution = 10
 
     nfreq = 100  # number of frequencies at which to compute flux

--- a/python/examples/cyl-ellipsoid.py
+++ b/python/examples/cyl-ellipsoid.py
@@ -19,7 +19,7 @@ def main():
 
     sim = mp.Simulation(cell_size=mp.Vector3(10, 10),
                         geometry=[c, e],
-                        boundary_layers=[mp.Pml(1.0)],
+                        boundary_layers=[mp.PML(1.0)],
                         sources=[sources],
                         symmetries=symmetries,
                         resolution=100)

--- a/python/examples/cyl-ellipsoid.py
+++ b/python/examples/cyl-ellipsoid.py
@@ -19,7 +19,7 @@ def main():
 
     sim = mp.Simulation(cell_size=mp.Vector3(10, 10),
                         geometry=[c, e],
-                        boundary_layers=[mp.PML(1.0)],
+                        boundary_layers=[mp.pml(1.0)],
                         sources=[sources],
                         symmetries=symmetries,
                         resolution=100)

--- a/python/examples/holey-wvg-bands.py
+++ b/python/examples/holey-wvg-bands.py
@@ -36,7 +36,7 @@ def main():
     sym = mp.Mirror(direction=mp.Y, phase=-1)
 
     sim = mp.Simulation(cell_size=cell, geometry=[b, c], sources=[s], symmetries=[sym],
-                        boundary_layers=[mp.Pml(dpml, direction=mp.Y)], resolution=20)
+                        boundary_layers=[mp.PML(dpml, direction=mp.Y)], resolution=20)
 
     kx = False  # if true, do run at specified kx and get fields
     k_interp = 19  # # k-points to interpolate, otherwise

--- a/python/examples/holey-wvg-bands.py
+++ b/python/examples/holey-wvg-bands.py
@@ -36,7 +36,7 @@ def main():
     sym = mp.Mirror(direction=mp.Y, phase=-1)
 
     sim = mp.Simulation(cell_size=cell, geometry=[b, c], sources=[s], symmetries=[sym],
-                        boundary_layers=[mp.PML(dpml, direction=mp.Y)], resolution=20)
+                        boundary_layers=[mp.pml(dpml, direction=mp.Y)], resolution=20)
 
     kx = False  # if true, do run at specified kx and get fields
     k_interp = 19  # # k-points to interpolate, otherwise

--- a/python/examples/holey-wvg-cavity.py
+++ b/python/examples/holey-wvg-cavity.py
@@ -48,7 +48,7 @@ def main(args):
     sim = mp.Simulation(cell_size=cell,
                         geometry=geometry,
                         sources=[],
-                        boundary_layers=[mp.PML(dpml)],
+                        boundary_layers=[mp.pml(dpml)],
                         resolution=20)
 
     if args.resonant_modes:

--- a/python/examples/holey-wvg-cavity.py
+++ b/python/examples/holey-wvg-cavity.py
@@ -48,7 +48,7 @@ def main(args):
     sim = mp.Simulation(cell_size=cell,
                         geometry=geometry,
                         sources=[],
-                        boundary_layers=[mp.Pml(dpml)],
+                        boundary_layers=[mp.PML(dpml)],
                         resolution=20)
 
     if args.resonant_modes:

--- a/python/examples/ring.py
+++ b/python/examples/ring.py
@@ -33,7 +33,7 @@ def main():
                         sources=[src],
                         resolution=10,
                         symmetries=[mp.Mirror(mp.Y)],
-                        boundary_layers=[mp.Pml(dpml)])
+                        boundary_layers=[mp.PML(dpml)])
 
     sim.run(
         mp.at_beginning(mp.output_epsilon),

--- a/python/examples/ring.py
+++ b/python/examples/ring.py
@@ -33,7 +33,7 @@ def main():
                         sources=[src],
                         resolution=10,
                         symmetries=[mp.Mirror(mp.Y)],
-                        boundary_layers=[mp.PML(dpml)])
+                        boundary_layers=[mp.pml(dpml)])
 
     sim.run(
         mp.at_beginning(mp.output_epsilon),

--- a/python/geom.py
+++ b/python/geom.py
@@ -69,7 +69,8 @@ class Medium(object):
                  D_conductivity_diag=Vector3(),
                  B_conductivity_diag=Vector3(),
                  epsilon=None,
-                 index=None):
+                 index=None,
+                 chi3=None):
 
         if epsilon:
             epsilon_diag = Vector3(epsilon, epsilon, epsilon)
@@ -84,7 +85,7 @@ class Medium(object):
         self.E_susceptibilities = E_susceptibilities
         self.H_susceptibilities = H_susceptibilities
         self.E_chi2_diag = E_chi2_diag
-        self.E_chi3_diag = E_chi3_diag
+        self.E_chi3_diag = Vector3(chi3, chi3, chi3) if chi3 else E_chi3_diag
         self.H_chi2_diag = H_chi2_diag
         self.H_chi3_diag = H_chi3_diag
         self.D_conductivity_diag = D_conductivity_diag

--- a/python/meep.i
+++ b/python/meep.i
@@ -47,6 +47,7 @@ PyObject *py_callback = NULL;
 
 static PyObject *py_geometric_object();
 static PyObject *py_source_time_object();
+static PyObject *py_material_object();
 static PyObject* vec2py(const meep::vec &v);
 static double py_callback_wrap(const meep::vec &v);
 static int pyv3_to_v3(PyObject *po, vector3 *v);
@@ -282,6 +283,16 @@ PyObject *py_do_harminv(PyObject *vals, double dt, double f_min, double f_max, i
     }
 
   delete $1;
+}
+
+%typecheck(SWIG_TYPECHECK_POINTER) material_type _default_material {
+    $1 = PyObject_IsInstance($input, py_material_object());
+}
+
+%typemap(in) material_type _default_material {
+    if(!pymaterial_to_material($input, &$1)) {
+        SWIG_fail;
+    }
 }
 
 // Rename python builtins

--- a/python/meep.i
+++ b/python/meep.i
@@ -285,11 +285,11 @@ PyObject *py_do_harminv(PyObject *vals, double dt, double f_min, double f_max, i
   delete $1;
 }
 
-%typecheck(SWIG_TYPECHECK_POINTER) material_type _default_material {
+%typecheck(SWIG_TYPECHECK_POINTER) material_type {
     $1 = PyObject_IsInstance($input, py_material_object());
 }
 
-%typemap(in) material_type _default_material {
+%typemap(in) material_type {
     if(!pymaterial_to_material($input, &$1)) {
         SWIG_fail;
     }

--- a/python/meep.i
+++ b/python/meep.i
@@ -305,6 +305,8 @@ PyObject *py_do_harminv(PyObject *vals, double dt, double f_min, double f_max, i
 
 %rename(get_field_from_comp) meep::fields::get_field(component, const vec &) const;
 
+%rename(_pml) meep::pml;
+
 // TODO:  Fix these with a typemap when necessary
 %feature("immutable") meep::fields_chunk::connections;
 %feature("immutable") meep::fields_chunk::num_connections;
@@ -342,7 +344,7 @@ extern boolean point_in_objectp(vector3 p, GEOMETRIC_OBJECT o);
         Harminv,
         Identity,
         Mirror,
-        PML,
+        pml,
         Rotate2,
         Rotate4,
         Simulation,

--- a/python/meep.i
+++ b/python/meep.i
@@ -342,7 +342,7 @@ extern boolean point_in_objectp(vector3 p, GEOMETRIC_OBJECT o);
         Harminv,
         Identity,
         Mirror,
-        Pml,
+        PML,
         Rotate2,
         Rotate4,
         Simulation,

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -33,9 +33,9 @@ def get_num_args(func):
 def py_v3_to_vec(dims, v3):
     if dims == 1:
         if v3.x == v3.y == v3.z:
-            return mp.vec(dims, v3.x)
+            return mp.vec_from_dim(0, v3.x)
         else:
-            return mp.vec(dims)
+            return mp.vec(v3.z)
     elif dims == 2:
         return mp.vec(v3.x, v3.y)
     elif dims == 3:
@@ -117,7 +117,7 @@ class Identity(Symmetry):
 
 class Volume(object):
 
-    def __init__(self, center, size=Vector3(), dims=2,):
+    def __init__(self, center, size=Vector3(), dims=2):
         self.center = center
         self.size = size
         self.dims = dims
@@ -214,7 +214,7 @@ class Simulation(object):
 
     def __init__(self, cell_size, geometry, sources, resolution, eps_averaging=True,
                  dimensions=2, boundary_layers=[], symmetries=[], verbose=False,
-                 force_complex_fields=False):
+                 force_complex_fields=False, default_material=mp.Medium()):
         self.cell_size = cell_size
         self.geometry = geometry
         self.sources = sources
@@ -228,7 +228,7 @@ class Simulation(object):
         self.subpixel_maxeval = 100000
         self.ensure_periodicity = False
         self.extra_materials = []
-        self.default_material = None
+        self.default_material = default_material
         self.epsion_input_file = ''
         self.num_chunks = 0
         self.courant = 0.5
@@ -322,8 +322,8 @@ class Simulation(object):
         self.structure = mp.structure(gv, dummy_eps, br, sym, self.num_chunks, self.courant,
                                       self.eps_averaging, self.subpixel_tol, self.subpixel_maxeval)
 
-        mp.set_materials_from_geometry(self.structure, self.geometry, self.eps_averaging,
-                                       self.subpixel_tol, self.subpixel_maxeval, self.ensure_periodicity)
+        mp.set_materials_from_geometry(self.structure, self.geometry, self.eps_averaging, self.subpixel_tol,
+                                       self.subpixel_maxeval, self.ensure_periodicity, False, self.default_material)
 
     def _init_fields(self):
         is_cylindrical = self.dimensions == CYLINDRICAL
@@ -486,7 +486,7 @@ class Simulation(object):
         if self.fields is None:
             self._init_fields()
 
-        where = Volume(src.center, src.size).swigobj
+        where = Volume(src.center, src.size, dims=self.dimensions).swigobj
 
         if isinstance(src, EigenModeSource):
             if src.direction < 0:
@@ -494,7 +494,7 @@ class Simulation(object):
             else:
                 direction = src.direction
 
-            eig_vol = Volume(src.eig_lattice_center, src.eig_lattice_size).swigobj
+            eig_vol = Volume(src.eig_lattice_center, src.eig_lattice_size, self.dimensions).swigobj
 
             if src.amp_func is None:
                 self.fields.add_eigenmode_src(
@@ -573,11 +573,12 @@ class Simulation(object):
         vol_list = None
 
         for s in stufflist:
-            v = Volume(center=s.center, size=s.size)
+            v = Volume(center=s.center, size=s.size, dims=self.dimensions)
             d0 = s.direction
             d = self.fields.normal_direction(v.swigobj) if d0 < 0 else d0
             c = mp.direction_component(mp.Sx, d)
-            vol_list = mp.volume_list(Volume(center=s.center, size=s.size).swigobj, c, s.weight, vol_list)
+            v2 = Volume(center=s.center, size=s.size, dims=self.dimensions).swigobj
+            vol_list = mp.volume_list(v2, c, s.weight, vol_list)
 
         stuff = add_dft_stuff(vol_list, fcen - df / 2, fcen + df / 2, nfreq)
 

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -647,7 +647,7 @@ def _create_boundary_region_from_boundary_layers(boundary_layers, gv):
             continue
 
         boundary_region_args = [
-            mp.boundary_region.pml,
+            mp.boundary_region.PML,
             layer.thickness,
             layer.r_asymptotic,
             layer.mean_stretch,

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -44,7 +44,7 @@ def py_v3_to_vec(dims, v3):
         raise ValueError("Invalid dimensions in Volume: {}".format(dims))
 
 
-class PML(object):
+class pml(object):
 
     def __init__(self, thickness,
                  direction=-1,
@@ -61,11 +61,11 @@ class PML(object):
         self.pml_profile = pml_profile
 
         if direction == -1 and side == -1:
-            self.swigobj = mp.pml(thickness, r_asymptotic, mean_stretch)
+            self.swigobj = mp._pml(thickness, r_asymptotic, mean_stretch)
         elif direction == -1:
-            self.swigobj = mp.pml(thickness, side, r_asymptotic, mean_stretch)
+            self.swigobj = mp._pml(thickness, side, r_asymptotic, mean_stretch)
         else:
-            self.swigobj = mp.pml(thickness, direction, side, r_asymptotic, mean_stretch)
+            self.swigobj = mp._pml(thickness, direction, side, r_asymptotic, mean_stretch)
 
     @property
     def r_asymptotic(self):
@@ -73,7 +73,7 @@ class PML(object):
 
     @r_asymptotic.setter
     def r_asymptotic(self, val):
-        self._r_asymptotic = check_positive('PML.r_asymptotic', val)
+        self._r_asymptotic = check_positive('pml.r_asymptotic', val)
 
     @property
     def mean_stretch(self):
@@ -84,10 +84,10 @@ class PML(object):
         if val >= 1:
             self._mean_stretch = val
         else:
-            raise ValueError("PML.mean_stretch must be >= 1. Got {}".format(val))
+            raise ValueError("pml.mean_stretch must be >= 1. Got {}".format(val))
 
 
-class Absorber(PML):
+class Absorber(pml):
     pass
 
 

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -44,7 +44,7 @@ def py_v3_to_vec(dims, v3):
         raise ValueError("Invalid dimensions in Volume: {}".format(dims))
 
 
-class Pml(object):
+class PML(object):
 
     def __init__(self, thickness,
                  direction=-1,
@@ -73,7 +73,7 @@ class Pml(object):
 
     @r_asymptotic.setter
     def r_asymptotic(self, val):
-        self._r_asymptotic = check_positive('Pml.r_asymptotic', val)
+        self._r_asymptotic = check_positive('PML.r_asymptotic', val)
 
     @property
     def mean_stretch(self):
@@ -84,10 +84,10 @@ class Pml(object):
         if val >= 1:
             self._mean_stretch = val
         else:
-            raise ValueError("Pml.mean_stretch must be >= 1. Got {}".format(val))
+            raise ValueError("PML.mean_stretch must be >= 1. Got {}".format(val))
 
 
-class Absorber(Pml):
+class Absorber(PML):
     pass
 
 
@@ -647,7 +647,7 @@ def _create_boundary_region_from_boundary_layers(boundary_layers, gv):
             continue
 
         boundary_region_args = [
-            mp.boundary_region.PML,
+            mp.boundary_region.pml,
             layer.thickness,
             layer.r_asymptotic,
             layer.mean_stretch,

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -32,10 +32,7 @@ def get_num_args(func):
 
 def py_v3_to_vec(dims, v3):
     if dims == 1:
-        if v3.x == v3.y == v3.z:
-            return mp.vec_from_dim(0, v3.x)
-        else:
-            return mp.vec(v3.z)
+        return mp.vec(v3.z)
     elif dims == 2:
         return mp.vec(v3.x, v3.y)
     elif dims == 3:

--- a/python/source.py
+++ b/python/source.py
@@ -13,12 +13,12 @@ def check_positive(prop, val):
 
 class Source(object):
 
-    def __init__(self, src, component, center, size=Vector3(), amplitude=complex(1.0), amp_func=None):
+    def __init__(self, src, component, center, size=Vector3(), amplitude=1.0, amp_func=None):
         self.src = src
         self.component = component
         self.center = center
         self.size = size
-        self.amplitude = amplitude
+        self.amplitude = complex(amplitude)
         self.amp_func = amp_func
 
 

--- a/python/source.py
+++ b/python/source.py
@@ -30,26 +30,34 @@ class SourceTime(object):
 
 class ContinuousSource(SourceTime):
 
-    def __init__(self, frequency, start_time=0, end_time=1.0e20, width=0, cutoff=3.0):
+    def __init__(self, frequency=None, start_time=0, end_time=1.0e20, width=0, cutoff=3.0, wavelength=None):
+        if frequency is None and wavelength is None:
+            raise ValueError("Must set either frequency or wavelength in {}.".format(self.__class__.__name__))
+
         super(ContinuousSource, self).__init__()
-        self.frequency = float(frequency)
+        self.frequency = 1 / wavelength if wavelength else frequency
         self.start_time = start_time
         self.end_time = end_time
         self.width = width
         self.cutoff = cutoff
-        self.swigobj = mp.continuous_src_time(frequency, width, start_time, end_time, cutoff)
+        self.swigobj = mp.continuous_src_time(self.frequency, self.width, self.start_time,
+                                              self.end_time, self.cutoff)
         self.swigobj.is_integrated = self.is_integrated
 
 
 class GaussianSource(SourceTime):
 
-    def __init__(self, frequency, width=0, fwidth=float('inf'), start_time=0, cutoff=5.0):
+    def __init__(self, frequency=None, width=0, fwidth=float('inf'), start_time=0, cutoff=5.0, wavelength=None):
+        if frequency is None and wavelength is None:
+            raise ValueError("Must set either frequency or wavelength in {}.".format(self.__class__.__name__))
+
         super(GaussianSource, self).__init__()
-        self.frequency = float(frequency)
+        self.frequency = 1 / wavelength if wavelength else frequency
         self.width = max(width, 1 / fwidth)
         self.start_time = start_time
         self.cutoff = cutoff
-        self.swigobj = mp.gaussian_src_time(frequency, self.width, start_time, start_time + 2 * self.width * cutoff)
+        self.swigobj = mp.gaussian_src_time(self.frequency, self.width, self.start_time,
+                                            self.start_time + 2 * self.width * self.cutoff)
         self.swigobj.is_integrated = self.is_integrated
 
 

--- a/python/source.py
+++ b/python/source.py
@@ -35,7 +35,7 @@ class ContinuousSource(SourceTime):
             raise ValueError("Must set either frequency or wavelength in {}.".format(self.__class__.__name__))
 
         super(ContinuousSource, self).__init__()
-        self.frequency = 1 / wavelength if wavelength else frequency
+        self.frequency = 1 / wavelength if wavelength else float(frequency)
         self.start_time = start_time
         self.end_time = end_time
         self.width = width
@@ -52,7 +52,7 @@ class GaussianSource(SourceTime):
             raise ValueError("Must set either frequency or wavelength in {}.".format(self.__class__.__name__))
 
         super(GaussianSource, self).__init__()
-        self.frequency = 1 / wavelength if wavelength else frequency
+        self.frequency = 1 / wavelength if wavelength else float(frequency)
         self.width = max(width, 1 / fwidth)
         self.start_time = start_time
         self.cutoff = cutoff

--- a/python/tests/3rd_harm_1d.py
+++ b/python/tests/3rd_harm_1d.py
@@ -19,7 +19,7 @@ class Test3rdHarm1d(unittest.TestCase):
 
         default_material = mp.Medium(index=1, chi3=self.k)
 
-        pml_layers = mp.PML(self.dpml)
+        pml_layers = mp.pml(self.dpml)
 
         sources = mp.Source(mp.GaussianSource(fcen, fwidth=df), component=mp.Ex,
                             center=mp.Vector3(0, 0, (-0.5 * self.sz) + self.dpml), amplitude=self.amp)

--- a/python/tests/3rd_harm_1d.py
+++ b/python/tests/3rd_harm_1d.py
@@ -19,7 +19,7 @@ class Test3rdHarm1d(unittest.TestCase):
 
         default_material = mp.Medium(index=1, chi3=self.k)
 
-        pml_layers = mp.Pml(self.dpml)
+        pml_layers = mp.PML(self.dpml)
 
         sources = mp.Source(mp.GaussianSource(fcen, fwidth=df), component=mp.Ex,
                             center=mp.Vector3(0, 0, (-0.5 * self.sz) + self.dpml), amplitude=self.amp)

--- a/python/tests/3rd_harm_1d.py
+++ b/python/tests/3rd_harm_1d.py
@@ -1,0 +1,60 @@
+from __future__ import division
+
+import unittest
+import meep as mp
+import numpy as np
+
+
+class Test3rdHarm1d(unittest.TestCase):
+
+    def setUp(self):
+        self.sz = 100
+        fcen = 1 / 3.0
+        df = fcen / 20.0
+        self.amp = 1.0
+        self.k = 1e-2
+        self.dpml = 1.0
+        dimensions = 1
+        cell = mp.Vector3(0, 0, self.sz)
+
+        default_material = mp.Medium(index=1, chi3=self.k)
+
+        pml_layers = mp.Pml(self.dpml)
+
+        sources = mp.Source(mp.GaussianSource(fcen, fwidth=df), component=mp.Ex,
+                            center=mp.Vector3(0, 0, (-0.5 * self.sz) + self.dpml), amplitude=self.amp)
+
+        nfreq = 400
+        fmin = fcen / 2.0
+        fmax = fcen * 4
+
+        self.sim = mp.Simulation(cell_size=cell,
+                                 geometry=[],
+                                 sources=[sources],
+                                 boundary_layers=[pml_layers],
+                                 default_material=default_material,
+                                 resolution=20,
+                                 dimensions=dimensions)
+
+        fr = mp.FluxRegion(mp.Vector3(0, 0, (0.5 * self.sz) - self.dpml - 0.5))
+        self.trans = self.sim.add_flux(0.5 * (fmin + fmax), fmax - fmin, nfreq, fr)
+        self.trans1 = self.sim.add_flux(fcen, 0, 1, fr)
+        self.trans3 = self.sim.add_flux(3 * fcen, 0, 1, fr)
+
+    def test_3rd_harm_1d(self):
+
+        expected_harmonics = [0.01, 1.0, 221.89548712071553, 1.752960413399477]
+
+        self.sim.run(
+            until_after_sources=mp.stop_when_fields_decayed(
+                50, mp.Ex, mp.Vector3(0, 0, (0.5 * self.sz) - self.dpml - 0.5), 1e-6
+            )
+        )
+
+        harmonics = [self.k, self.amp, mp.get_fluxes(self.trans1)[0], mp.get_fluxes(self.trans3)[0]]
+
+        np.testing.assert_allclose(expected_harmonics, harmonics)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/tests/bend_flux.py
+++ b/python/tests/bend_flux.py
@@ -30,7 +30,7 @@ class TestBendFlux(unittest.TestCase):
         sources = [mp.Source(mp.GaussianSource(fcen, fwidth=df), component=mp.Ez,
                              center=mp.Vector3(1 + (-0.5 * sx), wvg_ycen), size=mp.Vector3(0, w))]
 
-        pml_layers = [mp.PML(1.0)]
+        pml_layers = [mp.pml(1.0)]
         resolution = 10
         nfreq = 100
 

--- a/python/tests/bend_flux.py
+++ b/python/tests/bend_flux.py
@@ -30,7 +30,7 @@ class TestBendFlux(unittest.TestCase):
         sources = [mp.Source(mp.GaussianSource(fcen, fwidth=df), component=mp.Ez,
                              center=mp.Vector3(1 + (-0.5 * sx), wvg_ycen), size=mp.Vector3(0, w))]
 
-        pml_layers = [mp.Pml(1.0)]
+        pml_layers = [mp.PML(1.0)]
         resolution = 10
         nfreq = 100
 

--- a/python/tests/cyl_ellipsoid.py
+++ b/python/tests/cyl_ellipsoid.py
@@ -30,7 +30,7 @@ class TestCylEllipsoid(unittest.TestCase):
 
         self.sim = mp.Simulation(cell_size=mp.Vector3(10, 10),
                                  geometry=[c, e],
-                                 boundary_layers=[mp.PML(1.0)],
+                                 boundary_layers=[mp.pml(1.0)],
                                  sources=[sources],
                                  symmetries=symmetries,
                                  resolution=100)

--- a/python/tests/cyl_ellipsoid.py
+++ b/python/tests/cyl_ellipsoid.py
@@ -30,7 +30,7 @@ class TestCylEllipsoid(unittest.TestCase):
 
         self.sim = mp.Simulation(cell_size=mp.Vector3(10, 10),
                                  geometry=[c, e],
-                                 boundary_layers=[mp.Pml(1.0)],
+                                 boundary_layers=[mp.PML(1.0)],
                                  sources=[sources],
                                  symmetries=symmetries,
                                  resolution=100)

--- a/python/tests/holey_wvg_bands.py
+++ b/python/tests/holey_wvg_bands.py
@@ -25,7 +25,7 @@ class TestHoleyWvgBands(unittest.TestCase):
             geometry=[b, c],
             sources=[s],
             symmetries=[sym],
-            boundary_layers=[mp.Pml(1, direction=mp.Y)],
+            boundary_layers=[mp.PML(1, direction=mp.Y)],
             resolution=20
         )
 

--- a/python/tests/holey_wvg_bands.py
+++ b/python/tests/holey_wvg_bands.py
@@ -25,7 +25,7 @@ class TestHoleyWvgBands(unittest.TestCase):
             geometry=[b, c],
             sources=[s],
             symmetries=[sym],
-            boundary_layers=[mp.PML(1, direction=mp.Y)],
+            boundary_layers=[mp.pml(1, direction=mp.Y)],
             resolution=20
         )
 

--- a/python/tests/holey_wvg_cavity.py
+++ b/python/tests/holey_wvg_cavity.py
@@ -35,7 +35,7 @@ class TestHoleyWvgCavity(unittest.TestCase):
         self.sim = mp.Simulation(cell_size=cell,
                                  geometry=geometry,
                                  sources=[],
-                                 boundary_layers=[mp.Pml(self.dpml)],
+                                 boundary_layers=[mp.PML(self.dpml)],
                                  resolution=20)
 
     def test_resonant_modes(self):

--- a/python/tests/holey_wvg_cavity.py
+++ b/python/tests/holey_wvg_cavity.py
@@ -35,7 +35,7 @@ class TestHoleyWvgCavity(unittest.TestCase):
         self.sim = mp.Simulation(cell_size=cell,
                                  geometry=geometry,
                                  sources=[],
-                                 boundary_layers=[mp.PML(self.dpml)],
+                                 boundary_layers=[mp.pml(self.dpml)],
                                  resolution=20)
 
     def test_resonant_modes(self):

--- a/python/tests/physical.py
+++ b/python/tests/physical.py
@@ -34,7 +34,7 @@ class TestPhysical(unittest.TestCase):
 
         w = 0.30
 
-        s = mp.structure(self.gv, one, mp.pml(self.ymax / 3.0))
+        s = mp.structure(self.gv, one, mp._pml(self.ymax / 3.0))
 
         f = mp.fields(s)
 

--- a/python/tests/ring.py
+++ b/python/tests/ring.py
@@ -36,7 +36,7 @@ class TestRing(unittest.TestCase):
                                  sources=[src],
                                  resolution=10,
                                  symmetries=[mp.Mirror(mp.Y)],
-                                 boundary_layers=[mp.PML(dpml)])
+                                 boundary_layers=[mp.pml(dpml)])
 
         self.h = mp.Harminv(mp.Ez, mp.Vector3(r + 0.1), fcen, df)
 

--- a/python/tests/ring.py
+++ b/python/tests/ring.py
@@ -36,7 +36,7 @@ class TestRing(unittest.TestCase):
                                  sources=[src],
                                  resolution=10,
                                  symmetries=[mp.Mirror(mp.Y)],
-                                 boundary_layers=[mp.Pml(dpml)])
+                                 boundary_layers=[mp.PML(dpml)])
 
         self.h = mp.Harminv(mp.Ez, mp.Vector3(r + 0.1), fcen, df)
 

--- a/python/tests/source.py
+++ b/python/tests/source.py
@@ -22,6 +22,29 @@ class TestEigenModeSource(unittest.TestCase):
         self.assertEqual(custom_lattice.eig_lattice_center, elc)
 
 
+class TestSourceTime(unittest.TestCase):
+
+    def test_source_wavelength(self):
+        g_src = GaussianSource(wavelength=10)
+        c_src = ContinuousSource(wavelength=10)
+
+        self.assertAlmostEqual(1. / 10., g_src.frequency)
+        self.assertAlmostEqual(1. / 10., c_src.frequency)
+
+    def test_source_frequency(self):
+        g_src = GaussianSource(10)
+        c_src = ContinuousSource(10)
+
+        self.assertEqual(10, g_src.frequency)
+        self.assertEqual(10, c_src.frequency)
+
+        with self.assertRaises(ValueError):
+            GaussianSource()
+
+        with self.assertRaises(ValueError):
+            ContinuousSource()
+
+
 class TestSourceTypemaps(unittest.TestCase):
 
     expected_msg = "Expected a meep.source.SourceTime or a meep.src_time\n"

--- a/python/tests/source.py
+++ b/python/tests/source.py
@@ -57,7 +57,7 @@ class TestSourceTypemaps(unittest.TestCase):
         gv = mp.voltwo(16, 16, 10)
         gv.center_origin()
         sym = mp.mirror(mp.Y, gv)
-        the_structure = mp.structure(gv, dummy_eps, mp.pml(2), sym)
+        the_structure = mp.structure(gv, dummy_eps, mp._pml(2), sym)
         objects = []
         objects.append(Cylinder(1))
         mp.set_materials_from_geometry(the_structure, objects)

--- a/python/typemap_utils.cpp
+++ b/python/typemap_utils.cpp
@@ -55,7 +55,7 @@ static PyObject *py_meep_src_time_object() {
 
 static PyObject *py_material_object() {
     static PyObject *material_object = NULL;
-    if(material_object == NULL) {
+    if (material_object == NULL) {
         PyObject *geom_mod = PyImport_ImportModule("meep.geom");
         material_object = PyObject_GetAttrString(geom_mod, "Medium");
         Py_XDECREF(geom_mod);
@@ -103,7 +103,7 @@ static int pyv3_to_v3(PyObject *po, vector3 *v) {
     PyObject *py_y = PyObject_GetAttrString(po, "y");
     PyObject *py_z = PyObject_GetAttrString(po, "z");
 
-    if(!py_x || !py_y || !py_z) {
+    if (!py_x || !py_y || !py_z) {
         PyErr_SetString(PyExc_ValueError, "Vector3 is not initialized");
         return 0;
     }
@@ -125,12 +125,12 @@ static int pyv3_to_v3(PyObject *po, vector3 *v) {
 static int get_attr_v3(PyObject *py_obj, vector3 *v, const char *name) {
     PyObject *py_attr = PyObject_GetAttrString(py_obj, name);
 
-    if(!py_attr) {
+    if (!py_attr) {
         PyErr_Format(PyExc_ValueError, "Class attribute '%s' is None\n", name);
         return 0;
     }
 
-    if(!pyv3_to_v3(py_attr, v)) {
+    if (!pyv3_to_v3(py_attr, v)) {
         return 0;
     }
 
@@ -141,7 +141,7 @@ static int get_attr_v3(PyObject *py_obj, vector3 *v, const char *name) {
 static int get_attr_dbl(PyObject *py_obj, double *result, const char *name) {
     PyObject *py_attr = PyObject_GetAttrString(py_obj, name);
 
-    if(!py_attr) {
+    if (!py_attr) {
         PyErr_Format(PyExc_ValueError, "Class attribute '%s' is None\n", name);
         return 0;
     }
@@ -154,12 +154,12 @@ static int get_attr_dbl(PyObject *py_obj, double *result, const char *name) {
 static int get_attr_material(PyObject *po, material_type *m) {
     PyObject *py_material = PyObject_GetAttrString(po, "material");
 
-    if(!py_material) {
+    if (!py_material) {
         PyErr_SetString(PyExc_ValueError, "Object's material is not set\n");
         return 0;
     }
 
-    if(!pymaterial_to_material(py_material, m)) {
+    if (!pymaterial_to_material(py_material, m)) {
         return 0;
     }
 
@@ -169,7 +169,7 @@ static int get_attr_material(PyObject *po, material_type *m) {
 }
 
 static int py_susceptibility_to_susceptibility(PyObject *po, susceptibility_struct *s) {
-    if(!get_attr_v3(po, &s->sigma_diag, "sigma_diag") ||
+    if (!get_attr_v3(po, &s->sigma_diag, "sigma_diag") ||
        !get_attr_v3(po, &s->sigma_offdiag, "sigma_offdiag") ||
        !get_attr_dbl(po, &s->frequency, "frequency") ||
        !get_attr_dbl(po, &s->gamma, "gamma")) {
@@ -177,13 +177,13 @@ static int py_susceptibility_to_susceptibility(PyObject *po, susceptibility_stru
         return 0;
     }
 
-    if(!get_attr_dbl(po, &s->noise_amp, "noise_amp")) {
+    if (!get_attr_dbl(po, &s->noise_amp, "noise_amp")) {
         s->noise_amp = 0;
     }
 
     std::string class_name = py_class_name_as_string(po);
 
-    if(class_name.find(std::string("Drude")) != std::string::npos) {
+    if (class_name.find(std::string("Drude")) != std::string::npos) {
         s->drude = true;
     } else {
         s->drude = false;
@@ -195,7 +195,7 @@ static int py_susceptibility_to_susceptibility(PyObject *po, susceptibility_stru
 }
 
 static int py_list_to_susceptibility_list(PyObject *po, susceptibility_list *sl) {
-    if(!PyList_Check(po)) {
+    if (!PyList_Check(po)) {
         PyErr_SetString(PyExc_TypeError, "Expected a list\n");
         return 0;
     }
@@ -206,7 +206,7 @@ static int py_list_to_susceptibility_list(PyObject *po, susceptibility_list *sl)
 
     for(int i = 0; i < length; i++) {
         susceptibility_struct s;
-        if(!py_susceptibility_to_susceptibility(PyList_GetItem(po, i), &s)) {
+        if (!py_susceptibility_to_susceptibility(PyList_GetItem(po, i), &s)) {
             return 0;
         }
         sl->items[i].sigma_diag = s.sigma_diag;
@@ -229,7 +229,7 @@ static int pymaterial_to_material(PyObject *po, material_type *mt) {
     md->user_data = 0;
     md->medium = new medium_struct();
 
-    if(!get_attr_v3(po, &md->medium->epsilon_diag, "epsilon_diag") ||
+    if (!get_attr_v3(po, &md->medium->epsilon_diag, "epsilon_diag") ||
        !get_attr_v3(po, &md->medium->epsilon_offdiag, "epsilon_offdiag") ||
        !get_attr_v3(po, &md->medium->mu_diag, "mu_diag") ||
        !get_attr_v3(po, &md->medium->mu_offdiag, "mu_offdiag")) {
@@ -240,11 +240,11 @@ static int pymaterial_to_material(PyObject *po, material_type *mt) {
     PyObject *py_e_susceptibilities = PyObject_GetAttrString(po, "E_susceptibilities");
     PyObject *py_h_susceptibilities = PyObject_GetAttrString(po, "H_susceptibilities");
 
-    if(!py_e_susceptibilities || !py_h_susceptibilities) {
+    if (!py_e_susceptibilities || !py_h_susceptibilities) {
         return 0;
     }
 
-    if(!py_list_to_susceptibility_list(py_e_susceptibilities, &md->medium->E_susceptibilities) ||
+    if (!py_list_to_susceptibility_list(py_e_susceptibilities, &md->medium->E_susceptibilities) ||
        !py_list_to_susceptibility_list(py_h_susceptibilities, &md->medium->H_susceptibilities)) {
 
         return 0;
@@ -253,7 +253,7 @@ static int pymaterial_to_material(PyObject *po, material_type *mt) {
     Py_XDECREF(py_e_susceptibilities);
     Py_XDECREF(py_h_susceptibilities);
 
-    if(!get_attr_v3(po, &md->medium->E_chi2_diag, "E_chi2_diag") ||
+    if (!get_attr_v3(po, &md->medium->E_chi2_diag, "E_chi2_diag") ||
        !get_attr_v3(po, &md->medium->E_chi3_diag, "E_chi3_diag") ||
        !get_attr_v3(po, &md->medium->H_chi2_diag, "H_chi2_diag") ||
        !get_attr_v3(po, &md->medium->H_chi3_diag, "H_chi3_diag") ||
@@ -274,7 +274,7 @@ static int pysphere_to_sphere(PyObject *py_sphere, geometric_object *go) {
     vector3 center;
     double radius;
     
-    if(!get_attr_v3(py_sphere, &center, "center") ||
+    if (!get_attr_v3(py_sphere, &center, "center") ||
        !get_attr_dbl(py_sphere, &radius, "radius") ||
        !get_attr_material(py_sphere, &material)) {
 
@@ -292,7 +292,7 @@ static int pycylinder_to_cylinder(PyObject *py_cyl, geometric_object *cyl) {
     vector3 center, axis;
     double radius, height;
 
-    if(!get_attr_v3(py_cyl, &center, "center") ||
+    if (!get_attr_v3(py_cyl, &center, "center") ||
        !get_attr_v3(py_cyl, &axis, "axis") ||
        !get_attr_dbl(py_cyl, &radius, "radius") ||
        !get_attr_dbl(py_cyl, &height, "height") ||
@@ -309,14 +309,14 @@ static int pycylinder_to_cylinder(PyObject *py_cyl, geometric_object *cyl) {
 
 static int pywedge_to_wedge(PyObject *py_wedge, geometric_object *wedge) {
     geometric_object cyl;
-    if(!pycylinder_to_cylinder(py_wedge, &cyl)) {
+    if (!pycylinder_to_cylinder(py_wedge, &cyl)) {
         return 0;
     }
 
     double wedge_angle; 
     vector3 wedge_start;
 
-    if(!get_attr_dbl(py_wedge, &wedge_angle, "wedge_angle") ||
+    if (!get_attr_dbl(py_wedge, &wedge_angle, "wedge_angle") ||
        !get_attr_v3(py_wedge, &wedge_start, "wedge_start")) {
 
         wedge->subclass.cylinder_data = NULL;
@@ -337,12 +337,12 @@ static int pywedge_to_wedge(PyObject *py_wedge, geometric_object *wedge) {
 
 static int pycone_to_cone(PyObject *py_cone, geometric_object *cone) {
     geometric_object cyl;
-    if(!pycylinder_to_cylinder(py_cone, &cyl)) {
+    if (!pycylinder_to_cylinder(py_cone, &cyl)) {
         return 0;
     }
 
     double radius2;
-    if(!get_attr_dbl(py_cone, &radius2, "radius2")) {
+    if (!get_attr_dbl(py_cone, &radius2, "radius2")) {
         cone->subclass.cylinder_data = NULL;
         geometric_object_destroy(cyl);
         return 0;
@@ -363,7 +363,7 @@ static int pyblock_to_block(PyObject *py_blk, geometric_object *blk) {
     material_type material;
     vector3 center, e1, e2, e3, size;
 
-    if(!get_attr_material(py_blk, &material) ||
+    if (!get_attr_material(py_blk, &material) ||
        !get_attr_v3(py_blk, &center, "center") ||
        !get_attr_v3(py_blk, &e1, "e1") ||
        !get_attr_v3(py_blk, &e2, "e2") ||
@@ -380,7 +380,7 @@ static int pyblock_to_block(PyObject *py_blk, geometric_object *blk) {
 
 static int pyellipsoid_to_ellipsoid(PyObject *py_ell, geometric_object *e) {
     geometric_object blk;
-    if(!pyblock_to_block(py_ell, &blk)) {
+    if (!pyblock_to_block(py_ell, &blk)) {
         return 0;
     }
 
@@ -399,7 +399,7 @@ static int pyellipsoid_to_ellipsoid(PyObject *py_ell, geometric_object *e) {
 }
 
 static int py_list_to_gobj_list(PyObject *po, geometric_object_list *l) {
-    if(!PyList_Check(po)) {
+    if (!PyList_Check(po)) {
         PyErr_SetString(PyExc_TypeError, "Expected a list");
         return 0;
     }
@@ -412,7 +412,7 @@ static int py_list_to_gobj_list(PyObject *po, geometric_object_list *l) {
     for(int i = 0; i < length; i++) {
         PyObject *py_gobj = PyList_GetItem(po, i);
         geometric_object go;
-        if(!py_gobj_to_gobj(py_gobj, &go)) {
+        if (!py_gobj_to_gobj(py_gobj, &go)) {
             return 0;
         }
         geometric_object_copy(&go, &l->items[i]);
@@ -439,22 +439,22 @@ static int py_gobj_to_gobj(PyObject *po, geometric_object *o) {
     int success = 0;
     std::string go_type = py_class_name_as_string(po);
 
-    if(go_type == "Sphere") {
+    if (go_type == "Sphere") {
         success = pysphere_to_sphere(po, o);
     }
-    else if(go_type == "Cylinder") {
+    else if (go_type == "Cylinder") {
         success = pycylinder_to_cylinder(po, o);
     }
-    else if(go_type == "Wedge") {
+    else if (go_type == "Wedge") {
         success = pywedge_to_wedge(po, o);
     }
-    else if(go_type == "Cone") {
+    else if (go_type == "Cone") {
         success = pycone_to_cone(po, o);
     }
-    else if(go_type == "Block") {
+    else if (go_type == "Block") {
         success = pyblock_to_block(po, o);
     }
-    else if(go_type == "Ellipsoid") {
+    else if (go_type == "Ellipsoid") {
         success = pyellipsoid_to_ellipsoid(po, o);
     }
     else {

--- a/python/typemap_utils.cpp
+++ b/python/typemap_utils.cpp
@@ -53,6 +53,16 @@ static PyObject *py_meep_src_time_object() {
     return src_time;
 }
 
+static PyObject *py_material_object() {
+    static PyObject *material_object = NULL;
+    if(material_object == NULL) {
+        PyObject *geom_mod = PyImport_ImportModule("meep.geom");
+        material_object = PyObject_GetAttrString(geom_mod, "Medium");
+        Py_XDECREF(geom_mod);
+    }
+    return material_object;
+}
+
 static PyObject* vec2py(const meep::vec &v) {
 
     double x = 0, y = 0, z = 0;


### PR DESCRIPTION
`set_materials_from_geometry` now takes a `default_material` parameter.

This also includes a couple requests from Ardavan: 
* Rename Pml to PML
* Add `wavelength` param to sources

@stevengj @oskooi @HomerReid 
