### PR TITLE
Fix volume bug and add test

### DIFF
--- a/python/simulation.py
+++ b/python/simulation.py
@@ -750,7 +750,7 @@ class Simulation(object):
         if self.fields is None:
             raise RuntimeError("Fields must be initialized before calling output_component")
 
-        vol = self.fields.total_volume() if self.output_volume is None else self.output_volume.swigobj
+        vol = self.fields.total_volume() if self.output_volume is None else self.output_volume
         h5 = self.output_append_h5 if h5file is None else h5file
         append = h5file is None and self.output_append_h5 is not None
 
@@ -822,7 +822,7 @@ class Simulation(object):
         if self.fields is None:
             raise RuntimeError("Fields must be initialized before calling output_field_function")
 
-        ov = self.output_volume.swigobj if self.output_volume else self.fields.total_volume()
+        ov = self.output_volume if self.output_volume else self.fields.total_volume()
         h5 = self.output_append_h5 if h5file is None else h5file
         append = h5file is None and self.output_append_h5 is not None
 

--- a/python/tests/simulation.py
+++ b/python/tests/simulation.py
@@ -179,5 +179,11 @@ class TestSimulation(unittest.TestCase):
         sim._init_structure(k=mp.Vector3())
         self.assertEqual(sim.structure.gv.dim, mp.D2)
 
+    def test_in_volume(self):
+        sim = self.init_simple_simulation()
+        sim.filename_prefix = 'test_in_volume'
+        vol = mp.Volume(mp.Vector3(), size=mp.Vector3(x=2))
+        sim.run(mp.at_end(mp.in_volume(vol, mp.output_efield_z)), until=200)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Everything that sets `self.output_volume` already sets it as the swig object, so `output_component` and `output_field_function` can use it directly.
@stevengj @oskooi 