### PR TITLE
Improve usability of user-defined material functions

### DIFF
--- a/python/simulation.py
+++ b/python/simulation.py
@@ -481,6 +481,12 @@ class Simulation(object):
 
         return all_freqs
 
+    def set_epsilon(self, eps):
+        if self.structure is None:
+            self._init_fields()
+
+        self.structure.set_epsilon(eps, self.eps_averaging, self.subpixel_tol, self.subpixel_maxeval)
+
     def add_source(self, src):
         if self.fields is None:
             self._init_fields()

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -482,7 +482,7 @@ class Simulation(object):
         return all_freqs
 
     def set_epsilon(self, eps):
-        if self.structure is None:
+        if self.fields is None:
             self._init_fields()
 
         self.structure.set_epsilon(eps, self.eps_averaging, self.subpixel_tol, self.subpixel_maxeval)

--- a/python/typemap_utils.cpp
+++ b/python/typemap_utils.cpp
@@ -81,10 +81,24 @@ static PyObject* vec2py(const meep::vec &v) {
         z = v.z();
         break;
       case meep::Dcyl:
-        return Py_BuildValue("(ddd)", v.r(), v.z(), 0);
+        x = v.r();
+        z = v.z();
+        break;
     }
 
-    return Py_BuildValue("(ddd)", x, y, z);
+    PyObject *geom_mod = PyImport_ImportModule("meep.geom");
+    PyObject *v3_class = PyObject_GetAttrString(geom_mod, "Vector3");
+
+    PyObject *kwargs = Py_BuildValue("{s:d,s:d,s:d}", "x", x, "y", y, "z", z);
+    PyObject *args = PyTuple_New(0);
+    PyObject *pyv3 = PyObject_Call(v3_class, args, kwargs);
+
+    Py_DECREF(args);
+    Py_DECREF(kwargs);
+    Py_DECREF(geom_mod);
+    Py_DECREF(v3_class);
+
+    return pyv3;
 }
 
 static double py_callback_wrap(const meep::vec &v) {
@@ -95,7 +109,6 @@ static double py_callback_wrap(const meep::vec &v) {
     Py_XDECREF(pyret);
     return ret;
 }
-
 
 static int pyv3_to_v3(PyObject *po, vector3 *v) {
 


### PR DESCRIPTION
This allows user-defined material functions to manipulate their argument as a `Vector3` instead of a tuple. I.e.,
```python
def myeps(p):
    if abs(p.y) <= 0.5:
        return 12
    else:
        return 1
```
instead of
```python
def myeps(p):
    if abs(p[1]) <= 0.5:
        return 12
    else:
        return 1
```
Additionally, I've added a high-level `set_epsilon` so the user can do
```python
sim.set_epsilon(myeps)
```
instead of
```python
sim._init_structure()
sim.structure.set_epsilon(myeps)
```
@stevengj @oskooi @HomerReid 