### PR TITLE
Remove dead make targets

### DIFF
--- a/libmeepgeom/Makefile.am
+++ b/libmeepgeom/Makefile.am
@@ -42,7 +42,4 @@ bend_flux_ll_LDADD   = libmeepgeom.la $(MEEPLIBS)
 user_defined_material_SOURCES = user-defined-material.cpp
 user_defined_material_LDADD   = libmeepgeom.la $(MEEPLIBS)
 
-file_material_SOURCES = file-material.cpp
-file_material_LDADD   = libmeepgeom.la $(MEEPLIBS)
-
 noinst_DATA = cyl-ellipsoid-eps-ref.h5 array-slice-ll.h5


### PR DESCRIPTION
I noticed automake complaining about these lines.  Can they be removed, or does `file-material.cpp` need to be added to the project?
@HomerReid 