### PR TITLE
rename "pml" to "PML" in Python

### DIFF
--- a/python/examples/3rd-harm-1d.py
+++ b/python/examples/3rd-harm-1d.py
@@ -25,7 +25,7 @@ cell = mp.Vector3(0, 0, sz)
 # and pass it to the Simulation constructor
 default_material = mp.Medium(index=1, chi3=k)
 
-pml_layers = mp.pml(dpml)
+pml_layers = mp.PML(dpml)
 
 sources = mp.Source(mp.GaussianSource(fcen, fwidth=df), component=mp.Ex,
                     center=mp.Vector3(0, 0, (-0.5 * sz) + dpml), amplitude=amp)

--- a/python/examples/bend-flux.py
+++ b/python/examples/bend-flux.py
@@ -31,7 +31,7 @@ def main(args):
     sources = [mp.Source(mp.GaussianSource(fcen, fwidth=df), component=mp.Ez,
                          center=mp.Vector3(1 + (-0.5 * sx), wvg_ycen), size=mp.Vector3(0, w))]
 
-    pml_layers = [mp.pml(1.0)]
+    pml_layers = [mp.PML(1.0)]
     resolution = 10
 
     nfreq = 100  # number of frequencies at which to compute flux

--- a/python/examples/cavity_arrayslice.py
+++ b/python/examples/cavity_arrayslice.py
@@ -35,7 +35,7 @@ for i in range(3):
 sim = mp.Simulation(cell_size=cell,
                          geometry=geometry,
                          sources=[],
-                         boundary_layers=[mp.pml(dpml)],
+                         boundary_layers=[mp.PML(dpml)],
                          resolution=20)
 
 ##################################################

--- a/python/examples/cyl-ellipsoid.py
+++ b/python/examples/cyl-ellipsoid.py
@@ -19,7 +19,7 @@ def main():
 
     sim = mp.Simulation(cell_size=mp.Vector3(10, 10),
                         geometry=[c, e],
-                        boundary_layers=[mp.pml(1.0)],
+                        boundary_layers=[mp.PML(1.0)],
                         sources=[sources],
                         symmetries=symmetries,
                         resolution=100)

--- a/python/examples/holey-wvg-bands.py
+++ b/python/examples/holey-wvg-bands.py
@@ -36,7 +36,7 @@ def main():
     sym = mp.Mirror(direction=mp.Y, phase=-1)
 
     sim = mp.Simulation(cell_size=cell, geometry=[b, c], sources=[s], symmetries=[sym],
-                        boundary_layers=[mp.pml(dpml, direction=mp.Y)], resolution=20)
+                        boundary_layers=[mp.PML(dpml, direction=mp.Y)], resolution=20)
 
     kx = False  # if true, do run at specified kx and get fields
     k_interp = 19  # # k-points to interpolate, otherwise

--- a/python/examples/holey-wvg-cavity.py
+++ b/python/examples/holey-wvg-cavity.py
@@ -48,7 +48,7 @@ def main(args):
     sim = mp.Simulation(cell_size=cell,
                         geometry=geometry,
                         sources=[],
-                        boundary_layers=[mp.pml(dpml)],
+                        boundary_layers=[mp.PML(dpml)],
                         resolution=20)
 
     if args.resonant_modes:

--- a/python/examples/ring.py
+++ b/python/examples/ring.py
@@ -33,7 +33,7 @@ def main():
                         sources=[src],
                         resolution=10,
                         symmetries=[mp.Mirror(mp.Y)],
-                        boundary_layers=[mp.pml(dpml)])
+                        boundary_layers=[mp.PML(dpml)])
 
     sim.run(
         mp.at_beginning(mp.output_epsilon),

--- a/python/meep.i
+++ b/python/meep.i
@@ -350,7 +350,7 @@ extern boolean point_in_objectp(vector3 p, GEOMETRIC_OBJECT o);
         Harminv,
         Identity,
         Mirror,
-        pml,
+        PML,
         Rotate2,
         Rotate4,
         Simulation,

--- a/python/meep.i
+++ b/python/meep.i
@@ -311,8 +311,6 @@ PyObject *py_do_harminv(PyObject *vals, double dt, double f_min, double f_max, i
 
 %rename(get_field_from_comp) meep::fields::get_field(component, const vec &) const;
 
-%rename(_pml) meep::pml;
-
 // TODO:  Fix these with a typemap when necessary
 %feature("immutable") meep::fields_chunk::connections;
 %feature("immutable") meep::fields_chunk::num_connections;

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -41,7 +41,7 @@ def py_v3_to_vec(dims, v3):
         raise ValueError("Invalid dimensions in Volume: {}".format(dims))
 
 
-class pml(object):
+class PML(object):
 
     def __init__(self, thickness,
                  direction=-1,
@@ -70,7 +70,7 @@ class pml(object):
 
     @r_asymptotic.setter
     def r_asymptotic(self, val):
-        self._r_asymptotic = check_positive('pml.r_asymptotic', val)
+        self._r_asymptotic = check_positive('PML.r_asymptotic', val)
 
     @property
     def mean_stretch(self):
@@ -81,10 +81,10 @@ class pml(object):
         if val >= 1:
             self._mean_stretch = val
         else:
-            raise ValueError("pml.mean_stretch must be >= 1. Got {}".format(val))
+            raise ValueError("PML.mean_stretch must be >= 1. Got {}".format(val))
 
 
-class Absorber(pml):
+class Absorber(PML):
     pass
 
 

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -58,11 +58,11 @@ class PML(object):
         self.pml_profile = pml_profile
 
         if direction == -1 and side == -1:
-            self.swigobj = mp._pml(thickness, r_asymptotic, mean_stretch)
+            self.swigobj = mp.pml(thickness, r_asymptotic, mean_stretch)
         elif direction == -1:
-            self.swigobj = mp._pml(thickness, side, r_asymptotic, mean_stretch)
+            self.swigobj = mp.pml(thickness, side, r_asymptotic, mean_stretch)
         else:
-            self.swigobj = mp._pml(thickness, direction, side, r_asymptotic, mean_stretch)
+            self.swigobj = mp.pml(thickness, direction, side, r_asymptotic, mean_stretch)
 
     @property
     def r_asymptotic(self):

--- a/python/tests/3rd_harm_1d.py
+++ b/python/tests/3rd_harm_1d.py
@@ -19,7 +19,7 @@ class Test3rdHarm1d(unittest.TestCase):
 
         default_material = mp.Medium(index=1, chi3=self.k)
 
-        pml_layers = mp.pml(self.dpml)
+        pml_layers = mp.PML(self.dpml)
 
         sources = mp.Source(mp.GaussianSource(fcen, fwidth=df), component=mp.Ex,
                             center=mp.Vector3(0, 0, (-0.5 * self.sz) + self.dpml), amplitude=self.amp)

--- a/python/tests/bend_flux.py
+++ b/python/tests/bend_flux.py
@@ -30,7 +30,7 @@ class TestBendFlux(unittest.TestCase):
         sources = [mp.Source(mp.GaussianSource(fcen, fwidth=df), component=mp.Ez,
                              center=mp.Vector3(1 + (-0.5 * sx), wvg_ycen), size=mp.Vector3(0, w))]
 
-        pml_layers = [mp.pml(1.0)]
+        pml_layers = [mp.PML(1.0)]
         resolution = 10
         nfreq = 100
 

--- a/python/tests/cyl_ellipsoid.py
+++ b/python/tests/cyl_ellipsoid.py
@@ -30,7 +30,7 @@ class TestCylEllipsoid(unittest.TestCase):
 
         self.sim = mp.Simulation(cell_size=mp.Vector3(10, 10),
                                  geometry=[c, e],
-                                 boundary_layers=[mp.pml(1.0)],
+                                 boundary_layers=[mp.PML(1.0)],
                                  sources=[sources],
                                  symmetries=symmetries,
                                  resolution=100)

--- a/python/tests/holey_wvg_bands.py
+++ b/python/tests/holey_wvg_bands.py
@@ -25,7 +25,7 @@ class TestHoleyWvgBands(unittest.TestCase):
             geometry=[b, c],
             sources=[s],
             symmetries=[sym],
-            boundary_layers=[mp.pml(1, direction=mp.Y)],
+            boundary_layers=[mp.PML(1, direction=mp.Y)],
             resolution=20
         )
 

--- a/python/tests/holey_wvg_cavity.py
+++ b/python/tests/holey_wvg_cavity.py
@@ -35,7 +35,7 @@ class TestHoleyWvgCavity(unittest.TestCase):
         self.sim = mp.Simulation(cell_size=cell,
                                  geometry=geometry,
                                  sources=[],
-                                 boundary_layers=[mp.pml(self.dpml)],
+                                 boundary_layers=[mp.PML(self.dpml)],
                                  resolution=20)
 
     def test_resonant_modes(self):

--- a/python/tests/physical.py
+++ b/python/tests/physical.py
@@ -34,7 +34,7 @@ class TestPhysical(unittest.TestCase):
 
         w = 0.30
 
-        s = mp.structure(self.gv, one, mp._pml(self.ymax / 3.0))
+        s = mp.structure(self.gv, one, mp.pml(self.ymax / 3.0))
 
         f = mp.fields(s)
 

--- a/python/tests/ring.py
+++ b/python/tests/ring.py
@@ -36,7 +36,7 @@ class TestRing(unittest.TestCase):
                                  sources=[src],
                                  resolution=10,
                                  symmetries=[mp.Mirror(mp.Y)],
-                                 boundary_layers=[mp.pml(dpml)])
+                                 boundary_layers=[mp.PML(dpml)])
 
         self.h = mp.Harminv(mp.Ez, mp.Vector3(r + 0.1), fcen, df)
 

--- a/python/tests/source.py
+++ b/python/tests/source.py
@@ -57,7 +57,7 @@ class TestSourceTypemaps(unittest.TestCase):
         gv = mp.voltwo(16, 16, 10)
         gv.center_origin()
         sym = mp.mirror(mp.Y, gv)
-        the_structure = mp.structure(gv, dummy_eps, mp._pml(2), sym)
+        the_structure = mp.structure(gv, dummy_eps, mp.pml(2), sym)
         objects = []
         objects.append(Cylinder(1))
         mp.set_materials_from_geometry(the_structure, objects)


### PR DESCRIPTION
Following PEP 8 and discussion in #98.  cc @ChristopherHogan 