### PR TITLE
Only print on master node in MPI mode

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -221,7 +221,7 @@ RUNCODE=""
 if test "x$with_mpi" = "xyes"; then
    AC_CHECK_PROG(MPIRUN, mpirun, mpirun)
    # always use 2 processes for 'make check'
-   RUNCODE="$MPIRUN -np 2 --verbose -output-filename mpirun.out --timestamp-output" 
+   RUNCODE="$MPIRUN -np 2"
 fi
 AC_SUBST(RUNCODE)
 AM_CONDITIONAL(WITH_MPI, test "x$with_mpi" = "xyes")

--- a/python/meep.i
+++ b/python/meep.i
@@ -577,11 +577,4 @@ extern boolean point_in_objectp(vector3 p, GEOMETRIC_OBJECT o);
                 import sys
                 saved_stdout = sys.stdout
                 sys.stdout = open(os.devnull, 'w')
-
-            import atexit
-
-            @atexit.register
-            def close_dev_null():
-                if comm.Get_rank() != 0:
-                    sys.stdout.close()
 %}

--- a/python/meep.i
+++ b/python/meep.i
@@ -573,8 +573,15 @@ extern boolean point_in_objectp(vector3 p, GEOMETRIC_OBJECT o);
             master_printf('\n**\n** successfully loaded python MPI module (mpi4py)\n**\n')
 
             if comm.Get_rank() != 0:
+                import os
                 import sys
                 saved_stdout = sys.stdout
-                sys.stdout = None
-                del sys
+                sys.stdout = open(os.devnull, 'w')
+
+            import atexit
+
+            @atexit.register
+            def close_dev_null():
+                if comm.Get_rank() != 0:
+                    sys.stdout.close()
 %}

--- a/python/meep.i
+++ b/python/meep.i
@@ -571,4 +571,12 @@ extern boolean point_in_objectp(vector3 p, GEOMETRIC_OBJECT o);
             # this variable reference is needed for lazy initialization of MPI
             comm = MPI.COMM_WORLD
             master_printf('\n**\n** successfully loaded python MPI module (mpi4py)\n**\n')
+
+            if comm.Get_rank() != 0:
+                import sys
+                saved_stdout = sys.stdout
+                saved_stderr = sys.stderr
+                sys.stdout = None
+                sys.stderr = None
+                del sys
 %}

--- a/python/meep.i
+++ b/python/meep.i
@@ -575,8 +575,6 @@ extern boolean point_in_objectp(vector3 p, GEOMETRIC_OBJECT o);
             if comm.Get_rank() != 0:
                 import sys
                 saved_stdout = sys.stdout
-                saved_stderr = sys.stderr
                 sys.stdout = None
-                sys.stderr = None
                 del sys
 %}

--- a/python/tests/cyl_ellipsoid.py
+++ b/python/tests/cyl_ellipsoid.py
@@ -1,4 +1,4 @@
-from __future__ import division
+from __future__ import division, print_function
 
 import unittest
 import meep as mp

--- a/python/tests/cyl_ellipsoid.py
+++ b/python/tests/cyl_ellipsoid.py
@@ -1,4 +1,4 @@
-from __future__ import division, print_function
+from __future__ import division
 
 import unittest
 import meep as mp

--- a/python/tests/physical.py
+++ b/python/tests/physical.py
@@ -13,8 +13,6 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program if not, write to the Free Software Foundation,
 #  Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
-from __future__ import print_function
-
 import unittest
 
 import meep as mp

--- a/python/tests/physical.py
+++ b/python/tests/physical.py
@@ -13,6 +13,7 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program if not, write to the Free Software Foundation,
 #  Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+from __future__ import print_function
 
 import unittest
 


### PR DESCRIPTION
* Removed the `mpirun` flags that are specific to OpenMPI (anaconda uses MPICH).
* Python 2 files that call `print` in MPI mode will need `from __future__ import print_function` at the top.

@stevengj @oskooi @HomerReid 