### PR TITLE
Fix memory issues

### DIFF
--- a/python/meep.i
+++ b/python/meep.i
@@ -395,7 +395,7 @@ meep::volume_list *make_volume_list(const meep::volume &v, int c,
         if (((material_data *)$1.material)->medium.H_susceptibilities.items) {
             delete[] ((material_data *)$1.material)->medium.H_susceptibilities.items;
         }
-        delete (material_data *)$1.material;
+        free((material_data *)$1.material);
         geometric_object_destroy($1);
     }
 }
@@ -426,7 +426,7 @@ meep::volume_list *make_volume_list(const meep::volume &v, int c,
         if (((material_data *)$1.items[i].material)->medium.H_susceptibilities.items) {
         delete[] ((material_data *)$1.items[i].material)->medium.H_susceptibilities.items;
         }
-        delete (material_data *)$1.items[i].material;
+        free((material_data *)$1.items[i].material);
         geometric_object_destroy($1.items[i]);
     }
     delete[] $1.items;
@@ -539,7 +539,7 @@ meep::volume_list *make_volume_list(const meep::volume &v, int c,
     if ($1->medium.H_susceptibilities.items) {
         delete[] $1->medium.H_susceptibilities.items;
     }
-    delete $1;
+    free($1);
 }
 
 // Typemap suite for array_slice
@@ -775,7 +775,7 @@ meep::volume_list *make_volume_list(const meep::volume &v, int c,
             if ($1.items[i]->medium.H_susceptibilities.items) {
                 delete[] $1.items[i]->medium.H_susceptibilities.items;
             }
-            delete $1.items[i];
+            free($1.items[i]);
         }
         delete[] $1.items;
     }

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -683,6 +683,7 @@ structure_chunk::structure_chunk(const structure_chunk *o) : v(o->v) {
   FOR_FIELD_TYPES(ft) {
     {
       susceptibility *cur = NULL;
+      chiP[ft] = NULL;
       for (const susceptibility *ocur = o->chiP[ft]; ocur; ocur = ocur->next) {
 	if (cur) { cur->next = ocur->clone(); cur = cur->next; }
 	else { chiP[ft] = cur = ocur->clone(); }


### PR DESCRIPTION
`chiP[ft]` is never initialized if `o->chiP[ft]` is NULL in the `structure_chunk` copy constructor. This was causing a crash when calling `set_materials_from_geometry` in step functions. Something looks off about the `for` loop too. Won't `if (cur)` on line 687 never be true?

While debugging the crash above, valgrind revealed that the `material_data` objects from `make_dielectric`, `make_user_material` and `make_file_material` are created with `malloc`, so I adjusted the typemaps appropriately.

@stevengj @oskooi @HomerReid 