### PR TITLE
Fix TODOs and warnings

### DIFF
--- a/python/meep.i
+++ b/python/meep.i
@@ -52,7 +52,6 @@ PyObject *py_callback = NULL;
 PyObject *py_callback_v3 = NULL;
 PyObject *py_amp_func = NULL;
 
-static PyObject *py_geometric_object();
 static PyObject *py_source_time_object();
 static PyObject *py_material_object();
 static PyObject* vec2py(const meep::vec &v);
@@ -88,13 +87,13 @@ double py_pml_profile(double u, void *f) {
     PyObject *func = (PyObject *)f;
     PyObject *d = PyFloat_FromDouble(u);
 
-    if(!PyCallable_Check(func)) {
-        PyErr_SetString(PyExc_TypeError, "py_pml_profile: Object is not callable");
-        // TODO(chogan): Fix this error handling.
-        throw;
+    if (!PyCallable_Check(func)) {
+        PyErr_SetString(PyExc_TypeError, "py_pml_profile: Expected a callable");
+        PyErr_Print();
     }
 
     PyObject *pyret = PyObject_CallFunctionObjArgs(func, d, NULL);
+
     double ret = PyFloat_AsDouble(pyret);
     Py_XDECREF(pyret);
     Py_XDECREF(d);
@@ -285,10 +284,6 @@ meep::volume_list *make_volume_list(const meep::volume &v, int c,
 }
 
 // Typemap suite for GEOMETRIC_OBJECT
-
-%typecheck(SWIG_TYPECHECK_POINTER) GEOMETRIC_OBJECT {
-    $1 = PyObject_IsInstance($input, py_geometric_object());
-}
 
 %typemap(in) GEOMETRIC_OBJECT {
     if(!py_gobj_to_gobj($input, &$1)) {

--- a/python/typemap_utils.cpp
+++ b/python/typemap_utils.cpp
@@ -29,16 +29,6 @@
     #define PyInteger_FromLong(n) PyInt_FromLong(n)
 #endif
 
-static PyObject *py_geometric_object() {
-    static PyObject *geometric_object = NULL;
-    if (geometric_object == NULL) {
-        PyObject *geom_mod = PyImport_ImportModule("meep.geom");
-        geometric_object = PyObject_GetAttrString(geom_mod, "GeometricObject");
-        Py_XDECREF(geom_mod);
-    }
-    return geometric_object;
-}
-
 static PyObject *py_source_time_object() {
     static PyObject *source_time_object = NULL;
     if (source_time_object == NULL) {

--- a/python/vec.i
+++ b/python/vec.i
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2017 Massachusetts Institute of Technology  
+/* Copyright (C) 2005-2017 Massachusetts Institute of Technology
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -18,9 +18,6 @@
 
 // 322:  Redundant declarations are ok. The wrappers are created correctly.
 // 503:  We don't need to create class-specific wrappers for friend functions
-// TODO: Check all 509's individually.
-// TODO: Move warnfilters to separate 'warnings.i' file.
-%warnfilter(509);
 %warnfilter(322,509) meep::component_direction;
 %warnfilter(322,509) meep::direction_component;
 %warnfilter(322,503) meep::zero_vec;
@@ -28,6 +25,7 @@
 %warnfilter(322,503) meep::zero_ivec;
 %warnfilter(322,503) meep::one_ivec;
 %warnfilter(322,503) meep::iveccyl;
+%warnfilter(322) meep::abort;
 %warnfilter(503) meep::one_vec;
 %warnfilter(503) meep::volcyl;
 %warnfilter(503) meep::volone;
@@ -45,7 +43,9 @@
 %warnfilter(509) meep::ivec::ivec;
 %warnfilter(509) meep::symmetry::transform;
 %warnfilter(509) meep::symmetry::phase_shift;
-
+%warnfilter(509) meep::structure::structure;
+%warnfilter(451) meep::structure::outdir;
+%warnfilter(451) meep::fields_chunk::outdir;
 
 // Renaming python builtins
 %rename(meep_type) meep::type;
@@ -56,9 +56,8 @@
 %rename(symmetry_reduce) meep::symmetry::reduce;
 
 // Operator renaming
-// TODO: Test these
-%rename(volume_and) meep::volume::operator&&;
-%rename(grid_volume_getitem) meep::grid_volume::operator[];
+%rename(__contains__) meep::volume::operator&&;
+%rename(__getitem__) meep::grid_volume::operator[];
 %rename(symmetry_assign) meep::symmetry::operator=;
 
 %rename(vec_from_dim) meep::vec::vec(ndim, double);


### PR DESCRIPTION
* Ignore benign SWIG warnings.
* Finish all "TODO"s except for adding adaptive_integration.
* Remove `py_geometric_object`. Since no function accepting a `GEOMETRIC_OBJECT` takes default args, SWIG doesn't generate a dispatch function, which means the typecheck is never used.

@stevengj @oskooi 