### PR TITLE
Fix 2d Absorbers

### DIFF
--- a/libmeepgeom/meepgeom.cpp
+++ b/libmeepgeom/meepgeom.cpp
@@ -1436,14 +1436,13 @@ void destroy_absorber_list(absorber_list alist)
 
 void add_absorbing_layer(absorber_list alist,
                          double thickness, int direction, int side,
-                         double strength, double R_asymptotic, double mean_stretch,
+                         double R_asymptotic, double mean_stretch,
                          meep::pml_profile_func func, void *func_data)
 {
   absorber myabsorber;
   myabsorber.thickness=thickness;
   myabsorber.direction=direction;
   myabsorber.side=side;
-  myabsorber.strength=strength;
   myabsorber.R_asymptotic=R_asymptotic;
   myabsorber.mean_stretch=mean_stretch;
   myabsorber.pml_profile=func;
@@ -1525,7 +1524,7 @@ void set_materials_from_geometry(meep::structure *s,
               mythunk.func_data = layer->pml_profile_data;
               geps.set_cond_profile(d,b,layer->thickness, gv.inva*0.5,
                                     pml_profile_wrapper, (void *)&mythunk,
-                                    pow(layer->R_asymptotic,layer->strength));
+                                    layer->R_asymptotic);
             };
          };
       };

--- a/libmeepgeom/meepgeom.hpp
+++ b/libmeepgeom/meepgeom.hpp
@@ -65,7 +65,6 @@ typedef struct absorber {
   double thickness;
   int direction;
   int side;
-  double strength;
   double R_asymptotic;
   double mean_stretch;
   meep::pml_profile_func pml_profile;
@@ -80,7 +79,7 @@ void destroy_absorber_list(absorber_list alist);
 void add_absorbing_layer(absorber_list alist,
                          double thickness,
                          int direction=ALL_DIRECTIONS, int side=ALL_SIDES,
-                         double strength=1.0, double R_asymptotic=1.0e-15, double mean_stretch=1.0,
+                         double R_asymptotic=1.0e-15, double mean_stretch=1.0,
                          meep::pml_profile_func func=meep::pml_quadratic_profile, void *func_data=0);
 
 /***************************************************************/

--- a/python/meep.i
+++ b/python/meep.i
@@ -646,7 +646,7 @@ meep::volume_list *make_volume_list(const meep::volume &v, int c,
                 SWIG_fail;
             }
 
-            add_absorbing_layer($1, a.thickness, a.direction, a.side, a.strength,
+            add_absorbing_layer($1, a.thickness, a.direction, a.side,
                                 a.R_asymptotic, a.mean_stretch, py_pml_profile,
                                 a.pml_profile_data);
             Py_DECREF((PyObject *)a.pml_profile_data);

--- a/python/tests/absorber_1d.py
+++ b/python/tests/absorber_1d.py
@@ -56,6 +56,25 @@ class TestAbsorber(unittest.TestCase):
         f = self.sim.get_field_point(mp.Ex, mp.Vector3())
         self.assertAlmostEqual(f.real, 4.789444250711607e-10, places=6)
 
+    def test_absorber_2d(self):
+        source = mp.Source(
+            src=mp.GaussianSource(frequency=0.1, fwidth=0.1),
+            component=mp.Hz,
+            center=mp.Vector3()
+        )
+
+        sim = mp.Simulation(
+            cell_size=mp.Vector3(20, 20, 0),
+            resolution=10,
+            sources=[source],
+            boundary_layers=[mp.Absorber(5)]
+        )
+
+        sim.run(until_after_sources=1000)
+        v = mp.Vector3(4.13, 3.75, 0)
+        p = sim.get_field_point(mp.Hz, v)
+
+        self.assertAlmostEqual(-4.058476603571745e-11, p.real)
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/typemap_utils.cpp
+++ b/python/typemap_utils.cpp
@@ -437,7 +437,6 @@ static int pyabsorber_to_absorber(PyObject *py_absorber, meep_geom::absorber *a)
     }
 
     a->pml_profile_data = py_pml_profile_func;
-    a->strength = 1.0;
 
     return 1;
 }

--- a/python/typemap_utils.cpp
+++ b/python/typemap_utils.cpp
@@ -437,6 +437,7 @@ static int pyabsorber_to_absorber(PyObject *py_absorber, meep_geom::absorber *a)
     }
 
     a->pml_profile_data = py_pml_profile_func;
+    a->strength = 1.0;
 
     return 1;
 }


### PR DESCRIPTION
Fixes #198. The `strength` property in scheme is marked "obsolete" so I didn't add it to the Python `Absorber`. Should it be removed from C++?
@stevengj @HomerReid @oskooi