### PR TITLE
Workaround for SWIG 3.0.12 import handling

### DIFF
--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -62,15 +62,22 @@ endif
 
 if MAINTAINER_MODE
 
+SWIG ?= swig
 SWIG_SRC = meep.i numpy.i vec.i
+SWIG_VERSION = $(shell $(SWIG) -version | grep Version | awk '{print $$3}')
 
 meep-python.cpp: $(SWIG_SRC) $(HPPFILES)
-	swig -Wextra $(AM_CPPFLAGS) -outdir $(builddir) -c++ -python -o $@ $(srcdir)/meep.i
+	$(SWIG) -Wextra $(AM_CPPFLAGS) -outdir $(builddir) -c++ -python -o $@ $(srcdir)/meep.i
 
 meep.py: meep-python.cpp
 
 __init__.py: meep.py
 	cp $< $@
+	if [[ "${SWIG_VERSION}" = 3.0.12 ]]; then \
+		sed -i '/^if _swig_python_version_info >= (2, 7, 0):/,/^else:/d' $@; \
+		sed -i 's/    import _meep/from . import _meep/' $@; \
+	fi
+
 
 INIT_PY = __init__.py
 


### PR DESCRIPTION
This works around a [SWIG import issue](https://github.com/swig/swig/issues/769) by replacing the complicated import code meant to support old python versions with a simple `from . import _meep`. Let me know if you think it's worth supporting 3.0.9, 3.0.10, and 3.0.11 as well.  I'd have to install and test the three versions and likely adjust the `sed` commands. Most people should be on 3.0.8 (ubuntu 16.04) or the latest 3.0.12.
@stevengj @oskooi @HomerReid 