### PR TITLE
Portable sed commands

### DIFF
--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -74,8 +74,8 @@ meep.py: meep-python.cpp
 __init__.py: meep.py
 	cp $< $@
 	if [[ "${SWIG_VERSION}" = 3.0.12 ]]; then \
-		sed -i "" '/^if _swig_python_version_info >= (2, 7, 0):/,/^else:/d' $@; \
-		sed -i "" 's/    import _meep/from . import _meep/' $@; \
+		sed -i.bak '/^if _swig_python_version_info >= (2, 7, 0):/,/^else:/d' $@; \
+		sed -i.bak 's/    import _meep/from . import _meep/' $@; \
 	fi
 
 

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -101,7 +101,7 @@ meep: _meep.la __init__.py
 all-local: meep
 
 clean-local:
-	rm -rf meep
+	rm -rf meep __init__.py.bak
 
 distclean-local:
 	rm -f *.h5


### PR DESCRIPTION
Travis didn't catch this because it doesn't use SWIG 3.0.12. Creating a backup file seems to be the only portable way of doing it.
@stevengj @oskooi 