### PR TITLE
Align with MPB docs

### DIFF
--- a/libpympb/pympb.hpp
+++ b/libpympb/pympb.hpp
@@ -39,6 +39,7 @@ struct mode_solver {
   std::string epsilon_input_file;
   std::string mu_input_file;
   bool force_mu;
+  bool use_simple_preconditioner;
 
   int n[3];
   int local_N;
@@ -91,7 +92,7 @@ struct mode_solver {
               int mesh_size, meep_geom::material_data *_default_material, geometric_object_list geom,
               bool reset_fields, bool deterministic, double target_freq, int dims, bool verbose,
               bool periodicity, double flops, bool negative_epsilon_ok, std::string epsilon_input_file,
-              std::string mu_input_file, bool force_mu);
+              std::string mu_input_file, bool force_mu, bool use_simple_preconditioner);
   ~mode_solver();
 
   void init(int p, bool reset_fields);

--- a/python/geom.py
+++ b/python/geom.py
@@ -113,6 +113,19 @@ class Vector3(object):
         vperp = self - vpar
         return vpar + (vperp.scale(math.cos(theta)) + vcross.scale(math.sin(theta)))
 
+    # rotate vectors in lattice/reciprocal coords (note that the axis
+    # is also given in the corresponding basis):
+
+    def rotate_lattice(self, axis, theta, lat):
+        a = lattice_to_cartesian(axis, lat)
+        v = lattice_to_cartesian(self, lat)
+        return cartesian_to_lattice(v.rotate(a, theta), lat)
+
+    def rotate_reciprocal(self, axis, theta, lat):
+        a = reciprocal_to_cartesian(axis, lat)
+        v = reciprocal_to_cartesian(self, lat)
+        return cartesian_to_reciprocal(v.rotate(a, theta), lat)
+
 
 class Medium(object):
 

--- a/python/solver.py
+++ b/python/solver.py
@@ -33,8 +33,7 @@ class ModeSolver(object):
                  eigensolver_nwork=3,
                  eigensolver_block_size=-11,
                  eigensolver_flags=68,
-                 is_simple_preconditioner=False,
-                 is_deterministic=False,
+                 use_simple_preconditioner=False,
                  force_mu=False,
                  mu_input_file='',
                  epsilon_input_file='',
@@ -61,8 +60,7 @@ class ModeSolver(object):
         self.eigensolver_nwork = eigensolver_nwork
         self.eigensolver_block_size = eigensolver_block_size
         self.eigensolver_flags = eigensolver_flags
-        self.is_simple_preconditioner = is_simple_preconditioner
-        self.is_deterministic = is_deterministic
+        self.use_simple_preconditioner = use_simple_preconditioner
         self.force_mu = force_mu
         self.mu_input_file = mu_input_file
         self.epsilon_input_file = epsilon_input_file
@@ -204,6 +202,9 @@ class ModeSolver(object):
         self.mode_solver.get_curfield_cmplx(res)
 
         return np.reshape(res, dims)
+
+    def fix_field_phase(self):
+        self.mode_solver.fix_field_phase()
 
     def get_epsilon_point(self, p):
         return self.mode_solver.get_epsilon_point(p)
@@ -570,6 +571,12 @@ class ModeSolver(object):
         return self.mode_solver.compute_1_group_velocity_component(direction,
                                                                    which_band)
 
+    def compute_zparities(self):
+        return self.mode_solver.compute_zparities()
+
+    def compute_yparities(self):
+        return self.mode_solver.compute_yparities()
+
     def randomize_fields(self):
         self.mode_solver.randomize_fields()
 
@@ -605,24 +612,7 @@ class ModeSolver(object):
         mean_time = self.total_run_time / (mean_iters * num_runs)
         print("mean time per iteration = {} s".format(mean_time))
 
-    def run_parity(self, p, reset_fields, *band_functions):
-        if self.random_fields and self.randomize_fields not in band_functions:
-            band_functions.append(self.randomize_fields)
-
-        start = time.time()
-
-        self.all_freqs = np.zeros((len(self.k_points), self.num_bands))
-        self.band_range_data = []
-
-        init_time = time.time()
-
-        print("Initializing eigensolver data")
-        print("Computing {} bands with {} tolerance".format(self.num_bands, self.tolerance))
-
-        if type(self.default_material) is not mp.Medium and callable(self.default_material):
-            # TODO: Support epsilon_function user materials like meep?
-            self.default_material.eps = False
-
+    def init_params(self, p, reset_fields):
         self.mode_solver = mode_solver(
             self.num_bands,
             p,
@@ -643,7 +633,34 @@ class ModeSolver(object):
             self.epsilon_input_file,
             self.mu_input_file,
             self.force_mu,
+            self.use_simple_preconditioner,
         )
+
+    def set_parity(self, p):
+        self.mode_solver.set_parity(p)
+
+    def solve_kpoint(self, k):
+        self.mode_solver.solve_kpoint(k)
+
+    def run_parity(self, p, reset_fields, *band_functions):
+        if self.random_fields and self.randomize_fields not in band_functions:
+            band_functions.append(self.randomize_fields)
+
+        start = time.time()
+
+        self.all_freqs = np.zeros((len(self.k_points), self.num_bands))
+        self.band_range_data = []
+
+        init_time = time.time()
+
+        print("Initializing eigensolver data")
+        print("Computing {} bands with {} tolerance".format(self.num_bands, self.tolerance))
+
+        if type(self.default_material) is not mp.Medium and callable(self.default_material):
+            # TODO: Support epsilon_function user materials like meep?
+            self.default_material.eps = False
+
+        self.init_params(p, reset_fields)
 
         if isinstance(reset_fields, basestring):
             self.load_eigenvectors(reset_fields)

--- a/python/tests/geom.py
+++ b/python/tests/geom.py
@@ -331,6 +331,20 @@ class TestVector3(unittest.TestCase):
         self.assertEqual(mp.Vector3(1, 1, 1) * mp.Vector3(1, 1, 1), 3)
         self.assertEqual(0.5 * mp.Vector3(2, 2, 2), mp.Vector3(1, 1, 1))
 
+    def test_rotate_lattice(self):
+        axis = mp.Vector3(1)
+        v = mp.Vector3(2, 2, 2)
+        lattice = mp.Lattice(size=mp.Vector3(1, 1))
+        res = v.rotate_lattice(axis, 3, lattice)
+        self.assertTrue(res.close(mp.Vector3(2.0, -2.262225009320625, -1.6977449770811563)))
+
+    def test_rotate_reciprocal(self):
+        axis = mp.Vector3(1)
+        v = mp.Vector3(2, 2, 2)
+        lattice = mp.Lattice(size=mp.Vector3(1, 1))
+        res = v.rotate_reciprocal(axis, 3, lattice)
+        self.assertTrue(res.close(mp.Vector3(2.0, -2.262225009320625, -1.6977449770811563)))
+
 
 class TestLattice(unittest.TestCase):
 


### PR DESCRIPTION
This fixes a few things I noticed while creating the Python User Interface docs for MPB PR 43.
* pass `use_simple_preconditioner` option to libpympb
* Add `rotate_lattice` and `rotate_reciprocal` to `Vector3`, along with tests
* Add some missing high level methods to `ModeSolver`
@stevengj @oskooi 
