### PR TITLE
Add MPBArray subclass of np.ndarray to hold lattice for MPBData

### DIFF
--- a/libpympb/pympb.cpp
+++ b/libpympb/pympb.cpp
@@ -2117,6 +2117,10 @@ void mode_solver::get_lattice(double data[3][3]) {
   matrix3x3_to_arr(data, Rm);
 }
 
+vector3 mode_solver::get_cur_kvector() {
+   return cur_kvector;
+}
+
 std::vector<int> mode_solver::get_eigenvectors_slice_dims(int num_bands) {
   std::vector<int> res(3);
   res[0] = H.localN;

--- a/libpympb/pympb.hpp
+++ b/libpympb/pympb.hpp
@@ -130,6 +130,7 @@ struct mode_solver {
   void set_curfield_cmplx(std::complex<mpb_real> *cdata, int size);
 
   void get_lattice(double data[3][3]);
+  vector3 get_cur_kvector();
   void get_eigenvectors(int p_start, int p, std::complex<mpb_real> *cdata, int size);
   std::vector<int> get_eigenvectors_slice_dims(int num_bands);
   void set_eigenvectors(int b_start, std::complex<mpb_real> *cdata, int size);

--- a/python/examples/mpb_data_analysis.py
+++ b/python/examples/mpb_data_analysis.py
@@ -25,13 +25,13 @@ def main():
               get_efields))
 
     # Create an MPBData instance to transform the efields
-    md = mpb.MPBData(ms.get_lattice(), rectify=True, resolution=32, periods=3)
+    md = mpb.MPBData(rectify=True, resolution=32, periods=3)
 
     converted = []
     for f in efields:
         # Get just the z component of the efields
         f = f[:, :, 2]
-        converted.append(md.convert(f, ms.k_points[10]))
+        converted.append(md.convert(f))
 
     ms.run_te()
 
@@ -40,7 +40,7 @@ def main():
     plt.axis('off')
     plt.show()
 
-    md = mpb.MPBData(ms.get_lattice(), rectify=True, resolution=32, periods=3)
+    md = mpb.MPBData(rectify=True, resolution=32, periods=3)
     rectangular_data = md.convert(eps)
     plt.imshow(rectangular_data.T, interpolation='spline36', cmap='binary')
     plt.axis('off')

--- a/python/mpb.i
+++ b/python/mpb.i
@@ -291,6 +291,7 @@ static PyObject* cmatrix3x3_to_pymatrix(cmatrix3x3 *m) {
 
 %pythoncode %{
     from .solver import (
+        MPBArray,
         ModeSolver,
         output_hfield,
         output_hfield_x,

--- a/python/mpb_data.py
+++ b/python/mpb_data.py
@@ -1,11 +1,11 @@
 from __future__ import division
 
 import math
-import re
 
 import numpy as np
 import meep as mp
 from . import map_data
+from . import MPBArray
 
 
 class MPBData(object):
@@ -13,7 +13,7 @@ class MPBData(object):
     TWOPI = 6.2831853071795864769252867665590057683943388
 
     def __init__(self,
-                 lattice,
+                 lattice=None,
                  rectify=False,
                  x=0,
                  y=0,
@@ -277,6 +277,17 @@ class MPBData(object):
         self.cart_map = cart_map
 
     def convert(self, arr, kpoint=None):
+        if isinstance(arr, MPBArray):
+            self.lattice = arr.lattice
+
+        if self.lattice is None:
+            err = ("Couldn't find 'lattice.' You must do one of the following:\n" +
+                   "  1. Pass the ModeSolver lattice to the MPBData constructor\n" +
+                   "     i.e., MPBData(lattice=ms.get_lattice())\n" +
+                   "  2. Create an MPBArray to pass to MPBData.convert()\n" +
+                   "     i.e., mpb_arr = MPBArray(arr, ms.get_lattice(), ... ); mpb_data.convert(mpb_arr))")
+            raise ValueError(err)
+
         self.init_output_lattice(kpoint)
 
         if len(arr.shape) == 3:

--- a/python/mpb_data.py
+++ b/python/mpb_data.py
@@ -14,6 +14,7 @@ class MPBData(object):
 
     def __init__(self,
                  lattice=None,
+                 kpoint=None,
                  rectify=False,
                  x=0,
                  y=0,
@@ -26,6 +27,7 @@ class MPBData(object):
                  verbose=False):
 
         self.lattice = lattice
+        self.kpoint = kpoint
         self.rectify = rectify
 
         if periods:
@@ -56,7 +58,7 @@ class MPBData(object):
                              math.sin(self.TWOPI * self.phase_angle / 360.0))
         self.scaleby *= self.phase
 
-    def handle_dataset(self, in_arr, kvector):
+    def handle_dataset(self, in_arr):
 
         out_dims = [1, 1, 1]
         rank = len(in_arr.shape)
@@ -103,8 +105,8 @@ class MPBData(object):
         flat_in_arr_re = in_arr_re.ravel()
         flat_in_arr_im = in_arr_im.ravel() if isinstance(in_arr_im, np.ndarray) else np.array([])
 
-        if kvector:
-            kvector = [kvector.x, kvector.y, kvector.z]
+        if self.kpoint:
+            kvector = [self.kpoint.x, self.kpoint.y, self.kpoint.z]
         else:
             kvector = []
 
@@ -121,7 +123,7 @@ class MPBData(object):
 
         return np.reshape(out_arr_re, out_dims[:rank])
 
-    def handle_cvector_dataset(self, in_arr, kvector):
+    def handle_cvector_dataset(self, in_arr):
         in_x_re = np.real(in_arr[:, :, 0]).ravel()
         in_x_im = np.imag(in_arr[:, :, 0]).ravel()
         in_y_re = np.real(in_arr[:, :, 1]).ravel()
@@ -179,8 +181,8 @@ class MPBData(object):
             fmt = "Output data {}x{}x{}."
             print(fmt.format(out_dims[0], out_dims[1], out_dims[2]))
 
-        if kvector:
-            kvector = [kvector.x, kvector.y, kvector.z]
+        if self.kpoint:
+            kvector = [self.kpoint.x, self.kpoint.y, self.kpoint.z]
         else:
             kvector = []
 
@@ -205,7 +207,7 @@ class MPBData(object):
 
         return np.reshape(result, (out_dims[0], out_dims[1], 3))
 
-    def init_output_lattice(self, kvector):
+    def init_output_lattice(self):
 
         cart_map = mp.Matrix(
             mp.Vector3(1, 0, 0),
@@ -221,8 +223,9 @@ class MPBData(object):
 
         if self.verbose:
             print("Read lattice vectors")
-            if kvector:
-                print("Read Bloch wavevector ({:.6g}, {:.6g}, {:.6g})".format(kvector.x, kvector.y, kvector.z))
+            if self.kpoint:
+                fmt = "Read Bloch wavevector ({:.6g}, {:.6g}, {:.6g})"
+                print(fmt.format(self.kpoint.x, self.kpoint.y, self.kpoint.z))
             fmt = "Input lattice = ({:.6g}, {:.6g}, {:.6g}), ({:.6g}, {:.6g}, {:.6g}), ({:.6g}, {:.6g}, {:.6g})"
             print(fmt.format(Rin.c1.x, Rin.c1.y, Rin.c1.z,
                              Rin.c2.x, Rin.c2.y, Rin.c2.z,
@@ -279,6 +282,7 @@ class MPBData(object):
     def convert(self, arr, kpoint=None):
         if isinstance(arr, MPBArray):
             self.lattice = arr.lattice
+            self.kpoint = arr.kpoint
 
         if self.lattice is None:
             err = ("Couldn't find 'lattice.' You must do one of the following:\n" +
@@ -288,9 +292,12 @@ class MPBData(object):
                    "     i.e., mpb_arr = MPBArray(arr, ms.get_lattice(), ... ); mpb_data.convert(mpb_arr))")
             raise ValueError(err)
 
-        self.init_output_lattice(kpoint)
+        if kpoint:
+            self.kpoint = kpoint
+
+        self.init_output_lattice()
 
         if len(arr.shape) == 3:
-            return self.handle_cvector_dataset(arr, kpoint)
+            return self.handle_cvector_dataset(arr)
         else:
-            return self.handle_dataset(arr, kpoint)
+            return self.handle_dataset(arr)

--- a/python/tests/mpb.py
+++ b/python/tests/mpb.py
@@ -935,7 +935,7 @@ class TestModeSolver(unittest.TestCase):
             efield = np.vectorize(complex)(efield_re, efield_im)
 
         # rectangularize
-        md = mpb.MPBData(ms.get_lattice(), rectify=True, resolution=32, periods=3, verbose=True)
+        md = mpb.MPBData(lattice=ms.get_lattice(), rectify=True, resolution=32, periods=3, verbose=True)
         new_efield = md.convert(efield, ms.k_points[10])
         # check with ref file
 
@@ -973,7 +973,7 @@ class TestModeSolver(unittest.TestCase):
 
         # Test MPBData
         eps = ms.get_epsilon()
-        md = mpb.MPBData(ms.get_lattice(), rectify=True, resolution=32, periods=3, verbose=True)
+        md = mpb.MPBData(rectify=True, resolution=32, periods=3, verbose=True)
         new_eps = md.convert(eps)
         ref_fn = 'tri-rods-epsilon-r-m3-n32.h5'
         ref_path = os.path.join(self.data_dir, ref_fn)
@@ -1121,8 +1121,7 @@ class TestModeSolver(unittest.TestCase):
         k = mp.Vector3(1 / -3, 1 / 3)
         ms.run_tm(mpb.output_at_kpoint(k, mpb.fix_efield_phase, get_efields))
 
-        lat = ms.get_lattice()
-        md = mpb.MPBData(lat, rectify=True, periods=3, resolution=32, verbose=True)
+        md = mpb.MPBData(rectify=True, periods=3, resolution=32, verbose=True)
         result = md.convert(efields[-1], ms.k_points[10])
 
         ref_fn = 'converted-tri-rods-e.k11.b08.tm.h5'

--- a/python/tests/mpb.py
+++ b/python/tests/mpb.py
@@ -1122,7 +1122,7 @@ class TestModeSolver(unittest.TestCase):
         ms.run_tm(mpb.output_at_kpoint(k, mpb.fix_efield_phase, get_efields))
 
         md = mpb.MPBData(rectify=True, periods=3, resolution=32, verbose=True)
-        result = md.convert(efields[-1], ms.k_points[10])
+        result = md.convert(efields[-1])
 
         ref_fn = 'converted-tri-rods-e.k11.b08.tm.h5'
         ref_path = os.path.join(self.data_dir, ref_fn)


### PR DESCRIPTION
Numpy arrays returned from pyMPB are now returned as instances of `MPBArray`, which is just a `np.ndarray` that additionally holds the lattice. This facilitates creation of `MPBData`.

There are 3 ways to pass the lattice to `MPBData`:
### Option 1: Create MPBData with lattice and convert user array
```python
ms = mpb.ModeSolver(...)
md = mpb.MPBData(lattice=ms.get_lattice(), ...)
arr = user_numpy_array()
new_arr = md.convert(arr)
```
### Option 2: Create MPBArray from user array and convert
```python
ms = mpb.ModeSolver(...)
md = mpb.MPBData(...)
arr = user_numpy_array()
mpb_arr = mpb.MPBArray(arr, ms.get_lattice())
new_arr = md.convert(mpb_arr)
```
### Option 3: Convert MPBArray obtained from library call
```python
ms = mpb.ModeSolver(...)
md = mpb.MPBData(...)
arr = ms.get_epsilon()
new_arr = md.convert(arr)
```
@stevengj @oskooi @HomerReid 