### PR TITLE
Add output functions and synchronized_magnetic

### DIFF
--- a/python/examples/cyl-ellipsoid.py
+++ b/python/examples/cyl-ellipsoid.py
@@ -26,8 +26,8 @@ def main():
 
     def print_stuff(sim_obj):
         v = mp.Vector3(4.13, 3.75, 0)
-        p = sim._get_field_point(src_cmpt, v)
-        print("t, Ez: {} {}+{}i".format(sim._round_time(), p.real, p.imag))
+        p = sim.get_field_point(src_cmpt, v)
+        print("t, Ez: {} {}+{}i".format(sim.round_time(), p.real, p.imag))
 
     sim.run(mp.at_beginning(mp.output_epsilon),
             mp.at_every(0.25, print_stuff),
@@ -35,7 +35,7 @@ def main():
             mp.at_end(mp.output_efield_z),
             until=23)
 
-    print("stopped at meep time = {}".format(sim._round_time()))
+    print("stopped at meep time = {}".format(sim.round_time()))
 
 
 if __name__ == '__main__':

--- a/python/meep.i
+++ b/python/meep.i
@@ -403,10 +403,21 @@ extern boolean point_in_objectp(vector3 p, GEOMETRIC_OBJECT o);
         in_volume,
         interpolate,
         output_epsilon,
+        output_mu,
+        output_hpwr,
+        output_dpwr,
+        output_tot_pwr,
         output_hfield_z,
         output_efield_z,
+        output_poynting,
+        output_poynting_x,
+        output_poynting_y,
+        output_poynting_z,
+        output_poynting_r,
+        output_poynting_p,
         py_v3_to_vec,
         stop_when_fields_decayed,
+        synchronized_magnetic,
         to_appended
     )
     from .source import (

--- a/python/tests/cyl_ellipsoid.py
+++ b/python/tests/cyl_ellipsoid.py
@@ -37,8 +37,8 @@ class TestCylEllipsoid(unittest.TestCase):
 
         def print_stuff(sim_obj):
             v = mp.Vector3(4.13, 3.75, 0)
-            p = self.sim._get_field_point(self.src_cmpt, v)
-            print("t, Ez: {} {}+{}i".format(self.sim._round_time(), p.real, p.imag))
+            p = self.sim.get_field_point(self.src_cmpt, v)
+            print("t, Ez: {} {}+{}i".format(self.sim.round_time(), p.real, p.imag))
         self.print_stuff = print_stuff
 
     def run_simulation(self):

--- a/python/tests/ring.py
+++ b/python/tests/ring.py
@@ -56,7 +56,7 @@ class TestRing(unittest.TestCase):
         self.assertAlmostEqual(m1.amp.real, -0.00304951667301, places=4)
         self.assertAlmostEqual(m1.amp.imag, -0.00153192946717, places=4)
 
-        fp = self.sim._get_field_point(mp.Ez, mp.Vector3(1, 1))
+        fp = self.sim.get_field_point(mp.Ez, mp.Vector3(1, 1))
         self.assertAlmostEqual(fp, -0.08185972142450348)
 
 if __name__ == '__main__':


### PR DESCRIPTION
These are a few requests from Ardavan.

* Remove `_` prefix from `get_field_point` and `round_time` to signify that they are public methods.
* Add some extra output convenience functions
* Add `synchronize_magnetic`

@stevengj @oskooi @HomerReid 