### PR TITLE
Only run mpb tests serially

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ script:
   - export MEEP_VERSION=$(./configure -V | grep meep | awk '{print $3}')
   - mkdir -p build && pushd build
   - ../configure --enable-maintainer-mode --prefix=$HOME/local --with-libctl=$HOME/local/share/libctl ${MPICONF}
-  - make ${MKCHECKFLAGS} distcheck DISTCHECK_CONFIGURE_FLAGS="--with-libctl=${HOME}/local/share/libctl ${MPICONF}"
+  - travis_wait make ${MKCHECKFLAGS} distcheck DISTCHECK_CONFIGURE_FLAGS="--with-libctl=${HOME}/local/share/libctl ${MPICONF}"
 
 after_script:
   - BUILD_PREFIX=${TRAVIS_BUILD_DIR}/build/meep-${MEEP_VERSION}/_build

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ script:
   - export MEEP_VERSION=$(./configure -V | grep meep | awk '{print $3}')
   - mkdir -p build && pushd build
   - ../configure --enable-maintainer-mode --prefix=$HOME/local --with-libctl=$HOME/local/share/libctl ${MPICONF}
-  - travis_wait make ${MKCHECKFLAGS} distcheck DISTCHECK_CONFIGURE_FLAGS="--with-libctl=${HOME}/local/share/libctl ${MPICONF}"
+  - make ${MKCHECKFLAGS} distcheck DISTCHECK_CONFIGURE_FLAGS="--with-libctl=${HOME}/local/share/libctl ${MPICONF}"
 
 after_script:
   - BUILD_PREFIX=${TRAVIS_BUILD_DIR}/build/meep-${MEEP_VERSION}/_build

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -37,8 +37,10 @@ _mpb_la_CPPFLAGS = $(PYTHON_INCLUDES) $(AM_CPPFLAGS)
 # material_dispersion.py test must be excluded from test suite for MPI build
 if WITH_MPI
   MDPYTEST=
+  MPBPYTEST=
 else
   MDPYTEST=$(TEST_DIR)/material_dispersion.py
+  MPBPYTEST=$(TEST_DIR)/mpb.py
 endif
 
 TEST_DIR = tests
@@ -56,7 +58,7 @@ TESTS =                                   \
     $(TEST_DIR)/holey_wvg_cavity.py       \
     $(TEST_DIR)/ldos.py                   \
     $(MDPYTEST)                           \
-    $(TEST_DIR)/mpb.py                    \
+    $(MPBPYTEST)                          \
     $(TEST_DIR)/physical.py               \
     $(TEST_DIR)/pw_source.py              \
     $(TEST_DIR)/ring.py                   \

--- a/python/tests/mpb.py
+++ b/python/tests/mpb.py
@@ -1291,5 +1291,4 @@ class TestModeSolver(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    if mp.am_master():
-        unittest.main()
+    unittest.main()

--- a/python/tests/mpb.py
+++ b/python/tests/mpb.py
@@ -34,10 +34,8 @@ class TestModeSolver(unittest.TestCase):
         print('=' * 24)
 
         def rm_h5():
-            mp.all_wait()
-            if mp.am_master():
-                for f in glob.glob("{}*.h5".format(self.filename_prefix)):
-                    os.remove(f)
+            for f in glob.glob("{}*.h5".format(self.filename_prefix)):
+                os.remove(f)
 
         self.addCleanup(rm_h5)
 
@@ -196,7 +194,6 @@ class TestModeSolver(unittest.TestCase):
             self.assertLess(diff, tol)
 
     def compare_h5_files(self, ref_path, res_path, tol=1e-3):
-        mp.all_wait()
         with h5py.File(ref_path) as ref:
             with h5py.File(res_path, 'r') as res:
                 for k in ref.keys():
@@ -1294,4 +1291,5 @@ class TestModeSolver(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    if mp.am_master():
+        unittest.main()


### PR DESCRIPTION
Since PyMPB doesn't support mpi, we should always run the tests serially.
@stevengj @oskooi 