### PR TITLE
Fixes for running in Jupyter notebooks

### DIFF
--- a/python/simulation.py
+++ b/python/simulation.py
@@ -374,7 +374,7 @@ class Simulation(object):
         if filename == 'ipykernel_launcher.py':
             return ''
         else:
-            return re.sub(r'\.py', '', filename)
+            return re.sub(r'\.py$', '', filename)
 
     def _run_until(self, cond, step_funcs):
         self.interactive = False


### PR DESCRIPTION
* Fix h5file prefix when run within notebooks

We can't use `__file__` because it would always be the path to `simulation.py`, so I use the name of the running script, `sys.argv[0]`. If running in an interactive interpreter, this is an empty string, and if run in a notebook, I replace `ipykernel_launcher.py` with an empty string. I also removed `_init_include_files`, as it seemed superfluous for python.

* Fix `to_appended` when running within notebooks

The issue was that the output file can't be opened until the `h5file` object is destroyed. The example worked outside of a notebook because we never tried to access the `hz-slice.h5` file during execution. 

Now I destroy the `h5file` when the step_func is called with 'finish'. Normally the step funcs are called with 'finish' only at the end of a run, but this doesn't work for `during_sources` because it only calls `_eval_step_funcs` before a certain time (I think this is broken in scheme too, if that matters). I modified `during_sources` to evaluate the step funcs with 'finish' once immediately after the sources finish.

@oskooi @HomerReid 