### PR TITLE
Refactor get_array

### DIFF
--- a/doc/docs/Python_Tutorials/Basics.md
+++ b/doc/docs/Python_Tutorials/Basics.md
@@ -101,7 +101,7 @@ import matplotlib.pyplot as plt
 We will first create an image of the dielectric function $\varepsilon$. This involves obtaining a slice of the data using the [`get_array`](../Python_User_Interface/#array-slices) routine which outputs to a NumPy array and then display the results.
 
 ```py
-eps_data = sim.get_array(mp.Volume(mp.Vector3(), size=cell), mp.Dielectric)
+eps_data = sim.get_array(center=mp.Vector3(), size=cell, component=mp.Dielectric)
 plt.figure(dpi=100)
 plt.imshow(eps_data.transpose(), interpolation='spline36', cmap='binary')
 plt.axis('off')
@@ -111,7 +111,7 @@ plt.show()
 Next, we create an image of the scalar electric field $E_z$ by overlaying the dielectric function. We use the "RdBu" [colormap](https://matplotlib.org/examples/color/colormaps_reference.html) which goes from dark red (negative) to white (zero) to dark blue (positive).
 
 ```py
-ez_data = sim.get_array(mp.Volume(mp.Vector3(), size=cell), mp.Ez)
+ez_data = sim.get_array(center=mp.Vector3(), size=cell, component=mp.Ez)
 plt.figure(dpi=100)
 plt.imshow(eps_data.transpose(), interpolation='spline36', cmap='binary')
 plt.imshow(ez_data.transpose(), interpolation='spline36', cmap='RdBu', alpha=0.9)
@@ -209,7 +209,7 @@ vals = []
 def get_slice(sim):
     center = mp.Vector3(0, -3.5)
     size = mp.Vector3(16, 0)
-    vals.append(sim.get_array(mp.Volume(center, size=size), component=mp.Ez))
+    vals.append(sim.get_array(center=center, size=size, component=mp.Ez))
 
 sim.run(
     mp.at_beginning(mp.output_epsilon),

--- a/doc/docs/Python_Tutorials/Basics.md
+++ b/doc/docs/Python_Tutorials/Basics.md
@@ -101,7 +101,7 @@ import matplotlib.pyplot as plt
 We will first create an image of the dielectric function $\varepsilon$. This involves obtaining a slice of the data using the [`get_array`](../Python_User_Interface/#array-slices) routine which outputs to a NumPy array and then display the results.
 
 ```py
-eps_data = sim.get_array(mp.Vector3(), cell, mp.Dielectric)
+eps_data = sim.get_array(mp.Volume(mp.Vector3(), size=cell), mp.Dielectric)
 plt.figure(dpi=100)
 plt.imshow(eps_data.transpose(), interpolation='spline36', cmap='binary')
 plt.axis('off')
@@ -111,7 +111,7 @@ plt.show()
 Next, we create an image of the scalar electric field $E_z$ by overlaying the dielectric function. We use the "RdBu" [colormap](https://matplotlib.org/examples/color/colormaps_reference.html) which goes from dark red (negative) to white (zero) to dark blue (positive).
 
 ```py
-ez_data = sim.get_array(mp.Vector3(), cell, mp.Ez)
+ez_data = sim.get_array(mp.Volume(mp.Vector3(), size=cell), mp.Ez)
 plt.figure(dpi=100)
 plt.imshow(eps_data.transpose(), interpolation='spline36', cmap='binary')
 plt.imshow(ez_data.transpose(), interpolation='spline36', cmap='RdBu', alpha=0.9)
@@ -209,7 +209,7 @@ vals = []
 def get_slice(sim):
     center = mp.Vector3(0, -3.5)
     size = mp.Vector3(16, 0)
-    vals.append(sim.get_array(center=center, size=size, component=mp.Ez))
+    vals.append(sim.get_array(mp.Volume(center, size=size), component=mp.Ez))
 
 sim.run(
     mp.at_beginning(mp.output_epsilon),

--- a/doc/docs/Python_Tutorials/Frequency_Domain_Solver.md
+++ b/doc/docs/Python_Tutorials/Frequency_Domain_Solver.md
@@ -46,7 +46,8 @@ ez_dat = np.zeros((122,122,num_tols), dtype=np.complex_)
 for i in range(num_tols):
     sim.init_fields()
     sim.solve_cw(tols[i], 10000, 10)
-    ez_dat[:,:,i] = sim.get_array(center=mp.Vector3(), size=mp.Vector3(sxy-2*dpml,sxy-2*dpml), component=mp.Ez)
+    vol = mp.Volume(center=mp.Vector3(), size=mp.Vector3(sxy-2*dpml,sxy-2*dpml))
+    ez_dat[:,:,i] = sim.get_array(vol, component=mp.Ez)
 
 err_dat = np.zeros(num_tols-1)
 for i in range(num_tols-1):
@@ -58,7 +59,7 @@ plt.xlabel("frequency-domain solver tolerance");
 plt.ylabel("L2 norm of error in fields");
 plt.show()
 
-eps_data = sim.get_array(mp.Vector3(), mp.Vector3(sxy-2*dpml,sxy-2*dpml), mp.Dielectric)
+eps_data = sim.get_array(mp.Volume(mp.Vector3(), mp.Vector3(sxy-2*dpml,sxy-2*dpml)), mp.Dielectric)
 ez_data = np.absolute(ez_dat[:,:,num_tols-1])
 
 plt.figure(dpi=100)
@@ -104,7 +105,7 @@ ezi = f["ez_0.i"].value
 ezr = f["ez_0.r"].value
 ez_dat = ezr + 1j * ezi
 
-eps_data = sim.get_array(mp.Vector3(), mp.Vector3(sxy-2*dpml,sxy-2*dpml), mp.Dielectric)
+eps_data = sim.get_array(mp.Volume(mp.Vector3(), mp.Vector3(sxy-2*dpml,sxy-2*dpml)), mp.Dielectric)
 ez_data = np.absolute(ez_dat)
 
 plt.figure(dpi=100)

--- a/doc/docs/Python_Tutorials/Frequency_Domain_Solver.md
+++ b/doc/docs/Python_Tutorials/Frequency_Domain_Solver.md
@@ -46,8 +46,7 @@ ez_dat = np.zeros((122,122,num_tols), dtype=np.complex_)
 for i in range(num_tols):
     sim.init_fields()
     sim.solve_cw(tols[i], 10000, 10)
-    vol = mp.Volume(center=mp.Vector3(), size=mp.Vector3(sxy-2*dpml,sxy-2*dpml))
-    ez_dat[:,:,i] = sim.get_array(vol, component=mp.Ez)
+    ez_dat[:,:,i] = sim.get_array(center=mp.Vector3(), size=mp.Vector3(sxy-2*dpml,sxy-2*dpml), component=mp.Ez)
 
 err_dat = np.zeros(num_tols-1)
 for i in range(num_tols-1):
@@ -59,7 +58,7 @@ plt.xlabel("frequency-domain solver tolerance");
 plt.ylabel("L2 norm of error in fields");
 plt.show()
 
-eps_data = sim.get_array(mp.Volume(mp.Vector3(), mp.Vector3(sxy-2*dpml,sxy-2*dpml)), mp.Dielectric)
+eps_data = sim.get_array(center=mp.Vector3(), size=mp.Vector3(sxy-2*dpml,sxy-2*dpml), component=mp.Dielectric)
 ez_data = np.absolute(ez_dat[:,:,num_tols-1])
 
 plt.figure(dpi=100)
@@ -105,7 +104,7 @@ ezi = f["ez_0.i"].value
 ezr = f["ez_0.r"].value
 ez_dat = ezr + 1j * ezi
 
-eps_data = sim.get_array(mp.Volume(mp.Vector3(), mp.Vector3(sxy-2*dpml,sxy-2*dpml)), mp.Dielectric)
+eps_data = sim.get_array(center=mp.Vector3(), size=mp.Vector3(sxy-2*dpml,sxy-2*dpml), component=mp.Dielectric)
 ez_data = np.absolute(ez_dat)
 
 plt.figure(dpi=100)

--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -725,7 +725,7 @@ Note that the flux is always computed in the *positive* coordinate direction, al
 
 ### Volume
 
-Many Meep functions require you to specify a volume in space, corresponding to the C++ type `meep::volume`. This class creates such a volume object, given the `center` and `size` properties (just like e.g. a `Block` object). If the `size` is not specified, it defaults to (0,0,0), i.e. a single point.
+Many Meep functions require you to specify a volume in space, corresponding to the C++ type `meep::volume`. This class creates such a volume object, given the `center` and `size` properties (just like e.g. a `Block` object). If the `size` is not specified, it defaults to (0,0,0), i.e. a single point. Any method that accepts such a volume also accepts `center` and `size` keyword arguments. If these are specified instead of the volume, the library will construct a volume for you.
 
 Miscellaneous Functions
 -----------------------
@@ -767,29 +767,29 @@ Given a `component` or `derived_component` constant `c` and a `Vector3` `pt`, re
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 Equivalent to `get_field_point(meep.Dielectric, pt)`.
 
-**`add_dft_fields(cs, freq_min, freq_max, nfreq, [where])`**  
+**`add_dft_fields(cs, freq_min, freq_max, nfreq, where=None, center=None, size=None)`**  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-Given a list of field components `cs`, compute the Fourier transform of these fields for `nfreq` equally spaced frequencies covering the frequency range `freq_min` to `freq_max` over the `Volume` specified by `where` (default to the entire computationall cell).
+Given a list of field components `cs`, compute the Fourier transform of these fields for `nfreq` equally spaced frequencies covering the frequency range `freq_min` to `freq_max` over the `Volume` specified by `where` (default to the entire computationall cell). The volume can also be specified via the `center` and `size` arguments.
 
-**`flux_in_box(dir, box)`**  
+**`flux_in_box(dir, box=None, center=None, size=None)`**  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-Given a `direction` constant, and a `meep.Volume`, returns the flux (the integral of $\Re [\mathbf{E}^* \times \mathbf{H}]$) in that volume. Most commonly, you specify a volume that is a plane or a line, and a direction perpendicular to it, e.g. `flux_in_box(d=meep.X,meep.Volume(center=meep.Vector3(0,0,0),size=meep.Vector3(0,1,1)))`.
+Given a `direction` constant, and a `meep.Volume`, returns the flux (the integral of $\Re [\mathbf{E}^* \times \mathbf{H}]$) in that volume. Most commonly, you specify a volume that is a plane or a line, and a direction perpendicular to it, e.g. `flux_in_box(d=meep.X,meep.Volume(center=meep.Vector3(0,0,0),size=meep.Vector3(0,1,1)))`. If the `center` and `size` arguments are provided instead of `box`, meep will construct the appropriate volume for you.
 
-**`electric_energy_in_box(box)`**  
+**`electric_energy_in_box(box=None, center=None, size=None)`**  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-Given a `meep.Volume`, returns the integral of the electric-field energy $\mathbf{E}^* \cdot \mathbf{D}/2$ in the given volume. If the volume has zero size along a dimension, a lower-dimensional integral is used.
+Given a `meep.Volume`, returns the integral of the electric-field energy $\mathbf{E}^* \cdot \mathbf{D}/2$ in the given volume. If the volume has zero size along a dimension, a lower-dimensional integral is used. If the `center` and `size` arguments are provided instead of `box`, meep will construct the appropriate volume for you.
 
-**`magnetic_energy_in_box(box)`**  
+**`magnetic_energy_in_box(box=None, center=None, size=None)`**  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-Given a `meep.Volume`, returns the integral of the magnetic-field energy $\mathbf{H}^* \cdot \mathbf{B}/2$ in the given volume. If the volume has zero size along a dimension, a lower-dimensional integral is used.
+Given a `meep.Volume`, returns the integral of the magnetic-field energy $\mathbf{H}^* \cdot \mathbf{B}/2$ in the given volume. If the volume has zero size along a dimension, a lower-dimensional integral is used. If the `center` and `size` arguments are provided instead of `box`, meep will construct the appropriate volume for you.
 
-**`field_energy_in_box(box)`**  
+**`field_energy_in_box(box=None, center=None, size=None)`**  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-Given a `meep.Volume`, returns the integral of the electric- and magnetic-field energy $\mathbf{E}^* \cdot \mathbf{D}/2 + \mathbf{H}^* \cdot \mathbf{B}/2$ in the given volume. If the volume has zero size along a dimension, a lower-dimensional integral is used.
+Given a `meep.Volume`, returns the integral of the electric- and magnetic-field energy $\mathbf{E}^* \cdot \mathbf{D}/2 + \mathbf{H}^* \cdot \mathbf{B}/2$ in the given volume. If the volume has zero size along a dimension, a lower-dimensional integral is used. If the `center` and `size` arguments are provided instead of `box`, meep will construct the appropriate volume for you.
 
-**`modal_volume_in_box(box)`**  
+**`modal_volume_in_box(box=None, center=None, size=None)`**  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-Given a `meep.Volume`, returns the instantaneous modal volume according to the Purcell-effect definition: integral ($\varepsilon$|E|^2) / maximum ($\varepsilon$|E|^2). If no volume argument is provided, the entire computational cell is used by default.
+Given a `meep.Volume`, returns the instantaneous modal volume according to the Purcell-effect definition: integral ($\varepsilon$|E|^2) / maximum ($\varepsilon$|E|^2). If no volume argument is provided, the entire computational cell is used by default. If the `center` and `size` arguments are provided instead of `box`, meep will construct the appropriate volume for you.
 
 Note that if you are at a fixed frequency and you use complex fields (via Bloch-periodic boundary conditions or `fields_complex=True`), then one half of the flux or energy integrals above corresponds to the time average of the flux or energy for a simulation with real fields.
 
@@ -797,22 +797,22 @@ Often, you want the integration box to be the entire computational cell. A usefu
 
 One versatile feature is that you can supply an arbitrary function $f(\mathbf{x},c_1,c_2,\ldots)$ of position $\mathbf{x}$ and various field components $c_1,\ldots$ and ask Meep to integrate it over a given volume, find its maximum, or output it (via `output_field_function`, described later). This is done via the functions:
 
-**`integrate_field_function(cs, func, [where])`**  
+**`integrate_field_function(cs, func, where=None, center=None, size=None)`**  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-Returns the integral of the complex-valued function `func` over the `Volume` specified by `where` (defaults to entire computational cell) for the `meep::fields` contained in the `Simulation` instance that calls this method. `func` is a function of position (a `Vector3`, its first argument) and zero or more field components specified by `cs`: a list of `component` constants. `func` can be real- or complex-valued.
+Returns the integral of the complex-valued function `func` over the `Volume` specified by `where` (defaults to entire computational cell) for the `meep::fields` contained in the `Simulation` instance that calls this method. `func` is a function of position (a `Vector3`, its first argument) and zero or more field components specified by `cs`: a list of `component` constants. `func` can be real- or complex-valued. The volume can optionally be specified via the `center` and `size` arguments.
 
 If any dimension of `where` is zero, that dimension is not integrated over. In this way you can specify 1d, 2d, or 3d integrals.
 
-**`max_abs_field_function(cs, func, [where])`**  
+**`max_abs_field_function(cs, func, where=None, center=None, size=None)`**  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 As `integrate_field_function`, but returns the maximum absolute value of `func` in the volume `where` instead of its integral.
 
-The integration is performed by summing over the grid points with a simple trapezoidal rule, and the maximum is similarly over the grid points. See [Field Functions](Field_Functions.md) for examples of how to call `integrate_field_function` and `max_abs_field_function`. See [Synchronizing the Magnetic and Electric Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md) if you want to do computations combining the electric and magnetic fields.
+The integration is performed by summing over the grid points with a simple trapezoidal rule, and the maximum is similarly over the grid points. See [Field Functions](Field_Functions.md) for examples of how to call `integrate_field_function` and `max_abs_field_function`. See [Synchronizing the Magnetic and Electric Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md) if you want to do computations combining the electric and magnetic fields. The volume can optionally be specified via the `center` and `size` arguments.
 
 Occasionally, one wants to compute an integral that combines fields from two separate simulations (e.g. for nonlinear coupled-mode calculations). This functionality is supported in Meep, as long as the two simulations have the *same* computational cell, the same resolution, the same boundary conditions and symmetries (if any), and the same PML layers (if any).
 
-**`integrate2_field_function(fields2, cs1, cs2, func, [where])`**  
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Similar to `integrate_field_function`, but takes additional parameters `fields2` and `cs2`. `fields2` is a `meep::fields*` object similar to the global `fields` variable (see below) specifying the fields from another simulation. `cs1` is a list of components to integrate with from the `meep::fields` instance in `Simulation.fields`, as for `integrate_field_function`, while `cs2` is a list of components to integrate from `fields2`. Similar to `integrate_field_function`, `func` is a function that returns an number given arguments consisting of: the position vector, followed by the values of the components specified by `cs1` (in order), followed by the values of the components specified by `cs2` (in order).
+**`integrate2_field_function(fields2, cs1, cs2, func, where=None, center=None, size=None)`**  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Similar to `integrate_field_function`, but takes additional parameters `fields2` and `cs2`. `fields2` is a `meep::fields*` object similar to the global `fields` variable (see below) specifying the fields from another simulation. `cs1` is a list of components to integrate with from the `meep::fields` instance in `Simulation.fields`, as for `integrate_field_function`, while `cs2` is a list of components to integrate from `fields2`. Similar to `integrate_field_function`, `func` is a function that returns an number given arguments consisting of: the position vector, followed by the values of the components specified by `cs1` (in order), followed by the values of the components specified by `cs2` (in order). The volume can optionally be specified via the `center` and `size` arguments.
 
 To get two fields in memory at once for `integrate2_field_function`, the easiest way is to run one simulation within a given Python file, then save the results in another fields variable, then run a second simulation. This would look something like:
 
@@ -1012,9 +1012,9 @@ After the simulation run is complete, you can compute the far fields. This is us
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 Given a `Vector3` point `x` which can lie anywhere outside the near-field surface, including outside the computational cell and a `near2far` object, returns the computed (Fourier-transformed) "far" fields at `x` as list of length 6`nfreq`, consisting of fields (Ex1,Ey1,Ez1,Hx1,Hy1,Hz1,Ex2,Ey2,Ez2,Hx2,Hy2,Hz2,...) for the frequencies 1,2,…,`nfreq`.
 
-**`output_farfields(near2far, fname, where, resolution)`**  
+**`output_farfields(near2far, fname, resolution, where=None, center=None, size=None)`**  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-Given an HDF5 file name `fname` (does *not* include the `.h5` suffix), a `Volume` given by `where` (may be 0d, 1d, 2d, or 3d), and a `resolution` (in grid points / distance unit), outputs the far fields in `where` (which may lie *outside* the computational cell) in a grid with the given resolution (which may differ from the FDTD grid resolution) to the HDF5 file as a set of twelve array datasets `ex.r`, `ex.i`, ..., `hz.r`, `hz.i`, giving the real and imaginary parts of the Fourier-transformed $E$ and $H$ fields on this grid. Each dataset is an nx&#215;ny&#215;nz&#215;nfreq 4d array of space&#215;frequency although dimensions that =1 are omitted.
+Given an HDF5 file name `fname` (does *not* include the `.h5` suffix), a `Volume` given by `where` (may be 0d, 1d, 2d, or 3d), and a `resolution` (in grid points / distance unit), outputs the far fields in `where` (which may lie *outside* the computational cell) in a grid with the given resolution (which may differ from the FDTD grid resolution) to the HDF5 file as a set of twelve array datasets `ex.r`, `ex.i`, ..., `hz.r`, `hz.i`, giving the real and imaginary parts of the Fourier-transformed $E$ and $H$ fields on this grid. Each dataset is an nx&#215;ny&#215;nz&#215;nfreq 4d array of space&#215;frequency although dimensions that =1 are omitted. The volume can optionally be specified via `center` and `size`.
 
 Note that far fields have the same units and scaling as the *Fourier transforms* of the fields, and hence cannot be directly compared to time-domain fields. In practice, it is easiest to use the far fields in computations where overall scaling (units) cancel out or are irrelevant, e.g. to compute the fraction of the far fields in one region vs. another region.
 
@@ -1105,9 +1105,9 @@ Output the dielectric function (relative permittivity) $\varepsilon$. Note that 
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 Output the relative permeability function $\mu$. Note that this only outputs the frequency-independent part of $\mu$ (the $\omega\to\infty$ limit).
 
-**`output_dft(dft_fields, fname, [where])`**  
+**`output_dft(dft_fields, fname, where=None, center=None, size=None)`**  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-Output the Fourier-transformed fields in `dft_fields` (created by `add_dft_fields`) to an HDF5 file with name `fname` (does *not* include the `.h5` suffix). The `Volume` `where` defaults to the entire computational cell. 
+Output the Fourier-transformed fields in `dft_fields` (created by `add_dft_fields`) to an HDF5 file with name `fname` (does *not* include the `.h5` suffix). The `Volume` `where` defaults to the entire computational cell. The volume can also be specified via the `center` and `size` arguments.
 
 **`output_hpwr()`**  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
@@ -1154,14 +1154,16 @@ See also [Field Function Examples](Field_Function_Examples.md). See also [Synchr
 The output functions described above write the data for the fields and materials for the entire computational volume to an HDF5 file. This is useful for post-processing as you can later read in the HDF5 file to obtain field/material data as a NumPy array. However, in some cases it is convenient to bypass the disk altogether to obtain the data *directly* in the form of a NumPy array without writing/reading HDF5 files. Additionally, you may want the field/material data on just a subregion (or slice) of the entire volume. This functionality is provided by the `get_array` method which takes as input a subregion of the computational volume and the field/material component. The method returns a NumPy array containing values of the field/material at the current simulation time.
 
 ```python
- get_array(vol, component, cmplx=False, arr=None)
+ get_array(vol=None, center=None, size=None component=meep.Ez, cmplx=False, arr=None)
 ```
 
 with the following input parameters:
 
-+ `vol`: `Volume`: the orthogonal subregion/slice of the computational volume. The return value of `get_array` has the same dimensions as the `Volume`'s `size` attribute.
++ `vol`: `Volume`: the orthogonal subregion/slice of the computational volume. The return value of `get_array` has the same dimensions as the `Volume`'s `size` attribute. If this parameter is `None` (the default), then a `size` and `center` must be specified.
 
-+ `component`: field/material component (i.e., `mp.Ex`, `mp.Hy`, `mp.Sz`, `mp.Dielectric`, etc).
++ `center`, `size` : `Vector3` : If both are specified, the library will construct an apporpriate `Volume`. This is merely a convenience feature and alternative to supplying a `Volume`.
+
++ `component`: field/material component (i.e., `mp.Ex`, `mp.Hy`, `mp.Sz`, `mp.Dielectric`, etc). Defaults to `mp.Ez`.
 
 + `cmplx`: If `True`, return complex-valued data otherwise return real-valued data (default).
 

--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -1154,12 +1154,12 @@ See also [Field Function Examples](Field_Function_Examples.md). See also [Synchr
 The output functions described above write the data for the fields and materials for the entire computational volume to an HDF5 file. This is useful for post-processing as you can later read in the HDF5 file to obtain field/material data as a NumPy array. However, in some cases it is convenient to bypass the disk altogether to obtain the data *directly* in the form of a NumPy array without writing/reading HDF5 files. Additionally, you may want the field/material data on just a subregion (or slice) of the entire volume. This functionality is provided by the `get_array` method which takes as input a subregion of the computational volume and the field/material component. The method returns a NumPy array containing values of the field/material at the current simulation time.
 
 ```python
- get_array(center, size, component, cmplx=False, arr=None)
+ get_array(vol, component, cmplx=False, arr=None)
 ```
 
 with the following input parameters:
 
-+ `center`, `size`: `Vector3` properties of the orthogonal subregion/slice of the computational volume. The return value of `get_array` has the same dimensions as `size`.
++ `vol`: `Volume`: the orthogonal subregion/slice of the computational volume. The return value of `get_array` has the same dimensions as the `Volume`'s `size` attribute.
 
 + `component`: field/material component (i.e., `mp.Ex`, `mp.Hy`, `mp.Sz`, `mp.Dielectric`, etc).
 

--- a/python/examples/cavity-farfield.py
+++ b/python/examples/cavity-farfield.py
@@ -52,6 +52,6 @@ sim.run(until_after_sources=mp.stop_when_fields_decayed(50, mp.Hz, mp.Vector3(0.
 d2 = 20
 h = 4
 
-sim.output_farfields(nearfield, "spectra-{}-{}-{}".format(d1, d2, h),
-                     mp.Volume(mp.Vector3(0, (0.5 * w) + d2 + (0.5 * h)), size=mp.Vector3(sx - 2 * dpml, h)),
-                     resolution)
+sim.output_farfields(nearfield, "spectra-{}-{}-{}".format(d1, d2, h), resolution,
+                     where=mp.Volume(mp.Vector3(0, (0.5 * w) + d2 + (0.5 * h)),
+                                     size=mp.Vector3(sx - 2 * dpml, h)))

--- a/python/examples/cavity_arrayslice.py
+++ b/python/examples/cavity_arrayslice.py
@@ -51,12 +51,12 @@ yMax = +0.15 * sy
 # 1D slice of Hz data
 size_1d = mp.Vector3(xMax - xMin)
 center_1d = mp.Vector3((xMin + xMax) / 2)
-slice1d = sim.get_array(center=center_1d, size=size_1d, component=mp.Hz)
+slice1d = sim.get_array(mp.Volume(center_1d, size=size_1d), component=mp.Hz)
 
 # 2D slice of Hz data
 size_2d = mp.Vector3(xMax - xMin, yMax - yMin)
 center_2d = mp.Vector3((xMin + xMax) / 2, (yMin + yMax) / 2)
-slice2d = sim.get_array(center=center_2d, size=size_2d, component=mp.Hz)
+slice2d = sim.get_array(mp.Volume(center_2d, size=size_2d), component=mp.Hz)
 
 # plot 1D slice
 plt.subplot(1, 2, 1)

--- a/python/examples/material-dispersion.py
+++ b/python/examples/material-dispersion.py
@@ -46,4 +46,4 @@ all_freqs = sim.run_k_points(200, kpts)  # a list of lists of frequencies
 
 for fs, kx in zip(all_freqs, [v.x for v in kpts]):
     for f in fs:
-        print("eps:, {.6f}, {.6f}, {.6f}".format(f.real, f.imag, (kx / f)**2))
+        print("eps:, {:.6g}, {:.6g}, {:.6g}".format(f.real, f.imag, (kx / f)**2))

--- a/python/examples/mode-decomposition.py
+++ b/python/examples/mode-decomposition.py
@@ -1,3 +1,4 @@
+
 import meep as mp
 import math
 import argparse
@@ -13,25 +14,25 @@ def main(args):
     Lt = args.Lt      # taper length
 
     Si = mp.Medium(epsilon=12.0)
-    
+
     dair = 3.0
     dpml = 3.0
-    
+
     sx = dpml + Lw + Lt + Lw + dpml
     sy = dpml + dair + w2 + dair + dpml
     cell_size = mp.Vector3(sx, sy, 0)
 
-    geometry = [ mp.Block(material=Si, center=mp.Vector3(0,0,0), size=mp.Vector3(mp.inf,w1,mp.inf)), 
+    geometry = [ mp.Block(material=Si, center=mp.Vector3(0,0,0), size=mp.Vector3(mp.inf,w1,mp.inf)),
                  mp.Block(material=Si, center=mp.Vector3(0.5*sx-0.5*(Lt+Lw+dpml),0,0), size=mp.Vector3(Lt+Lw+dpml,w2,mp.inf)) ]
 
     # form linear taper
 
     hh = w2
     ww = 2*Lt
-    
+
     # taper angle (CCW, relative to +X axis)
     rot_theta = math.atan(0.5*(w2-w1)/Lt)
-    
+
     pvec = mp.Vector3(-0.5*sx+dpml+Lw,0.5*w1,0)
     cvec = mp.Vector3(-0.5*sx+dpml+Lw+0.5*ww,0.5*hh+0.5*w1,0)
     rvec = cvec-pvec
@@ -56,7 +57,7 @@ def main(args):
 
     # mode frequency
     fcen = 0.15
-    
+
     sources = [ mp.EigenModeSource(src=mp.GaussianSource(fcen, fwidth=0.5*fcen),
                                    component=mp.Ez,
                                    size=mp.Vector3(0,sy-2*dpml,0),
@@ -65,9 +66,9 @@ def main(args):
                                    eig_parity=mp.ODD_Z,
                                    eig_kpoint=mp.Vector3(0.4,0,0),
                                    eig_resolution=32) ]
-    
+
     symmetries = [ mp.Mirror(mp.Y,+1) ]
-    
+
     sim = mp.Simulation(resolution=resolution,
                         cell_size=cell_size,
                         boundary_layers=boundary_layers,
@@ -77,7 +78,7 @@ def main(args):
 
     xm = -0.5*sx + dpml + 0.5*Lw; # x-coordinate of monitor
     mflux = sim.add_flux(fcen, 0, 1, mp.FluxRegion(center=mp.Vector3(xm,0), size=mp.Vector3(0,sy-2*dpml)));
-        
+
     sim.run(until_after_sources=mp.stop_when_fields_decayed(50, mp.Ez, mp.Vector3(xm,0), 1e-10))
 
     bands = np.array([1],dtype=np.int32) # indices of modes for which to compute expansion coefficients
@@ -91,7 +92,7 @@ def main(args):
     alpha0Minus = alpha[2*0 + 1]; # coefficient of backward-traveling fundamental mode
 
     print("refl:, {}, {:.8f}".format(Lt, abs(alpha0Minus)**2))
-    
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('-Lt',  type=float, default=3.0, help='taper length (default: 3.0)')

--- a/python/examples/solve-cw.py
+++ b/python/examples/solve-cw.py
@@ -33,7 +33,7 @@ ez_dat = np.zeros((122,122,num_tols), dtype=np.complex_)
 for i in range(num_tols):
     sim.init_fields()
     sim.solve_cw(tols[i], 10000, 10)
-    ez_dat[:,:,i] = sim.get_array(center=mp.Vector3(), size=mp.Vector3(sxy-2*dpml,sxy-2*dpml), component=mp.Ez)
+    ez_dat[:,:,i] = sim.get_array(mp.Volume(mp.Vector3(), size=mp.Vector3(sxy-2*dpml,sxy-2*dpml)), component=mp.Ez)
 
 err_dat = np.zeros(num_tols-1)
 for i in range(num_tols-1):
@@ -45,7 +45,7 @@ plt.xlabel("frequency-domain solver tolerance");
 plt.ylabel("L2 norm of error in fields");
 plt.show()
 
-eps_data = sim.get_array(mp.Vector3(), mp.Vector3(sxy-2*dpml,sxy-2*dpml), mp.Dielectric)
+eps_data = sim.get_array(mp.Volume(Vector3(), mp.Vector3(sxy-2*dpml,sxy-2*dpml)), mp.Dielectric)
 ez_data = np.absolute(ez_dat[:,:,num_tols-1])
 
 plt.figure(dpi=100)
@@ -81,7 +81,7 @@ ezi = f["ez_0.i"].value
 ezr = f["ez_0.r"].value
 ez_dat = ezr + 1j * ezi
 
-eps_data = sim.get_array(mp.Vector3(), mp.Vector3(sxy-2*dpml,sxy-2*dpml), mp.Dielectric)
+eps_data = sim.get_array(mp.Volume(Vector3(), mp.Vector3(sxy-2*dpml,sxy-2*dpml)), mp.Dielectric)
 ez_data = np.absolute(ez_dat)
 
 plt.figure(dpi=100)

--- a/python/examples/solve-cw.py
+++ b/python/examples/solve-cw.py
@@ -10,6 +10,7 @@ pad = 4
 dpml = 2
 
 sxy = 2*(r+w+pad+dpml)
+vol = mp.Volume(mp.Vector3(), size=mp.Vector3(sxy-2*dpml,sxy-2*dpml))
 
 c1 = mp.Cylinder(radius=r+w, material=mp.Medium(index=n))
 c2 = mp.Cylinder(radius=r)
@@ -33,7 +34,7 @@ ez_dat = np.zeros((122,122,num_tols), dtype=np.complex_)
 for i in range(num_tols):
     sim.init_fields()
     sim.solve_cw(tols[i], 10000, 10)
-    ez_dat[:,:,i] = sim.get_array(mp.Volume(mp.Vector3(), size=mp.Vector3(sxy-2*dpml,sxy-2*dpml)), component=mp.Ez)
+    ez_dat[:,:,i] = sim.get_array(vol, component=mp.Ez)
 
 err_dat = np.zeros(num_tols-1)
 for i in range(num_tols-1):
@@ -45,7 +46,7 @@ plt.xlabel("frequency-domain solver tolerance");
 plt.ylabel("L2 norm of error in fields");
 plt.show()
 
-eps_data = sim.get_array(mp.Volume(Vector3(), mp.Vector3(sxy-2*dpml,sxy-2*dpml)), mp.Dielectric)
+eps_data = sim.get_array(vol, component=mp.Dielectric)
 ez_data = np.absolute(ez_dat[:,:,num_tols-1])
 
 plt.figure(dpi=100)
@@ -70,7 +71,7 @@ sim = mp.Simulation(cell_size=mp.Vector3(sxy,sxy),
                     symmetries=[mp.Mirror(mp.Y)],
                     boundary_layers=[mp.PML(dpml)])
 
-dfts = sim.add_dft_fields([mp.Ez], mp.Volume(center=mp.Vector3(), size=mp.Vector3(sxy-2*dpml,sxy-2*dpml)), fcen, fcen, 1)
+dfts = sim.add_dft_fields([mp.Ez], fcen, fcen, 1, where=vol)
 sim.run(until_after_sources=100)
 sim.output_dft(dfts, "dft_fields")
 
@@ -81,7 +82,7 @@ ezi = f["ez_0.i"].value
 ezr = f["ez_0.r"].value
 ez_dat = ezr + 1j * ezi
 
-eps_data = sim.get_array(mp.Volume(Vector3(), mp.Vector3(sxy-2*dpml,sxy-2*dpml)), mp.Dielectric)
+eps_data = sim.get_array(vol, component=mp.Dielectric)
 ez_data = np.absolute(ez_dat)
 
 plt.figure(dpi=100)

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -305,6 +305,21 @@ class Simulation(object):
     def _fit_volume_to_simulation(self, vol):
         return Volume(vol.center, vol.size, dims=self.dimensions, is_cylindrical=self.is_cylindrical)
 
+    # Every function that takes a user volume can be specified either by a volume
+    # (a Python Volume or a SWIG-wrapped meep::volume), or a center and a size
+    def _volume_from_kwargs(self, vol=None, center=None, size=None):
+        if vol:
+            if isinstance(vol, Volume):
+                # A pure Python Volume
+                return self._fit_volume_to_simulation(vol).swigobj
+            else:
+                # A SWIG-wrapped meep::volume
+                return vol
+        elif size and center:
+            return Volume(center, size=size, dims=self.dimensions, is_cylindrical=self.is_cylindrical).swigobj
+        else:
+            raise ValueError("Need either a Volume, or a size and center")
+
     def _infer_dimensions(self, k):
         if self.dimensions == 3:
 
@@ -657,25 +672,25 @@ class Simulation(object):
                     src.amplitude * 1.0
                 )
 
-    def add_dft_fields(self, components, freq_min, freq_max, nfreq, where=None):
+    def add_dft_fields(self, components, freq_min, freq_max, nfreq, where=None, center=None, size=None):
         if self.fields is None:
             self.init_fields()
 
-        if where is None:
+        try:
+            where = self._volume_from_kwargs(where, center, size)
+        except ValueError:
             where = self.fields.total_volume()
-        else:
-            where = self._fit_volume_to_simulation(where).swigobj
 
         return self.fields.add_dft_fields(components, where, freq_min, freq_max, nfreq)
 
-    def output_dft(self, dft_fields, fname, where=None):
+    def output_dft(self, dft_fields, fname, where=None, center=None, size=None):
         if self.fields is None:
             self.init_fields()
 
-        if where is None:
+        try:
+            where = self._volume_from_kwargs(where, center, size)
+        except ValueError:
             where = self.fields.total_volume()
-        else:
-            where = self._fit_volume_to_simulation(where).swigobj
 
         self.fields.output_dft(dft_fields, fname, where)
 
@@ -688,9 +703,9 @@ class Simulation(object):
     def get_farfield(self, f, v):
         return mp._get_farfield(f, py_v3_to_vec(self.dimensions, v, is_cylindrical=self.is_cylindrical))
 
-    def output_farfields(self, near2far, fname, where, resolution):
-        vol = self._fit_volume_to_simulation(where)
-        near2far.save_farfields(fname, self.get_filename_prefix(), vol.swigobj, resolution)
+    def output_farfields(self, near2far, fname, resolution, where=None, center=None, size=None):
+        vol = self._volume_from_kwargs(where, center, size)
+        near2far.save_farfields(fname, self.get_filename_prefix(), vol, resolution)
 
     def load_near2far(self, fname, n2f):
         if self.fields is None:
@@ -755,50 +770,46 @@ class Simulation(object):
         self.load_flux(fname, flux)
         flux.scale_dfts(complex(-1.0))
 
-    def flux_in_box(self, d, box):
+    def flux_in_box(self, d, box=None, center=None, size=None):
         if self.fields is None:
             raise RuntimeError('Fields must be initialized before using flux_in_box')
 
-        if isinstance(box, mp.Volume):
-            box = self._fit_volume_to_simulation(box).swigobj
+        box = self._volume_from_kwargs(box, center, size)
 
         return self.fields.flux_in_box(d, box)
 
-    def electric_energy_in_box(self, box):
+    def electric_energy_in_box(self, box=None, center=None, size=None):
         if self.fields is None:
             raise RuntimeError('Fields must be initialized before using electric_energy_in_box')
 
-        if isinstance(box, mp.Volume):
-            box = self._fit_volume_to_simulation(box).swigobj
+        box = self._volume_from_kwargs(box, center, size)
 
         return self.fields.electric_energy_in_box(box)
 
-    def magnetic_energy_in_box(self, box):
+    def magnetic_energy_in_box(self, box=None, center=None, size=None):
         if self.fields is None:
             raise RuntimeError('Fields must be initialized before using magnetic_energy_in_box')
 
-        if isinstance(box, mp.Volume):
-            box = self._fit_volume_to_simulation(box).swigobj
+        box = self._volume_from_kwargs(box, center, size)
 
         return self.fields.magnetic_energy_in_box(box)
 
-    def field_energy_in_box(self, box):
+    def field_energy_in_box(self, box=None, center=None, size=None):
         if self.fields is None:
             raise RuntimeError('Fields must be initialized before using field_energy_in_box')
 
-        if isinstance(box, mp.Volume):
-            box = self._fit_volume_to_simulation(box).swigobj
+        box = self._volume_from_kwargs(box, center, size)
 
         return self.fields.field_energy_in_box(box)
 
-    def modal_volume_in_box(self, box=None):
+    def modal_volume_in_box(self, box=None, center=None, size=None):
         if self.fields is None:
             raise RuntimeError('Fields must be initialized before using modal_volume_in_box')
 
-        if box is None:
+        try:
+            box = self._volume_from_kwargs(box, center, size)
+        except ValueError:
             box = self.fields.total_volume()
-        else:
-            box = self._fit_volume_to_simulation(box).swigobj
 
         return self.fields.modal_volume_in_box(box)
 
@@ -866,10 +877,10 @@ class Simulation(object):
         cmd = re.sub(r'\$EPS', self.last_eps_filename, opts)
         return convert_h5(rm_h5, cmd, *step_funcs)
 
-    def get_array(self, vol, component=mp.Ez, cmplx=None, arr=None):
+    def get_array(self, vol=None, center=None, size=None, component=mp.Ez, cmplx=None, arr=None):
         dim_sizes = np.zeros(3, dtype=np.int32)
-        v = self._fit_volume_to_simulation(vol)
-        self.fields.get_array_slice_dimensions(v.swigobj, dim_sizes)
+        v = self._volume_from_kwargs(vol, center, size)
+        self.fields.get_array_slice_dimensions(v, dim_sizes)
 
         dims = [s for s in dim_sizes if s != 0]
 
@@ -891,9 +902,9 @@ class Simulation(object):
             arr = np.zeros(dims, dtype=np.complex128 if cmplx else np.float64)
 
         if np.iscomplexobj(arr):
-            self.fields.get_complex_array_slice(vol.swigobj, component, arr)
+            self.fields.get_complex_array_slice(v, component, arr)
         else:
-            self.fields.get_array_slice(vol.swigobj, component, arr)
+            self.fields.get_array_slice(v, component, arr)
 
         return arr
 
@@ -910,23 +921,24 @@ class Simulation(object):
         if h5file is None:
             self.output_h5_hook(self.fields.h5file_name(name, self.get_filename_prefix(), True))
 
-    def _get_field_function_volume(self, where):
-        if where is None:
+    def _get_field_function_volume(self, where=None, center=None, size=None):
+        try:
+            where = self._volume_from_kwargs(where, center, size)
+        except ValueError:
             where = self.fields.total_volume()
-        else:
-            where = self._fit_volume_to_simulation(where).swigobj
+
         return where
 
-    def integrate_field_function(self, cs, func, where=None):
-        where = self._get_field_function_volume(where)
+    def integrate_field_function(self, cs, func, where=None, center=None, size=None):
+        where = self._get_field_function_volume(where, center, size)
         return self.fields.integrate([cs, func], where)
 
-    def integrate2_field_function(self, fields2, cs1, cs2, func, where=None):
-        where = self._get_field_function_volume(where)
+    def integrate2_field_function(self, fields2, cs1, cs2, func, where=None, center=None, size=None):
+        where = self._get_field_function_volume(where, center, size)
         return self.fields.integrate2(fields2, [cs1, cs2, func], where)
 
-    def max_abs_field_function(self, cs, func, where=None):
-        where = self._get_field_function_volume(where)
+    def max_abs_field_function(self, cs, func, where=None, center=None, size=None):
+        where = self._get_field_function_volume(where, center, size)
         return self.fields.max_abs([cs, func], where)
 
     def change_k_point(self, k):

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -866,10 +866,10 @@ class Simulation(object):
         cmd = re.sub(r'\$EPS', self.last_eps_filename, opts)
         return convert_h5(rm_h5, cmd, *step_funcs)
 
-    def get_array(self, center, size, component=mp.Ez, cmplx=None, arr=None):
+    def get_array(self, vol, component=mp.Ez, cmplx=None, arr=None):
         dim_sizes = np.zeros(3, dtype=np.int32)
-        vol = Volume(center, size=size, dims=self.dimensions, is_cylindrical=self.is_cylindrical)
-        self.fields.get_array_slice_dimensions(vol.swigobj, dim_sizes)
+        v = self._fit_volume_to_simulation(vol)
+        self.fields.get_array_slice_dimensions(v.swigobj, dim_sizes)
 
         dims = [s for s in dim_sizes if s != 0]
 

--- a/python/tests/cavity_arrayslice.py
+++ b/python/tests/cavity_arrayslice.py
@@ -58,24 +58,28 @@ class TestCavityArraySlice(unittest.TestCase):
 
     def test_1d_slice(self):
         self.sim.run(until_after_sources=0)
-        hl_slice1d = self.sim.get_array(center=self.center_1d, size=self.size_1d, component=mp.Hz)
+        vol = mp.Volume(center=self.center_1d, size=self.size_1d)
+        hl_slice1d = self.sim.get_array(vol, component=mp.Hz)
         np.testing.assert_allclose(self.expected_1d, hl_slice1d)
 
     def test_2d_slice(self):
         self.sim.run(until_after_sources=0)
-        hl_slice2d = self.sim.get_array(center=self.center_2d, size=self.size_2d, component=mp.Hz)
+        vol = mp.Volume(center=self.center_2d, size=self.size_2d)
+        hl_slice2d = self.sim.get_array(vol, component=mp.Hz)
         np.testing.assert_allclose(self.expected_2d, hl_slice2d)
 
     def test_1d_slice_user_array(self):
         self.sim.run(until_after_sources=0)
         arr = np.zeros(126, dtype=np.float64)
-        self.sim.get_array(center=self.center_1d, size=self.size_1d, component=mp.Hz, arr=arr)
+        vol = mp.Volume(center=self.center_1d, size=self.size_1d)
+        self.sim.get_array(vol, component=mp.Hz, arr=arr)
         np.testing.assert_allclose(self.expected_1d, arr)
 
     def test_2d_slice_user_array(self):
         self.sim.run(until_after_sources=0)
         arr = np.zeros((126, 38), dtype=np.float64)
-        self.sim.get_array(center=self.center_2d, size=self.size_2d, component=mp.Hz, arr=arr)
+        vol = mp.Volume(center=self.center_2d, size=self.size_2d)
+        self.sim.get_array(vol, component=mp.Hz, arr=arr)
         np.testing.assert_allclose(self.expected_2d, arr)
 
     def test_illegal_user_array(self):
@@ -83,32 +87,33 @@ class TestCavityArraySlice(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             arr = np.zeros(128)
-            self.sim.get_array(center=self.center_1d, size=self.size_1d,
-                               component=mp.Hz, arr=arr)
+            vol = mp.Volume(center=self.center_1d, size=self.size_1d)
+            self.sim.get_array(vol, component=mp.Hz, arr=arr)
 
         with self.assertRaises(ValueError):
             arr = np.zeros((126, 39))
-            self.sim.get_array(center=self.center_2d, size=self.size_2d,
-                               component=mp.Hz, arr=arr)
+            vol = mp.Volume(center=self.center_2d, size=self.size_2d)
+            self.sim.get_array(vol, component=mp.Hz, arr=arr)
 
         with self.assertRaises(ValueError):
             arr = np.zeros((126, 38))
-            self.sim.get_array(center=self.center_2d, size=self.size_2d,
-                               component=mp.Hz, cmplx=True, arr=arr)
+            vol = mp.Volume(center=self.center_2d, size=self.size_2d)
+            self.sim.get_array(vol, component=mp.Hz, cmplx=True, arr=arr)
 
     def test_1d_complex_slice(self):
         self.sim.run(until_after_sources=0)
-        hl_slice1d = self.sim.get_array(center=self.center_1d, size=self.size_1d,
-                                        component=mp.Hz, cmplx=True)
+        vol = mp.Volume(center=self.center_1d, size=self.size_1d)
+        hl_slice1d = self.sim.get_array(vol, component=mp.Hz, cmplx=True)
         self.assertTrue(hl_slice1d.dtype == np.complex128)
         self.assertTrue(hl_slice1d.shape[0] == 126)
 
     def test_2d_complex_slice(self):
         self.sim.run(until_after_sources=0)
-        hl_slice2d = self.sim.get_array(center=self.center_2d, size=self.size_2d,
-                                        component=mp.Hz, cmplx=True)
+        vol = mp.Volume(center=self.center_2d, size=self.size_2d)
+        hl_slice2d = self.sim.get_array(vol, component=mp.Hz, cmplx=True)
         self.assertTrue(hl_slice2d.dtype == np.complex128)
         self.assertTrue(hl_slice2d.shape[0] == 126 and hl_slice2d.shape[1] == 38)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/tests/simulation.py
+++ b/python/tests/simulation.py
@@ -241,10 +241,10 @@ class TestSimulation(unittest.TestCase):
         eps = {'arr1': None, 'arr2': None}
 
         def get_arr1(sim):
-            eps['arr1'] = sim.get_array(mp.Vector3(), mp.Vector3(10, 10), mp.Dielectric)
+            eps['arr1'] = sim.get_array(mp.Volume(mp.Vector3(), mp.Vector3(10, 10)), mp.Dielectric)
 
         def get_arr2(sim):
-            eps['arr2'] = sim.get_array(mp.Vector3(), mp.Vector3(10, 10), mp.Dielectric)
+            eps['arr2'] = sim.get_array(mp.Volume(mp.Vector3(), mp.Vector3(10, 10)), mp.Dielectric)
 
         sim.run(mp.at_time(50, get_arr1), mp.at_time(100, change_geom),
                 mp.at_end(get_arr2), until=200)

--- a/python/tests/simulation.py
+++ b/python/tests/simulation.py
@@ -241,10 +241,12 @@ class TestSimulation(unittest.TestCase):
         eps = {'arr1': None, 'arr2': None}
 
         def get_arr1(sim):
-            eps['arr1'] = sim.get_array(mp.Volume(mp.Vector3(), mp.Vector3(10, 10)), mp.Dielectric)
+            eps['arr1'] = sim.get_array(mp.Volume(mp.Vector3(), mp.Vector3(10, 10)),
+                                        component=mp.Dielectric)
 
         def get_arr2(sim):
-            eps['arr2'] = sim.get_array(mp.Volume(mp.Vector3(), mp.Vector3(10, 10)), mp.Dielectric)
+            eps['arr2'] = sim.get_array(mp.Volume(mp.Vector3(), mp.Vector3(10, 10)),
+                                        component=mp.Dielectric)
 
         sim.run(mp.at_time(50, get_arr1), mp.at_time(100, change_geom),
                 mp.at_end(get_arr2), until=200)


### PR DESCRIPTION
Replace `center` and `size` arguments to `get_array` with a `meep.Volume`.
@stevengj @oskooi @HomerReid 