### PR TITLE
Only run make distcheck. Alternative to PR #183

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,10 +76,11 @@ script:
 #
   - pushd python
   - make ${MKCHECKFLAGS} check || (cat test-suite.log && exit 1)
+  - make clean
   - popd
 #
   # Only run distcheck in nightly builds because it doubles the build time
   # - if [ "${TRAVIS_EVENT_TYPE}" == cron ]; then make distcheck DISTCHECK_CONFIGURE_FLAGS="--with-libctl=${HOME}/local/share/libctl"; fi
 
-  - make distcheck DISTCHECK_CONFIGURE_FLAGS="--with-libctl=${HOME}/local/share/libctl"
+  - make ${MKCHECKFLAGS} distcheck DISTCHECK_CONFIGURE_FLAGS="--with-libctl=${HOME}/local/share/libctl ${MPICONF}"
   - popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,4 +78,8 @@ script:
   - make ${MKCHECKFLAGS} check || (cat test-suite.log && exit 1)
   - popd
 #
+  # Only run distcheck in nightly builds because it doubles the build time
+  # - if [ "${TRAVIS_EVENT_TYPE}" == cron ]; then make distcheck DISTCHECK_CONFIGURE_FLAGS="--with-libctl=${HOME}/local/share/libctl"; fi
+
+  - make distcheck DISTCHECK_CONFIGURE_FLAGS="--with-libctl=${HOME}/local/share/libctl"
   - popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,7 @@ script:
   - popd
 #
   # Only run distcheck in nightly builds because it doubles the build time
-  # - if [ "${TRAVIS_EVENT_TYPE}" == cron ]; then make distcheck DISTCHECK_CONFIGURE_FLAGS="--with-libctl=${HOME}/local/share/libctl"; fi
+  # - if [ "${TRAVIS_EVENT_TYPE}" == cron ]; then make ${MKCHECKFLAGS} distcheck DISTCHECK_CONFIGURE_FLAGS="--with-libctl=${HOME}/local/share/libctl ${MPICONF}"; fi
 
   - make ${MKCHECKFLAGS} distcheck DISTCHECK_CONFIGURE_FLAGS="--with-libctl=${HOME}/local/share/libctl ${MPICONF}"
   - popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,28 +59,7 @@ matrix:
 # build/test instructions
 ##################################################
 script:
-  - set -e
   - autoreconf --verbose --install --symlink --force
   - mkdir -p build && pushd build
-#
   - ../configure --enable-maintainer-mode --prefix=$HOME/local --with-libctl=$HOME/local/share/libctl ${MPICONF}
-  - make -j 2
-#
-  - pushd tests
-  - make ${MKCHECKFLAGS} check TESTS="${CORETESTS}" VERBOSE=1 || (cat test-suite.log && exit 1)
-  - popd
-#
-  - pushd libmeepgeom
-  - make ${MKCHECKFLAGS} check || (cat test-suite.log && exit 1)
-  - popd
-#
-  - pushd python
-  - make ${MKCHECKFLAGS} check || (cat test-suite.log && exit 1)
-  - make clean
-  - popd
-#
-  # Only run distcheck in nightly builds because it doubles the build time
-  # - if [ "${TRAVIS_EVENT_TYPE}" == cron ]; then make ${MKCHECKFLAGS} distcheck DISTCHECK_CONFIGURE_FLAGS="--with-libctl=${HOME}/local/share/libctl ${MPICONF}"; fi
-
   - make ${MKCHECKFLAGS} distcheck DISTCHECK_CONFIGURE_FLAGS="--with-libctl=${HOME}/local/share/libctl ${MPICONF}"
-  - popd

--- a/libmeepgeom/Makefile.am
+++ b/libmeepgeom/Makefile.am
@@ -43,3 +43,6 @@ user_defined_material_SOURCES = user-defined-material.cpp
 user_defined_material_LDADD   = libmeepgeom.la $(MEEPLIBS)
 
 dist_noinst_DATA = cyl-ellipsoid-eps-ref.h5 array-slice-ll.h5
+
+distclean-local:
+	rm -f eps-000000000.h5

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -1,5 +1,3 @@
-SWIG_SRC = meep.i numpy.i vec.i
-EXTRA_DIST = $(SWIG_SRC)
 HPPFILES=                                    \
  $(top_srcdir)/src/meep_internals.hpp        \
  $(top_srcdir)/src/bicgstab.hpp              \
@@ -8,9 +6,10 @@ HPPFILES=                                    \
  $(top_srcdir)/libmeepgeom/meepgeom.hpp      \
  $(top_srcdir)/libmeepgeom/material_data.hpp
 
-BUILT_SOURCES = meep-python.cpp meep.py __init__.py
+BUILT_SOURCES = meep-python.cpp __init__.py
+EXTRA_DIST = $(BUILT_SOURCES) typemap_utils.cpp examples tests
 
-CLEANFILES = $(BUILT_SOURCES) meep-python.h
+CLEANFILES = $(BUILT_SOURCES) meep.py
 
 AM_CPPFLAGS = -I$(top_srcdir)/src                   \
               -I$(top_srcdir)/libmeepgeom           \
@@ -63,12 +62,7 @@ endif
 
 if MAINTAINER_MODE
 
-PY_PKG_FILES =               \
-    __init__.py              \
-    $(srcdir)/geom.py        \
-    $(srcdir)/simulation.py  \
-    $(srcdir)/source.py      \
-    .libs/_meep.so
+SWIG_SRC = meep.i numpy.i vec.i
 
 meep-python.cpp: $(SWIG_SRC) $(HPPFILES)
 	swig -Wextra $(AM_CPPFLAGS) -outdir $(builddir) -c++ -python -o $@ $(srcdir)/meep.i
@@ -78,13 +72,29 @@ meep.py: meep-python.cpp
 __init__.py: meep.py
 	cp $< $@
 
-pymeep: _meep.la __init__.py
-	test -d meep || mkdir meep
+INIT_PY = __init__.py
+
+else
+
+INIT_PY = $(srcdir)/__init__.py
+
+endif # MAINTAINER_MODE
+
+PY_PKG_FILES =               \
+    $(INIT_PY)               \
+    $(srcdir)/geom.py        \
+    $(srcdir)/simulation.py  \
+    $(srcdir)/source.py      \
+    .libs/_meep.so
+
+meep: _meep.la __init__.py
+	mkdir -p meep
 	cp $(PY_PKG_FILES) meep
 
-all-local: pymeep
+all-local: meep
 
 clean-local:
 	rm -rf meep
 
-endif # MAINTAINER_MODE
+distclean-local:
+	rm -f *.h5

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -99,3 +99,6 @@ dac: $(DAC)
 
 clean-local::
 	rm -f *.o *.dac debug_out_* *.done
+
+distclean-local:
+	rm -f *.h5


### PR DESCRIPTION
Here is a version of #183 that runs `make distcheck` instead of `make` and `make check`. 

### Advantages
1. Code that breaks the source distribution will never make it to master.
2. .travis.yml file is simpler.
3. Don't need a separate nightly build
### Disadvantages
1. We lose the ability to customize `make check`, which means CI times will be slightly longer.
2. We can't display `test-suite.log` on a failure because the build directory is non-deterministic. From the automake manual:
> [The `make distcheck`] actions are performed in a temporary directory. Please note that the exact location and the exact structure of such a directory (where the read-only sources are placed, how the temporary build and install directories are named and how deeply they are nested, etc.) is to be considered an implementation detail, which can change at any time; so do not reply on it.

I'm fine with this if we can get around disadvantage 2. I guess I could just ignore the advice and "rely" on the build directory being `build/meep-1.4.1/_build`, which is what the logs show (although when I build locally it's `build/meep-1.4.1/_build/sub` instead). Seems error prone.
@stevengj @oskooi @HomerReid 