### PR TITLE
Fix failing wvg_src.py test

### DIFF
--- a/python/meep.i
+++ b/python/meep.i
@@ -462,6 +462,8 @@ meep::volume_list *make_volume_list(const meep::volume &v, int c,
 
 %rename(get_field_from_comp) meep::fields::get_field(component, const vec &) const;
 
+%feature("python:cdefaultargs") meep::fields::add_eigenmode_source;
+
 // TODO:  Fix these with a typemap when necessary
 %feature("immutable") meep::fields_chunk::connections;
 %feature("immutable") meep::fields_chunk::num_connections;


### PR DESCRIPTION
Fixes the issue reported by Ardavan.  I'm not sure why Travis didn't detect this, but the python shadow class for `fields` had a default argument in `add_eigenmode_source` for the amplitude function, `A=None`. SWIG wasn't handling the dispatching correctly, and since C++ has its own default for this argument, we want to let C++ handle it instead of python.
@stevengj @oskooi 