### PR TITLE
Add dft_fields functions to scheme API

### DIFF
--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -1105,9 +1105,9 @@ Output the dielectric function (relative permittivity) $\varepsilon$. Note that 
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 Output the relative permeability function $\mu$. Note that this only outputs the frequency-independent part of $\mu$ (the $\omega\to\infty$ limit).
 
-**`output_dft(dft_fields, fname)`**  
+**`output_dft(dft_fields, fname, [where])`**  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-Output the Fourier-transformed fields in `dft_fields` (created by `add_dft_fields`) to an HDF5 file with name `fname` (does *not* include the `.h5` suffix).
+Output the Fourier-transformed fields in `dft_fields` (created by `add_dft_fields`) to an HDF5 file with name `fname` (does *not* include the `.h5` suffix). The `Volume` `where` defaults to the entire computational cell. 
 
 **`output_hpwr()`**  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;

--- a/doc/docs/Scheme_User_Interface.md
+++ b/doc/docs/Scheme_User_Interface.md
@@ -698,6 +698,10 @@ Given a `component` or `derived-component` constant `c` and a `vector3` `pt`, re
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 Equivalent to `(get-field-point Dielectric pt)`.
 
+**`(add-dft-fields cs freq-min freq-max nfreq [where])`**  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+Given a list of field components `cs`, compute the Fourier transform of these fields for `nfreq` equally spaced frequencies covering the frequency range `freq-min` to `freq-max` over the `volume` specified by `where` (default to the entire computationall cell).
+
 **`(flux-in-box dir box)`**  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 Given a `direction` constant, and a `meep::volume*`, returns the flux (the integral of $\Re [\mathbf{E}^* \times \mathbf{H}]$) in that volume. Most commonly, you specify a volume that is a plane or a line, and a direction perpendicular to it, e.g. `(flux-in-box `X (volume (center 0) (size 0 1 1)))`.
@@ -1031,6 +1035,10 @@ Output the dielectric function (relative permittivity) $\varepsilon$. Note that 
 **`output-mu`**  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 Output the relative permeability function $\mu$. Note that this only outputs the frequency-independent part of $\mu$ (the $\omega\to\infty$ limit).
+
+**`(output-dft dft-fields fname [where])`**  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+Output the Fourier-transformed fields in `dft-fields` (created by `add-dft-fields`) to an HDF5 file with name `fname` (does *not* include the `.h5` suffix). The `volume` `where` defaults to the entire computational cell.
 
 **`output-hpwr`**  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;

--- a/scheme/meep.i
+++ b/scheme/meep.i
@@ -163,6 +163,10 @@ static inline std::complex<double> my_complex_func3(std::complex<double> x) {
        SCM_NFALSEP(scm_procedure_p(gh_cdr($input)));
 }
 
+%typecheck(SWIG_TYPECHECK_POINTER) (meep::component *components, int num_components) {
+    $1 = SCM_NFALSEP(scm_list_p($input));
+}
+
 %typemap(in) (meep::component *components, int num_components) {
   $2 = list_length($input);
   $1 = new meep::component[$2];

--- a/scheme/meep.i
+++ b/scheme/meep.i
@@ -163,6 +163,21 @@ static inline std::complex<double> my_complex_func3(std::complex<double> x) {
        SCM_NFALSEP(scm_procedure_p(gh_cdr($input)));
 }
 
+%typemap(in) (meep::component *components, int num_components) {
+  $2 = list_length($input);
+  $1 = new meep::component[$2];
+
+  for (int i = 0; i < $2; ++i) {
+    $1[i] = meep::component(integer_list_ref($input, i));
+  }
+}
+
+%typemap(freearg) (meep::component *components, int num_components) {
+  if ($1) {
+    delete[] $1;
+  }
+}
+
 // Need to tell SWIG about any method that returns a new object
 // which needs to be garbage-collected.
 %newobject meep::fields::open_h5file;

--- a/scheme/meep.scm.in
+++ b/scheme/meep.scm.in
@@ -673,6 +673,19 @@
   (meep-dft-near2far-scale-dfts near2far -1.0))
 
 ; ****************************************************************
+; dft fields
+
+(define (add-dft-fields components freq_min freq_max nfreq . where)
+  (if (null? fields) (init-fields))
+  (let ((vol (if (null? where) (meep-fields-total-volume fields) (car where))))
+    (meep-fields-add-dft-fields fields components vol freq_min freq_max nfreq)))
+
+(define (output-dft dft_fields fname . where)
+  (if (null? fields) (init-fields))
+  (let ((vol (if (null? where) (meep-fields-total-volume fields) (car where))))
+    (meep-fields-output-dft fields dft_fields fname vol)))
+
+; ****************************************************************
 ; Generic step functions: these are functions which are called
 ; (potentially) at every time step.  They can either be a thunk
 ; or they can take one argument, to-do.  to-do is either 'step


### PR DESCRIPTION
I (sanity) tested the high level wrappers with this script:

```scheme
(define-param n 3.4)
(define-param w 1)
(define-param r 1)
(define-param pad 4)
(define-param dpml 2)

(define-param sxy (* 2 (+ r w pad dpml)))

(set! geometry (list (make cylinder
                           (radius (+ r w))
                           (material (make medium (index n)))
                           (center 0 0 0)
                           (height infinity))
                     (make cylinder
                           (radius r)
                           (material vacuum)
                           (center 0 0 0)
                           (height infinity))))

(define-param fcen 0.118)
(define-param df 0.08)

(set! sources (list (make source (src (make gaussian-src (frequency fcen) (fwidth df)))
                          (component Ez) (center (+ r 0.1)))))

(set! geometry-lattice (make lattice (size sxy sxy no-size)))
(set! resolution 10)
(set! force-complex-fields? true)
(set! symmetries (list (make mirror-sym (direction Y))))
(set! pml-layers (list (make pml (thickness dpml))))

(init-fields)
(define dfts (add-dft-fields (list Ez) fcen fcen 1))
(run-sources+ 100)
(output-dft dfts "dft_fields")
```
@stevengj @oskooi @HomerReid 