### PR TITLE
Remove meep's infinity from python wrapper

### DIFF
--- a/python/meep.i
+++ b/python/meep.i
@@ -821,6 +821,7 @@ meep::volume_list *make_volume_list(const meep::volume &v, int c,
 %ignore is_medium;
 %ignore is_medium;
 %ignore is_metal;
+%ignore meep::infinity;
 
 %include "vec.i"
 %include "meep.hpp"


### PR DESCRIPTION
It was confusing that `mp.inf` and `mp.infinity` were available from python, especially since using `mp.infinity` doesn't produce correct results.
@stevengj @oskooi 