### PR TITLE
add components_allocated flag to track whether fields are allocated

### DIFF
--- a/src/dft.cpp
+++ b/src/dft.cpp
@@ -170,6 +170,12 @@ dft_chunk *fields::add_dft(component c, const volume &where,
   if (coordinate_mismatch(gv.dim, c))
     return NULL;
 
+  /* If you call add_dft before adding sources, it will do nothing
+     since no fields will be found.   This is almost certainly not
+     what the user wants. */
+  if (!components_allocated)
+    abort("allocate field components (by adding sources) before adding dft objects");
+
   dft_chunk_data data;  
   data.c = c;
   data.vc = vc;

--- a/src/fields.cpp
+++ b/src/fields.cpp
@@ -32,6 +32,7 @@ fields::fields(structure *s, double m, double beta,
   S(s->S), gv(s->gv), user_volume(s->user_volume), v(s->v), m(m), beta(beta)
 {
   verbosity = 0;
+  components_allocated = false;
   synchronized_magnetic_fields = 0;
   outdir = new char[strlen(s->outdir) + 1]; strcpy(outdir, s->outdir);
   if (gv.dim == Dcyl)
@@ -83,6 +84,7 @@ fields::fields(const fields &thef) :
   S(thef.S), gv(thef.gv), user_volume(thef.user_volume), v(thef.v)
 {
   verbosity = 0;
+  components_allocated = thef.components_allocated;
   synchronized_magnetic_fields = thef.synchronized_magnetic_fields;
   outdir = new char[strlen(thef.outdir) + 1]; strcpy(outdir, thef.outdir);
   m = thef.m;
@@ -456,6 +458,8 @@ void fields::require_component(component c) {
 
   if (beta != 0 && gv.dim != D2)
     abort("Nonzero beta unsupported in dimensions other than 2.");
+
+  components_allocated = true;
 
   // check if we are in 2d but anisotropy couples xy with z
   bool aniso2d = false;

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1215,6 +1215,7 @@ class fields {
   double coskna[5], sinkna[5];
   boundary_condition boundaries[2][5];
   char *outdir;
+  bool components_allocated;
 
   // fields.cpp methods:
   fields(structure *, double m=0, double beta=0,


### PR DESCRIPTION
to catch bugs where user calls `add_flux` before adding any sources.