### PR TITLE
Fix source distribution and run make distcheck in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,10 +76,11 @@ script:
 #
   - pushd python
   - make ${MKCHECKFLAGS} check || (cat test-suite.log && exit 1)
+  - make clean
   - popd
 #
   # Only run distcheck in nightly builds because it doubles the build time
   # - if [ "${TRAVIS_EVENT_TYPE}" == cron ]; then make distcheck DISTCHECK_CONFIGURE_FLAGS="--with-libctl=${HOME}/local/share/libctl"; fi
 
-  - make distcheck DISTCHECK_CONFIGURE_FLAGS="--with-libctl=${HOME}/local/share/libctl"
+  - make ${MKCHECKFLAGS} distcheck DISTCHECK_CONFIGURE_FLAGS="--with-libctl=${HOME}/local/share/libctl ${MPICONF}"
   - popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,4 +78,8 @@ script:
   - make ${MKCHECKFLAGS} check || (cat test-suite.log && exit 1)
   - popd
 #
+  # Only run distcheck in nightly builds because it doubles the build time
+  # - if [ "${TRAVIS_EVENT_TYPE}" == cron ]; then make distcheck DISTCHECK_CONFIGURE_FLAGS="--with-libctl=${HOME}/local/share/libctl"; fi
+
+  - make distcheck DISTCHECK_CONFIGURE_FLAGS="--with-libctl=${HOME}/local/share/libctl"
   - popd

--- a/libmeepgeom/Makefile.am
+++ b/libmeepgeom/Makefile.am
@@ -43,3 +43,6 @@ user_defined_material_SOURCES = user-defined-material.cpp
 user_defined_material_LDADD   = libmeepgeom.la $(MEEPLIBS)
 
 dist_noinst_DATA = cyl-ellipsoid-eps-ref.h5 array-slice-ll.h5
+
+distclean-local:
+	rm -f eps-000000000.h5

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -1,5 +1,3 @@
-SWIG_SRC = meep.i numpy.i vec.i
-EXTRA_DIST = $(SWIG_SRC)
 HPPFILES=                                    \
  $(top_srcdir)/src/meep_internals.hpp        \
  $(top_srcdir)/src/bicgstab.hpp              \
@@ -8,9 +6,10 @@ HPPFILES=                                    \
  $(top_srcdir)/libmeepgeom/meepgeom.hpp      \
  $(top_srcdir)/libmeepgeom/material_data.hpp
 
-BUILT_SOURCES = meep-python.cpp meep.py __init__.py
+BUILT_SOURCES = meep-python.cpp __init__.py
+EXTRA_DIST = $(BUILT_SOURCES) typemap_utils.cpp examples tests
 
-CLEANFILES = $(BUILT_SOURCES) meep-python.h
+CLEANFILES = $(BUILT_SOURCES) meep.py
 
 AM_CPPFLAGS = -I$(top_srcdir)/src                   \
               -I$(top_srcdir)/libmeepgeom           \
@@ -63,12 +62,7 @@ endif
 
 if MAINTAINER_MODE
 
-PY_PKG_FILES =               \
-    __init__.py              \
-    $(srcdir)/geom.py        \
-    $(srcdir)/simulation.py  \
-    $(srcdir)/source.py      \
-    .libs/_meep.so
+SWIG_SRC = meep.i numpy.i vec.i
 
 meep-python.cpp: $(SWIG_SRC) $(HPPFILES)
 	swig -Wextra $(AM_CPPFLAGS) -outdir $(builddir) -c++ -python -o $@ $(srcdir)/meep.i
@@ -78,13 +72,29 @@ meep.py: meep-python.cpp
 __init__.py: meep.py
 	cp $< $@
 
-pymeep: _meep.la __init__.py
-	test -d meep || mkdir meep
+INIT_PY = __init__.py
+
+else
+
+INIT_PY = $(srcdir)/__init__.py
+
+endif # MAINTAINER_MODE
+
+PY_PKG_FILES =               \
+    $(INIT_PY)               \
+    $(srcdir)/geom.py        \
+    $(srcdir)/simulation.py  \
+    $(srcdir)/source.py      \
+    .libs/_meep.so
+
+meep: _meep.la __init__.py
+	mkdir -p meep
 	cp $(PY_PKG_FILES) meep
 
-all-local: pymeep
+all-local: meep
 
 clean-local:
 	rm -rf meep
 
-endif # MAINTAINER_MODE
+distclean-local:
+	rm -f *.h5

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -99,3 +99,6 @@ dac: $(DAC)
 
 clean-local::
 	rm -f *.o *.dac debug_out_* *.done
+
+distclean-local:
+	rm -f *.h5


### PR DESCRIPTION
These are the changes required for `make distcheck` to work. Travis will now run `make distcheck` so we can catch distribution bugs earlier. However, since that would double the build times, we only want Travis to do this once per day, not every commit. After this is green and approved, but before merging, I'll set Travis to only run `make distcheck`  if `[ "${TRAVIS_EVENT_TYPE}" == cron ]`. Then Steven can add a daily cron job in the Travis settings.
@stevengj @oskooi @HomerReid 