### PR TITLE
Align docs and *in_box functions

### DIFF
--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -773,27 +773,27 @@ Given a list of field components `cs`, compute the Fourier transform of these fi
 
 **`flux_in_box(dir, box)`**  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-Given a `direction` constant, and a `meep::volume*`, returns the flux (the integral of $\Re [\mathbf{E}^* \times \mathbf{H}]$) in that volume. Most commonly, you specify a volume that is a plane or a line, and a direction perpendicular to it, e.g. `flux_in_box(d=meep.X,meep.Volume(center=meep.Vector3(0,0,0),size=meep.Vector3(0,1,1)))`.
+Given a `direction` constant, and a `meep.Volume`, returns the flux (the integral of $\Re [\mathbf{E}^* \times \mathbf{H}]$) in that volume. Most commonly, you specify a volume that is a plane or a line, and a direction perpendicular to it, e.g. `flux_in_box(d=meep.X,meep.Volume(center=meep.Vector3(0,0,0),size=meep.Vector3(0,1,1)))`.
 
 **`electric_energy_in_box(box)`**  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-Given a `meep::volume*`, returns the integral of the electric-field energy $\mathbf{E}^* \cdot \mathbf{D}/2$ in the given volume. If the volume has zero size along a dimension, a lower-dimensional integral is used.
+Given a `meep.Volume`, returns the integral of the electric-field energy $\mathbf{E}^* \cdot \mathbf{D}/2$ in the given volume. If the volume has zero size along a dimension, a lower-dimensional integral is used.
 
 **`magnetic_energy_in_box(box)`**  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-Given a `meep::volume*`, returns the integral of the magnetic-field energy $\mathbf{H}^* \cdot \mathbf{B}/2$ in the given volume. If the volume has zero size along a dimension, a lower-dimensional integral is used.
+Given a `meep.Volume`, returns the integral of the magnetic-field energy $\mathbf{H}^* \cdot \mathbf{B}/2$ in the given volume. If the volume has zero size along a dimension, a lower-dimensional integral is used.
 
 **`field_energy_in_box(box)`**  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-Given a `meep::volume*`, returns the integral of the electric- and magnetic-field energy $\mathbf{E}^* \cdot \mathbf{D}/2 + \mathbf{H}^* \cdot \mathbf{B}/2$ in the given volume. If the volume has zero size along a dimension, a lower-dimensional integral is used.
+Given a `meep.Volume`, returns the integral of the electric- and magnetic-field energy $\mathbf{E}^* \cdot \mathbf{D}/2 + \mathbf{H}^* \cdot \mathbf{B}/2$ in the given volume. If the volume has zero size along a dimension, a lower-dimensional integral is used.
 
 **`modal_volume_in_box(box)`**  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-Given a `meep::volume`, returns the instantaneous modal volume according to the Purcell-effect definition: integral ($\varepsilon$|E|^2) / maximum ($\varepsilon$|E|^2). If no volume argument is provided, the entire computational cell is used by default.
+Given a `meep.Volume`, returns the instantaneous modal volume according to the Purcell-effect definition: integral ($\varepsilon$|E|^2) / maximum ($\varepsilon$|E|^2). If no volume argument is provided, the entire computational cell is used by default.
 
 Note that if you are at a fixed frequency and you use complex fields (via Bloch-periodic boundary conditions or `fields_complex=True`), then one half of the flux or energy integrals above corresponds to the time average of the flux or energy for a simulation with real fields.
 
-Often, you want the integration box to be the entire computational cell. A useful function to return this box, which you can then use for the `box` arguments above, is `fields.total_volume()`.
+Often, you want the integration box to be the entire computational cell. A useful function to return this box, which you can then use for the `box` arguments above, is `Simulation.total_volume()`.
 
 One versatile feature is that you can supply an arbitrary function $f(\mathbf{x},c_1,c_2,\ldots)$ of position $\mathbf{x}$ and various field components $c_1,\ldots$ and ask Meep to integrate it over a given volume, find its maximum, or output it (via `output_field_function`, described later). This is done via the functions:
 

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -759,44 +759,48 @@ class Simulation(object):
         if self.fields is None:
             raise RuntimeError('Fields must be initialized before using flux_in_box')
 
-        box = self._fit_volume_to_simulation(box)
+        if isinstance(box, mp.Volume):
+            box = self._fit_volume_to_simulation(box).swigobj
 
-        return self.fields.flux_in_box(d, box.swigobj)
+        return self.fields.flux_in_box(d, box)
 
     def electric_energy_in_box(self, box):
         if self.fields is None:
             raise RuntimeError('Fields must be initialized before using electric_energy_in_box')
 
-        box = self._fit_volume_to_simulation(box)
+        if isinstance(box, mp.Volume):
+            box = self._fit_volume_to_simulation(box).swigobj
 
-        return self.fields.electric_energy_in_box(box.swigobj)
+        return self.fields.electric_energy_in_box(box)
 
     def magnetic_energy_in_box(self, box):
         if self.fields is None:
             raise RuntimeError('Fields must be initialized before using magnetic_energy_in_box')
 
-        box = self._fit_volume_to_simulation(box)
+        if isinstance(box, mp.Volume):
+            box = self._fit_volume_to_simulation(box).swigobj
 
-        return self.fields.magnetic_energy_in_box(box.swigobj)
+        return self.fields.magnetic_energy_in_box(box)
 
     def field_energy_in_box(self, box):
         if self.fields is None:
             raise RuntimeError('Fields must be initialized before using field_energy_in_box')
 
-        box = self._fit_volume_to_simulation(box)
+        if isinstance(box, mp.Volume):
+            box = self._fit_volume_to_simulation(box).swigobj
 
-        return self.fields.field_energy_in_box(box.swigobj)
+        return self.fields.field_energy_in_box(box)
 
-    def modal_volume_in_box(self, vol=None):
+    def modal_volume_in_box(self, box=None):
         if self.fields is None:
             raise RuntimeError('Fields must be initialized before using modal_volume_in_box')
 
-        if vol is None:
-            vol = self.fields.total_volume()
+        if box is None:
+            box = self.fields.total_volume()
         else:
-            vol = self._fit_volume_to_simulation(vol).swigobj
+            box = self._fit_volume_to_simulation(box).swigobj
 
-        return self.fields.modal_volume_in_box(vol)
+        return self.fields.modal_volume_in_box(box)
 
     def solve_cw(self, tol=1e-8, maxiters=10000, L=2):
         if self.fields is None:

--- a/python/tests/simulation.py
+++ b/python/tests/simulation.py
@@ -262,6 +262,22 @@ class TestSimulation(unittest.TestCase):
         self.assertAlmostEqual(sim.fields.modal_volume_in_box(vol.swigobj),
                                sim.modal_volume_in_box(vol))
 
+    def test_in_box_volumes(self):
+        sim = self.init_simple_simulation()
+        sim.run(until=200)
+
+        tv = sim.fields.total_volume()
+        v = mp.Volume(mp.Vector3(), size=mp.Vector3(5, 5))
+
+        sim.electric_energy_in_box(tv)
+        sim.electric_energy_in_box(v)
+        sim.flux_in_box(mp.X, tv)
+        sim.flux_in_box(mp.X, v)
+        sim.magnetic_energy_in_box(tv)
+        sim.magnetic_energy_in_box(v)
+        sim.field_energy_in_box(tv)
+        sim.field_energy_in_box(v)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
* The `*in_box` functions already accepted `meep.Volume`s, but this wasn't reflected in the docs.
* Let `*in_box` functions accept SWIG `meep::volume`s or python `meep.Volume`s so the user can pass `total_volume()` as described in the docs.
@stevengj @oskooi 