### PR TITLE
Quote list of tests to run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ script:
   - make -j 2
 #
   - pushd tests
-  - make ${MKCHECKFLAGS} check TESTS=${CORETESTS} VERBOSE=1 || (cat test-suite.log && exit 1)
+  - make ${MKCHECKFLAGS} check TESTS="${CORETESTS}" VERBOSE=1 || (cat test-suite.log && exit 1)
   - popd
 #
   - pushd libmeepgeom


### PR DESCRIPTION
Since `CORETESTS` is a list of strings separated by white space, it has to be quoted. Travis was just running the first test in the list and skipping the rest.
@stevengj @oskooi @HomerReid 