### PR TITLE
Add support for field functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,23 +67,15 @@ script:
   - make
 #
   - pushd tests
-  - make check TESTS=${CORETESTS} VERBOSE=1
+  - make check TESTS=${CORETESTS} VERBOSE=1 || cat ../../tests/test-suite.log
   - popd
 #
   - pushd libmeepgeom
-  - make check
+  - make check || cat ../../libmeepgeom/test-suite.log
   - popd
 #
   - pushd python
-  - make check
+  - make check || cat ../../python/tests/test-suite.log
   - popd
 #
   - popd
-
-##################################################
-##################################################
-##################################################
-after_failure:
-  - if [ -r test-suite.log ]; then cat test-suite.log; fi
-  - if [ -r tests/test-suite.log ]; then cat tests/test-suite.log; fi
-  - if [ -r python/test-suite.log ]; then cat python/test-suite.log; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ script:
   - popd
 #
   - pushd python
-  - make check || cat ../../python/tests/test-suite.log
+  - make check || cat ../../python/test-suite.log
   - popd
 #
   - popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,15 +67,15 @@ script:
   - make
 #
   - pushd tests
-  - make check TESTS=${CORETESTS} VERBOSE=1 || cat ../../tests/test-suite.log
+  - make check TESTS=${CORETESTS} VERBOSE=1 || cat test-suite.log
   - popd
 #
   - pushd libmeepgeom
-  - make check || cat ../../libmeepgeom/test-suite.log
+  - make check || cat test-suite.log
   - popd
 #
   - pushd python
-  - make check || cat ../../python/test-suite.log
+  - make check || cat test-suite.log
   - popd
 #
   - popd

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -35,6 +35,7 @@ TESTS =                                 \
     $(TEST_DIR)/bend_flux.py            \
     $(TEST_DIR)/cavity_arrayslice.py    \
     $(TEST_DIR)/cyl_ellipsoid.py        \
+    $(TEST_DIR)/field_functions.py      \
     $(TEST_DIR)/force.py                \
     $(TEST_DIR)/geom.py                 \
     $(TEST_DIR)/holey_wvg_bands.py      \

--- a/python/examples/metal-cavity-ldos.py
+++ b/python/examples/metal-cavity-ldos.py
@@ -1,7 +1,6 @@
 from __future__ import division
 
 import math
-
 import meep as mp
 import argparse
 

--- a/python/examples/metal-cavity-ldos.py
+++ b/python/examples/metal-cavity-ldos.py
@@ -1,6 +1,7 @@
 from __future__ import division
 
 import math
+
 import meep as mp
 import argparse
 

--- a/python/meep.i
+++ b/python/meep.i
@@ -51,8 +51,6 @@ typedef struct {
 PyObject *py_callback = NULL;
 PyObject *py_callback_v3 = NULL;
 PyObject *py_amp_func = NULL;
-PyObject *py_amp_func_v3 = NULL;
-PyObject *py_field_func_v3 = NULL;
 
 static PyObject *py_geometric_object();
 static PyObject *py_source_time_object();

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -764,19 +764,29 @@ class Simulation(object):
         self.fields.output_hdf5(name, cs + func, ov, h5, append, self.output_single_precision,
                                 self._get_filename_prefix(), real_only)
         if h5file is None:
-            self.output_h5_hook(self.fields.h5file_name(name, self._get_filename_prefix(), True)
+            self.output_h5_hook(self.fields.h5file_name(name, self._get_filename_prefix(), True))
 
     def get_where_and_fields(self, waf):
-        pass
+        f = waf[1] if len(waf) == 2 else self.fields
+
+        if f is None:
+            raise RuntimeError("Fields must be initialized before calling get_where_and_fields")
+
+        where = f.total_volume() if not waf else waf[0]
+
+        return where, f
 
     def integrate_field_function(self, cs, func, *where_and_fields):
-        pass
+        waf = self.get_where_and_fields(where_and_fields)
+        return waf[1].integrate([cs, func], waf[0])
 
     def integrate2_field_function(self, fields2, cs1, cs2, func, *where_and_fields):
-        pass
+        waf = self.get_where_and_fields(where_and_fields)
+        return waf[1].integrate(fields2, [cs1, cs2, func], waf[0])
 
     def max_abs_field_function(self, cs, func, *where_and_fields):
-        pass
+        waf = self.get_where_and_fields(where_and_fields)
+        return waf[1].max_abs([cs, func], waf[0])
 
     def change_k_point(self, k):
         self.k_point = k

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -774,6 +774,12 @@ class Simulation(object):
 
         where = f.total_volume() if not waf else waf[0]
 
+        if type(where) is Volume:
+            if self.is_cylindrical:
+                where = where.to_cylindrical().swigobj
+            else:
+                where = where.swigobj
+
         return where, f
 
     def integrate_field_function(self, cs, func, *where_and_fields):

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -761,7 +761,7 @@ class Simulation(object):
         h5 = self.output_append_h5 if h5file is None else h5file
         append = h5file is None and self.output_append_h5 is not None
 
-        self.fields.output_hdf5(name, cs + func, ov, h5, append, self.output_single_precision,
+        self.fields.output_hdf5(name, [cs, func], ov, h5, append, self.output_single_precision,
                                 self._get_filename_prefix(), real_only)
         if h5file is None:
             self.output_h5_hook(self.fields.h5file_name(name, self._get_filename_prefix(), True))

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -766,33 +766,20 @@ class Simulation(object):
         if h5file is None:
             self.output_h5_hook(self.fields.h5file_name(name, self._get_filename_prefix(), True))
 
-    def get_where_and_fields(self, waf):
-        f = waf[1] if len(waf) == 2 else self.fields
-
-        if f is None:
-            raise RuntimeError("Fields must be initialized before calling get_where_and_fields")
-
-        where = f.total_volume() if not waf else waf[0]
-
-        if type(where) is Volume:
-            if self.is_cylindrical:
-                where = where.to_cylindrical().swigobj
-            else:
-                where = where.swigobj
-
-        return where, f
-
-    def integrate_field_function(self, cs, func, *where_and_fields):
-        waf = self.get_where_and_fields(where_and_fields)
-        return waf[1].integrate([cs, func], waf[0])
+    def integrate_field_function(self, cs, func, where=None):
+        if where is None: where = self.fields.total_volume()
+        if self.is_cylindrical: where = where.to_cylindrical()
+        return self.fields.integrate([cs, func], where.swigobj)
 
     def integrate2_field_function(self, fields2, cs1, cs2, func, *where_and_fields):
-        waf = self.get_where_and_fields(where_and_fields)
-        return waf[1].integrate(fields2, [cs1, cs2, func], waf[0])
+        if where is None: where = self.fields.total_volume()
+        if self.is_cylindrical: where = where.to_cylindrical()
+        return self.fields.integrate(fields2, [cs1, cs2, func], where.swigobj)
 
     def max_abs_field_function(self, cs, func, *where_and_fields):
-        waf = self.get_where_and_fields(where_and_fields)
-        return waf[1].max_abs([cs, func], waf[0])
+        if where is None: where = self.fields.total_volume()
+        if self.is_cylindrical: where = where.to_cylindrical()
+        return self.fields.max_abs([cs, func], where.swigobj)
 
     def change_k_point(self, k):
         self.k_point = k

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -1178,7 +1178,6 @@ def dft_ldos(fcen, df, nfreq):
             sim.ldos_Fdata = mp._dft_ldos_F(ldos)
             sim.ldos_Jdata = mp._dft_ldos_J(ldos)
             display_csv(sim, 'ldos', zip(get_ldos_freqs(ldos), sim.ldos_data))
-
     return _ldos
 
 

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -1178,6 +1178,7 @@ def dft_ldos(fcen, df, nfreq):
             sim.ldos_Fdata = mp._dft_ldos_F(ldos)
             sim.ldos_Jdata = mp._dft_ldos_J(ldos)
             display_csv(sim, 'ldos', zip(get_ldos_freqs(ldos), sim.ldos_data))
+
     return _ldos
 
 

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -753,6 +753,31 @@ class Simulation(object):
 
         return arr
 
+    def output_field_function(self, name, cs, func, real_only=False, h5file=None):
+        if self.fields is None:
+            raise RuntimeError("Fields must be initialized before calling output_field_function")
+
+        ov = self.output_volume if self.output_volume else self.fields.total_volume()
+        h5 = self.output_append_h5 if h5file is None else h5file
+        append = h5file is None and self.output_append_h5 is not None
+
+        self.fields.output_hdf5(name, cs + func, ov, h5, append, self.output_single_precision,
+                                self._get_filename_prefix(), real_only)
+        if h5file is None:
+            self.output_h5_hook(self.fields.h5file_name(name, self._get_filename_prefix(), True)
+
+    def get_where_and_fields(self, waf):
+        pass
+
+    def integrate_field_function(self, cs, func, *where_and_fields):
+        pass
+
+    def integrate2_field_function(self, fields2, cs1, cs2, func, *where_and_fields):
+        pass
+
+    def max_abs_field_function(self, cs, func, *where_and_fields):
+        pass
+
     def change_k_point(self, k):
         self.k_point = k
 

--- a/python/tests/field_functions.py
+++ b/python/tests/field_functions.py
@@ -1,0 +1,47 @@
+import unittest
+
+import meep as mp
+
+
+class TestFieldFunctions(unittest.TestCase):
+
+    def setUp(self):
+        resolution = 20
+
+        cell = mp.Vector3(10, 10, 0)
+
+        pml_layers = mp.PML(1.0)
+
+        self.fcen = 1.0
+        df = 1.0
+
+        sources = mp.Source(src=mp.GaussianSource(self.fcen, fwidth=df), center=mp.Vector3(),
+                            component=mp.Ez)
+
+        symmetries = [mp.Mirror(mp.X), mp.Mirror(mp.Y)]
+
+        self.sim = mp.Simulation(resolution=resolution,
+                                 cell_size=cell,
+                                 boundary_layers=[pml_layers],
+                                 sources=[sources],
+                                 symmetries=symmetries)
+
+    def test_field_functions(self):
+        self.sim.run(until=200)
+
+        def f(r, ex, hz, eps):
+            return (r.x * r.norm() + ex) - (eps * hz)
+
+        cs = [mp.Ex, mp.Hz, mp.Dielectric]
+        res1 = self.sim.integrate_field_function(cs, f)
+        vol = mp.Volume(size=mp.Vector3(1), center=mp.Vector3())
+        res2 = self.sim.integrate_field_function(cs, f, vol)
+        res3 = self.sim.max_abs_field_function(cs, f, vol)
+
+        self.assertAlmostEqual(res1, complex(-6.938893903907228e-18, 0))
+        self.assertAlmostEqual(res2, complex(0, 0))
+        self.assertAlmostEqual(res3, 0.27593732304637586)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/tests/field_functions.py
+++ b/python/tests/field_functions.py
@@ -42,6 +42,8 @@ class TestFieldFunctions(unittest.TestCase):
         self.assertAlmostEqual(res1, complex(-6.938893903907228e-18, 0))
         self.assertAlmostEqual(res2, complex(0, 0))
 
+        self.sim.output_field_function("weird-function", self.cs, f)
+
     def test_max_abs_field_function(self):
         self.sim.run(until=200)
 

--- a/python/typemap_utils.cpp
+++ b/python/typemap_utils.cpp
@@ -21,10 +21,12 @@
     #define PyObject_ToCharPtr(n) PyUnicode_AsUTF8(n)
     #define PyInteger_Check(n) PyLong_Check(n)
     #define PyInteger_AsLong(n) PyLong_AsLong(n)
+    #define PyInteger_FromLong(n) PyLong_FromLong(n)
 #else
     #define PyObject_ToCharPtr(n) PyString_AsString(n)
     #define PyInteger_Check(n) PyInt_Check(n)
     #define PyInteger_AsLong(n) PyInt_AsLong(n)
+    #define PyInteger_FromLong(n) PyInt_FromLong(n)
 #endif
 
 static PyObject *py_geometric_object() {
@@ -67,36 +69,7 @@ static PyObject *py_material_object() {
     return material_object;
 }
 
-// v3 is a global python Vector3 object. We currently need one for the material
-// function and one for the amplitude function, so we pass it in from vec2py
-static void set_py_v3(double x, double y, double z, PyObject **v3) {
-    if (*v3 == NULL) {
-        PyObject *geom_mod = PyImport_ImportModule("meep.geom");
-        PyObject *v3_class = PyObject_GetAttrString(geom_mod, "Vector3");
-        PyObject *args = PyTuple_New(0);
-        *v3 = PyObject_Call(v3_class, args, NULL);
-
-        Py_DECREF(args);
-        Py_DECREF(geom_mod);
-        Py_DECREF(v3_class);
-    }
-
-    PyObject *pyx = PyFloat_FromDouble(x);
-    PyObject *pyy = PyFloat_FromDouble(y);
-    PyObject *pyz = PyFloat_FromDouble(z);
-
-    PyObject_SetAttrString(*v3, "x", pyx);
-    PyObject_SetAttrString(*v3, "y", pyy);
-    PyObject_SetAttrString(*v3, "z", pyz);
-
-    Py_DECREF(pyx);
-    Py_DECREF(pyy);
-    Py_DECREF(pyz);
-
-    return;
-}
-
-static PyObject* vec2py(const meep::vec &v, bool amp_func) {
+static PyObject* vec2py(const meep::vec &v) {
 
     double x = 0, y = 0, z = 0;
 
@@ -119,13 +92,30 @@ static PyObject* vec2py(const meep::vec &v, bool amp_func) {
         break;
     }
 
-    if (!amp_func) {
-        set_py_v3(x, y, z, &py_callback_v3);
-        return py_callback_v3;
-    } else {
-        set_py_v3(x, y, z, &py_amp_func_v3);
-        return py_amp_func_v3;
+    if (py_callback_v3 == NULL) {
+        PyObject *geom_mod = PyImport_ImportModule("meep.geom");
+        PyObject *v3_class = PyObject_GetAttrString(geom_mod, "Vector3");
+        PyObject *args = PyTuple_New(0);
+        py_callback_v3 = PyObject_Call(v3_class, args, NULL);
+
+        Py_DECREF(args);
+        Py_DECREF(geom_mod);
+        Py_DECREF(v3_class);
     }
+
+    PyObject *pyx = PyFloat_FromDouble(x);
+    PyObject *pyy = PyFloat_FromDouble(y);
+    PyObject *pyz = PyFloat_FromDouble(z);
+
+    PyObject_SetAttrString(py_callback_v3, "x", pyx);
+    PyObject_SetAttrString(py_callback_v3, "y", pyy);
+    PyObject_SetAttrString(py_callback_v3, "z", pyz);
+
+    Py_DECREF(pyx);
+    Py_DECREF(pyy);
+    Py_DECREF(pyz);
+
+    return py_callback_v3;
 }
 
 static double py_callback_wrap(const meep::vec &v) {
@@ -137,12 +127,44 @@ static double py_callback_wrap(const meep::vec &v) {
 }
 
 static std::complex<double> py_amp_func_wrap(const meep::vec &v) {
-    PyObject *pyv = vec2py(v, true);
+    PyObject *pyv = vec2py(v);
     PyObject *pyret = PyObject_CallFunctionObjArgs(py_amp_func, pyv, NULL);
     double real = PyComplex_RealAsDouble(pyret);
     double imag = PyComplex_ImagAsDouble(pyret);
     std::complex<double> ret(real, imag);
     Py_DECREF(pyret);
+    return ret;
+}
+
+static std::complex<double> py_field_func_wrap(const std::complex<double> *fields,
+                                               const meep::vec &loc,
+                                               void *data_) {
+    PyObject *pyv = vec2py(loc);
+
+    py_field_func_data *data = (py_field_func_data *)data_;
+    int len = data->num_components;
+
+    PyObject *py_args = PyTuple_New(len + 1);
+    // Increment here because PyTuple_SetItem steals a reference
+    Py_INCREF(pyv);
+    PyTuple_SetItem(py_args, 0, pyv);
+
+    for (Py_ssize_t i = 1; i < len + 1; i++) {
+        PyObject *cmplx = PyComplex_FromDoubles(fields[i].real(), fields[i].imag());
+        PyTuple_SetItem(py_args, i, cmplx);
+    }
+
+    PyObject *pyret = PyObject_CallObject(data->func, py_args);
+
+    if (!pyret) {
+        PyErr_PrintEx(0);
+    }
+
+    double real = PyComplex_RealAsDouble(pyret);
+    double imag = PyComplex_ImagAsDouble(pyret);
+    std::complex<double> ret(real, imag);
+    Py_DECREF(pyret);
+    Py_DECREF(py_args);
     return ret;
 }
 


### PR DESCRIPTION
* Added test for `integrate_field_function`, `output_field_function`, and `max_abs_field_function`.
* Still need a test for `integrate2_field_function`. I'll probably need a scheme example.
* Reusing the same global `Vector3` instead of having a separate one for material funcs, amplitude funcs, and field funcs.

@stevengj @oskooi @HomerReid 