### PR TITLE
Improve options to multiply Bloch phase

### DIFF
--- a/libpympb/pympb.cpp
+++ b/libpympb/pympb.cpp
@@ -1889,9 +1889,11 @@ cvector3 mode_solver::get_field_point(vector3 p) {
   return F;
 }
 
-void mode_solver::multiply_bloch_phase() {
+void mode_solver::multiply_bloch_phase(std::complex<double> *cdata) {
 
   std::vector<mpb_real> kvector = get_output_k();
+
+  scalar_complex *data = cdata ? (scalar_complex*)cdata : (scalar_complex*)curfield;
 
   int dims[] = {mdata->nx, mdata->ny, mdata->nz};
   int local_dims[] = {mdata->local_nx, mdata->ny, mdata->nz};
@@ -1944,9 +1946,9 @@ void mode_solver::multiply_bloch_phase() {
 
         for (int component = 0; component < 3; ++component) {
           int ijkc = ijk + component;
-          re = curfield[ijkc].re; im = curfield[ijkc].im;
-          curfield[ijkc].re = re * p_re - im * p_im;
-          curfield[ijkc].im = im * p_re + re * p_im;
+          re = data[ijkc].re; im = data[ijkc].im;
+          data[ijkc].re = re * p_re - im * p_im;
+          data[ijkc].im = im * p_re + re * p_im;
         }
       }
     }

--- a/libpympb/pympb.cpp
+++ b/libpympb/pympb.cpp
@@ -2555,7 +2555,7 @@ void add_cmplx_times_phase(mpb_real *sum_re, mpb_real *sum_im, mpb_real d_re, mp
 void map_data(mpb_real *d_in_re, int size_in_re, mpb_real *d_in_im, int size_in_im,
               int n_in[3], mpb_real *d_out_re, int size_out_re, mpb_real *d_out_im,
               int size_out_im, int n_out[3], matrix3x3 coord_map, mpb_real *kvector,
-              bool pick_nearest, bool verbose) {
+              bool pick_nearest, bool verbose, bool multiply_bloch_phase) {
   (void)size_in_re;
   (void)size_in_im;
   (void)size_out_re;
@@ -2611,6 +2611,13 @@ void map_data(mpb_real *d_in_re, int size_in_re, mpb_real *d_in_im, int size_in_
          MODF_POSITIVE(x, xi);
          MODF_POSITIVE(y, yi);
          MODF_POSITIVE(z, zi);
+
+         if (multiply_bloch_phase) {
+           xi += x;
+           yi += y;
+           zi += z;
+         }
+
          i1 = x * n_in[0]; j1 = y * n_in[1]; k1 = z * n_in[2];
          dx = x * n_in[0] - i1;
          dy = y * n_in[1] - j1;

--- a/libpympb/pympb.hpp
+++ b/libpympb/pympb.hpp
@@ -162,7 +162,7 @@ struct mode_solver {
   cvector3 get_field_point(vector3 p);
   cvector3 get_bloch_field_point(vector3 p);
 
-  void multiply_bloch_phase();
+  void multiply_bloch_phase(std::complex<double> *cdata=NULL);
   void fix_field_phase();
   void compute_field_divergence();
   std::vector<mpb_real> compute_zparities();

--- a/libpympb/pympb.hpp
+++ b/libpympb/pympb.hpp
@@ -15,7 +15,7 @@ namespace py_mpb {
 void map_data(mpb_real *d_in_re, int size_in_re, mpb_real *d_in_im, int size_in_im,
               int n_in[3], mpb_real *d_out_re, int size_out_re, mpb_real *d_out_im,
               int size_out_im, int n_out[3], matrix3x3 coord_map, mpb_real *kvector,
-              bool pick_nearest, bool verbose);
+              bool pick_nearest, bool verbose, bool multiply_bloch_phase);
 
 bool with_hermitian_epsilon();
 

--- a/python/examples/mpb_data_analysis.py
+++ b/python/examples/mpb_data_analysis.py
@@ -19,7 +19,7 @@ def main():
 
     # Band function to collect the efields
     def get_efields(ms, band):
-        efields.append(ms.get_efield(band, output=True))
+        efields.append(ms.get_efield(band, bloch_phase=True))
 
     ms.run_tm(mpb.output_at_kpoint(mp.Vector3(1 / -3, 1 / 3), mpb.fix_efield_phase,
               get_efields))

--- a/python/examples/mpb_data_analysis.py
+++ b/python/examples/mpb_data_analysis.py
@@ -19,7 +19,7 @@ def main():
 
     # Band function to collect the efields
     def get_efields(ms, band):
-        efields.append(ms.get_efield(band, bloch_phase=True))
+        efields.append(ms.get_efield(band))
 
     ms.run_tm(mpb.output_at_kpoint(mp.Vector3(1 / -3, 1 / 3), mpb.fix_efield_phase,
               get_efields))

--- a/python/meep.i
+++ b/python/meep.i
@@ -586,9 +586,6 @@ meep::volume_list *make_volume_list(const meep::volume &v, int c,
     $1 = (std::complex<double> *)array_data($input);
 }
 
-// py_mpb::mode_solver::multiply_bloch_phase
-%apply std::complex<double>* slice {std::complex<double>* cdata};
-
 %typecheck(SWIG_TYPECHECK_POINTER) meep::component {
     $1 = PyInteger_Check($input) && PyInteger_AsLong($input) < 100;
 }
@@ -881,7 +878,6 @@ meep::volume_list *make_volume_list(const meep::volume &v, int c,
 %rename(get_field_from_comp) meep::fields::get_field(component, const vec &) const;
 
 %feature("python:cdefaultargs") meep::fields::add_eigenmode_source;
-%feature("python:cdefaultargs") py_mpb::mode_solver::multiply_bloch_phase;
 
 %feature("immutable") meep::fields_chunk::connections;
 %feature("immutable") meep::fields_chunk::num_connections;

--- a/python/meep.i
+++ b/python/meep.i
@@ -586,6 +586,9 @@ meep::volume_list *make_volume_list(const meep::volume &v, int c,
     $1 = (std::complex<double> *)array_data($input);
 }
 
+// py_mpb::mode_solver::multiply_bloch_phase
+%apply std::complex<double>* slice {std::complex<double>* cdata};
+
 %typecheck(SWIG_TYPECHECK_POINTER) meep::component {
     $1 = PyInteger_Check($input) && PyInteger_AsLong($input) < 100;
 }
@@ -878,6 +881,7 @@ meep::volume_list *make_volume_list(const meep::volume &v, int c,
 %rename(get_field_from_comp) meep::fields::get_field(component, const vec &) const;
 
 %feature("python:cdefaultargs") meep::fields::add_eigenmode_source;
+%feature("python:cdefaultargs") py_mpb::mode_solver::multiply_bloch_phase;
 
 %feature("immutable") meep::fields_chunk::connections;
 %feature("immutable") meep::fields_chunk::num_connections;

--- a/python/mpb.i
+++ b/python/mpb.i
@@ -346,6 +346,19 @@ static mpb_real field_integral_energy_callback(mpb_real energy, mpb_real epsilon
     $3 = (void*)$input;
 }
 
+%typecheck(SWIG_TYPECHECK_POINTER, fragment="NumPy_Fragments") std::complex<double>* cdata {
+    $1 = is_array($input) || $input == Py_None;
+}
+
+%typemap(in) std::complex<double>* cdata {
+    if ($input != Py_None) {
+        $1 = (std::complex<double> *)array_data($input);
+    }
+    else {
+        $1 = NULL;
+    }
+}
+
 %apply double { number };
 
 %include "pympb.hpp"

--- a/python/mpb_data.py
+++ b/python/mpb_data.py
@@ -112,7 +112,7 @@ class MPBData(object):
 
         map_data(flat_in_arr_re, flat_in_arr_im, np.array(in_dims, dtype=np.intc),
                  out_arr_re, out_arr_im, np.array(out_dims, dtype=np.intc), self.coord_map,
-                 kvector, self.pick_nearest, self.verbose)
+                 kvector, self.pick_nearest, self.verbose, False)
 
         if np.iscomplexobj(in_arr):
             # multiply * scaleby for complex data
@@ -123,7 +123,7 @@ class MPBData(object):
 
         return np.reshape(out_arr_re, out_dims[:rank])
 
-    def handle_cvector_dataset(self, in_arr):
+    def handle_cvector_dataset(self, in_arr, multiply_bloch_phase):
         in_x_re = np.real(in_arr[:, :, 0]).ravel()
         in_x_im = np.imag(in_arr[:, :, 0]).ravel()
         in_y_re = np.real(in_arr[:, :, 1]).ravel()
@@ -193,7 +193,7 @@ class MPBData(object):
 
             map_data(d_in[dim][0].ravel(), d_in[dim][1].ravel(), np.array(in_dims, dtype=np.intc),
                      out_arr_re, out_arr_im, np.array(out_dims, dtype=np.intc), self.coord_map,
-                     kvector, self.pick_nearest, self.verbose)
+                     kvector, self.pick_nearest, self.verbose, multiply_bloch_phase)
 
             # multiply * scaleby
             complex_out = np.vectorize(complex)(out_arr_re, out_arr_im)
@@ -298,13 +298,6 @@ class MPBData(object):
         self.init_output_lattice()
 
         if len(arr.shape) == 3:
-            if not arr.bloch_phase:
-                err = ('The input array has not been multiplied by the Bloch phase. You can get ' +
-                       'appropriate field data by passing bloch_phase=True to any get_*field function. ' +
-                       'Alternatively, ModeSolver.multiply_bloch_phase(array) will return an array ' +
-                       'that has been muliplied by the Bloch phase.')
-                raise ValueError(err)
-
-            return self.handle_cvector_dataset(arr)
+            return self.handle_cvector_dataset(arr, not arr.bloch_phase)
         else:
             return self.handle_dataset(arr)

--- a/python/mpb_data.py
+++ b/python/mpb_data.py
@@ -298,6 +298,13 @@ class MPBData(object):
         self.init_output_lattice()
 
         if len(arr.shape) == 3:
+            if not arr.bloch_phase:
+                err = ('The input array has not been multiplied by the Bloch phase. You can get ' +
+                       'appropriate field data by passing bloch_phase=True to any get_*field function. ' +
+                       'Alternatively, ModeSolver.multiply_bloch_phase(array) will return an array ' +
+                       'that has been muliplied by the Bloch phase.')
+                raise ValueError(err)
+
             return self.handle_cvector_dataset(arr)
         else:
             return self.handle_dataset(arr)

--- a/python/solver.py
+++ b/python/solver.py
@@ -26,13 +26,14 @@ U_SUM = 2
 
 class MPBArray(np.ndarray):
 
-    def __new__(cls, input_array, lattice, kpoint=None):
+    def __new__(cls, input_array, lattice, kpoint=None, bloch_phase=False):
         # Input array is an already formed ndarray instance
         # We first cast to be our class type
         obj = np.asarray(input_array).view(cls)
         # add the new properties to the created instance
         obj.lattice = lattice
         obj.kpoint = kpoint
+        obj.bloch_phase = bloch_phase
         # Finally, we must return the newly created object:
         return obj
 
@@ -64,6 +65,7 @@ class MPBArray(np.ndarray):
         # arr.view(MPBArray).
         self.lattice = getattr(obj, 'lattice', None)
         self.kpoint = getattr(obj, 'kpoint', None)
+        self.bloch_phase = getattr(obj, 'bloch_phase', False)
 
 
 class ModeSolver(object):
@@ -169,6 +171,12 @@ class ModeSolver(object):
     def get_freqs(self):
         return self.mode_solver.get_freqs()
 
+    def multiply_bloch_phase(self, arr):
+        dims = arr.shape
+        arr = arr.ravel()
+        self.mode_solver.multiply_bloch_phase(arr)
+        return np.reshape(arr, dims)
+
     def get_poynting(self, which_band):
         e = self.get_efield(which_band).ravel()
         h = self.get_hfield(which_band).ravel()
@@ -215,23 +223,23 @@ class ModeSolver(object):
 
         return np.reshape(mu, dims)
 
-    def get_bfield(self, which_band, output=False):
-        return self._get_field('b', which_band, output)
+    def get_bfield(self, which_band, bloch_phase=False):
+        return self._get_field('b', which_band, bloch_phase)
 
-    def get_efield(self, which_band, output=False):
-        return self._get_field('e', which_band, output)
+    def get_efield(self, which_band, bloch_phase=False):
+        return self._get_field('e', which_band, bloch_phase)
 
-    def get_dfield(self, which_band, output=False):
-        return self._get_field('d', which_band, output)
+    def get_dfield(self, which_band, bloch_phase=False):
+        return self._get_field('d', which_band, bloch_phase)
 
-    def get_hfield(self, which_band, output=False):
-        return self._get_field('h', which_band, output)
+    def get_hfield(self, which_band, bloch_phase=False):
+        return self._get_field('h', which_band, bloch_phase)
 
     def get_charge_density(self, which_band):
         self.get_efield(which_band)
         self.mode_solver.compute_field_divergence()
 
-    def _get_field(self, f, band, output):
+    def _get_field(self, f, band, bloch_phase):
         if self.mode_solver is None:
             raise ValueError("Must call a run function before attempting to get a field")
 
@@ -248,13 +256,13 @@ class ModeSolver(object):
         dims += [3]
         arr = np.zeros(np.prod(dims), np.complex128)
 
-        if output:
+        if bloch_phase:
             self.mode_solver.multiply_bloch_phase()
 
         self.mode_solver.get_curfield_cmplx(arr)
 
         arr = np.reshape(arr, dims)
-        res = MPBArray(arr, self.get_lattice(), self.current_k)
+        res = MPBArray(arr, self.get_lattice(), self.current_k, bloch_phase=bloch_phase)
 
         return res
 

--- a/python/solver.py
+++ b/python/solver.py
@@ -223,16 +223,16 @@ class ModeSolver(object):
 
         return np.reshape(mu, dims)
 
-    def get_bfield(self, which_band, bloch_phase=False):
+    def get_bfield(self, which_band, bloch_phase=True):
         return self._get_field('b', which_band, bloch_phase)
 
-    def get_efield(self, which_band, bloch_phase=False):
+    def get_efield(self, which_band, bloch_phase=True):
         return self._get_field('e', which_band, bloch_phase)
 
-    def get_dfield(self, which_band, bloch_phase=False):
+    def get_dfield(self, which_band, bloch_phase=True):
         return self._get_field('d', which_band, bloch_phase)
 
-    def get_hfield(self, which_band, bloch_phase=False):
+    def get_hfield(self, which_band, bloch_phase=True):
         return self._get_field('h', which_band, bloch_phase)
 
     def get_charge_density(self, which_band):
@@ -985,93 +985,93 @@ class ModeSolver(object):
 # Predefined output functions (functions of the band index), for passing to `run`
 
 def output_hfield(ms, which_band):
-    ms.get_hfield(which_band)
+    ms.get_hfield(which_band, False)
     ms.output_field()
 
 
 def output_hfield_x(ms, which_band):
-    ms.get_hfield(which_band)
+    ms.get_hfield(which_band, False)
     ms.output_field_x()
 
 
 def output_hfield_y(ms, which_band):
-    ms.get_hfield(which_band)
+    ms.get_hfield(which_band, False)
     ms.output_field_y()
 
 
 def output_hfield_z(ms, which_band):
-    ms.get_hfield(which_band)
+    ms.get_hfield(which_band, False)
     ms.output_field_z()
 
 
 def output_bfield(ms, which_band):
-    ms.get_bfield(which_band)
+    ms.get_bfield(which_band, False)
     ms.output_field()
 
 
 def output_bfield_x(ms, which_band):
-    ms.get_bfield(which_band)
+    ms.get_bfield(which_band, False)
     ms.output_field_x()
 
 
 def output_bfield_y(ms, which_band):
-    ms.get_bfield(which_band)
+    ms.get_bfield(which_band, False)
     ms.output_field_y()
 
 
 def output_bfield_z(ms, which_band):
-    ms.get_bfield(which_band)
+    ms.get_bfield(which_band, False)
     ms.output_field_z()
 
 
 def output_dfield(ms, which_band):
-    ms.get_dfield(which_band)
+    ms.get_dfield(which_band, False)
     ms.output_field()
 
 
 def output_dfield_x(ms, which_band):
-    ms.get_dfield(which_band)
+    ms.get_dfield(which_band, False)
     ms.output_field_x()
 
 
 def output_dfield_y(ms, which_band):
-    ms.get_dfield(which_band)
+    ms.get_dfield(which_band, False)
     ms.output_field_y()
 
 
 def output_dfield_z(ms, which_band):
-    ms.get_dfield(which_band)
+    ms.get_dfield(which_band, False)
     ms.output_field_z()
 
 
 def output_efield(ms, which_band):
-    ms.get_efield(which_band)
+    ms.get_efield(which_band, False)
     ms.output_field()
 
 
 def output_efield_x(ms, which_band):
-    ms.get_efield(which_band)
+    ms.get_efield(which_band, False)
     ms.output_field_x()
 
 
 def output_efield_y(ms, which_band):
-    ms.get_efield(which_band)
+    ms.get_efield(which_band, False)
     ms.output_field_y()
 
 
 def output_efield_z(ms, which_band):
-    ms.get_efield(which_band)
+    ms.get_efield(which_band, False)
     ms.output_field_z()
 
 
 def output_bpwr(ms, which_band):
-    ms.get_bfield(which_band)
+    ms.get_bfield(which_band, False)
     ms.compute_field_energy()
     ms.output_field()
 
 
 def output_dpwr(ms, which_band):
-    ms.get_dfield(which_band)
+    ms.get_dfield(which_band, False)
     ms.compute_field_energy()
     ms.output_field()
 
@@ -1091,7 +1091,7 @@ def output_dpwr_in_objects(output_func, min_energy, objects=[]):
     """
 
     def _output(ms, which_band):
-        ms.get_dfield(which_band)
+        ms.get_dfield(which_band, False)
         ms.compute_field_energy()
         energy = ms.compute_energy_in_objects(objects)
         fmt = "dpwr:, {}, {}, {} "
@@ -1143,22 +1143,22 @@ def display_group_velocities(ms):
 # given band based upon the spatial representation of the given field
 
 def fix_hfield_phase(ms, which_band):
-    ms.get_hfield(which_band)
+    ms.get_hfield(which_band, False)
     ms.mode_solver.fix_field_phase()
 
 
 def fix_bfield_phase(ms, which_band):
-    ms.get_bfield(which_band)
+    ms.get_bfield(which_band, False)
     ms.mode_solver.fix_field_phase()
 
 
 def fix_dfield_phase(ms, which_band):
-    ms.get_dfield(which_band)
+    ms.get_dfield(which_band, False)
     ms.mode_solver.fix_field_phase()
 
 
 def fix_efield_phase(ms, which_band):
-    ms.get_efield(which_band)
+    ms.get_efield(which_band, False)
     ms.mode_solver.fix_field_phase()
 
 

--- a/python/tests/mpb.py
+++ b/python/tests/mpb.py
@@ -334,7 +334,7 @@ class TestModeSolver(unittest.TestCase):
         get_field_func = getattr(ms, "get_{}field".format(field))
         fix_phase_func = getattr(mpb, "fix_{}field_phase".format(field))
         fix_phase_func(ms, ms.num_bands)
-        fields = get_field_func(ms.num_bands)
+        fields = get_field_func(ms.num_bands, bloch_phase=True)
 
         ref_fname = "tutorial-{}.k16.b08.te.h5".format(field)
         ref_path = os.path.join(self.data_dir, ref_fname)
@@ -1123,7 +1123,7 @@ class TestModeSolver(unittest.TestCase):
         efields = []
 
         def get_efields(ms, band):
-            efields.append(ms.get_efield(8, output=True))
+            efields.append(ms.get_efield(8, bloch_phase=True))
 
         k = mp.Vector3(1 / -3, 1 / 3)
         ms.run_tm(mpb.output_at_kpoint(k, mpb.fix_efield_phase, get_efields))
@@ -1286,6 +1286,18 @@ class TestModeSolver(unittest.TestCase):
 
         field_integral = ms.compute_field_integral(f2)
         self.assertAlmostEqual(field_integral, 02.0735366548785272e-18 - 3.0259168624899837e-6j)
+
+    def test_multiply_bloch_phase(self):
+        ms = self.init_solver()
+        ms.run_te()
+
+        mpb.fix_efield_phase(ms, 8)
+        efield = ms.get_efield(8)
+        bloch_efield = ms.multiply_bloch_phase(efield)
+
+        ref_fn = 'tutorial-e.k16.b08.te.h5'
+        ref_path = os.path.join(self.data_dir, ref_fn)
+        self.check_fields_against_h5(ref_path, bloch_efield)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
You had requested that `MPBArray` hold a flag that `MPBData` could check to determine whether or not `multiply_bloch_phase` has been called on the input array. The issue there is that `MPBData` would need a `ModeSolver` instance to call `multiply_bloch_phase`.

This adds two ways to control the Bloch phase.
1. `get_*field` has a `bloch_phase` flag that can be set to true but is false by default.
2. `multiply_bloch_phase` can take an optional numpy array. If called with no argument, it does its work on whatever's in `curfield`.

If `MPBData` gets an array that hasn't been multiplied by the Bloch phase, it prints an error message explaining how to do that.

@stevengj @oskooi 