### PR TITLE
MPB Additions

### DIFF
--- a/libpympb/pympb.cpp
+++ b/libpympb/pympb.cpp
@@ -203,7 +203,8 @@ mode_solver::mode_solver(int num_bands,
                          std::string epsilon_input_file,
                          std::string mu_input_file,
                          bool force_mu,
-                         bool use_simple_preconditioner):
+                         bool use_simple_preconditioner,
+                         vector3 grid_size):
   num_bands(num_bands),
   parity(parity),
   target_freq(target_freq),
@@ -214,6 +215,7 @@ mode_solver::mode_solver(int num_bands,
   mu_input_file(mu_input_file),
   force_mu(force_mu),
   use_simple_preconditioner(use_simple_preconditioner),
+  grid_size(grid_size),
   eigensolver_nwork(3),
   eigensolver_block_size(-11),
   last_parity(-2),
@@ -715,9 +717,9 @@ bool mode_solver::using_mu() {
 void mode_solver::init(int p, bool reset_fields) {
   int have_old_fields = 0;
 
-  n[0] = std::max(resolution[0] * std::ceil(geometry_lattice.size.x), 1.0);
-  n[1] = std::max(resolution[1] * std::ceil(geometry_lattice.size.y), 1.0);
-  n[2] = std::max(resolution[2] * std::ceil(geometry_lattice.size.z), 1.0);
+  n[0] = grid_size.x;
+  n[1] = grid_size.y;
+  n[2] = grid_size.z;
 
   if (target_freq != 0.0) {
     meep::master_printf("Target frequency is %g\n", target_freq);

--- a/libpympb/pympb.cpp
+++ b/libpympb/pympb.cpp
@@ -2133,10 +2133,6 @@ void mode_solver::get_lattice(double data[3][3]) {
   matrix3x3_to_arr(data, Rm);
 }
 
-vector3 mode_solver::get_cur_kvector() {
-   return cur_kvector;
-}
-
 std::vector<int> mode_solver::get_eigenvectors_slice_dims(int num_bands) {
   std::vector<int> res(3);
   res[0] = H.localN;

--- a/libpympb/pympb.hpp
+++ b/libpympb/pympb.hpp
@@ -41,7 +41,6 @@ struct mode_solver {
   bool force_mu;
   bool use_simple_preconditioner;
   vector3 grid_size;
-  bool use_eigensolver_davidson;
 
   int n[3];
   int local_N;
@@ -94,7 +93,7 @@ struct mode_solver {
               bool reset_fields, bool deterministic, double target_freq, int dims, bool verbose,
               bool periodicity, double flops, bool negative_epsilon_ok, std::string epsilon_input_file,
               std::string mu_input_file, bool force_mu, bool use_simple_preconditioner, vector3 grid_size,
-              bool use_eigensolver_davidson, int eigensolver_nwork, int eigensolver_block_size);
+              int eigensolver_nwork, int eigensolver_block_size);
   ~mode_solver();
 
   void init(int p, bool reset_fields);

--- a/libpympb/pympb.hpp
+++ b/libpympb/pympb.hpp
@@ -40,6 +40,7 @@ struct mode_solver {
   std::string mu_input_file;
   bool force_mu;
   bool use_simple_preconditioner;
+  vector3 grid_size;
 
   int n[3];
   int local_N;
@@ -92,7 +93,7 @@ struct mode_solver {
               int mesh_size, meep_geom::material_data *_default_material, geometric_object_list geom,
               bool reset_fields, bool deterministic, double target_freq, int dims, bool verbose,
               bool periodicity, double flops, bool negative_epsilon_ok, std::string epsilon_input_file,
-              std::string mu_input_file, bool force_mu, bool use_simple_preconditioner);
+              std::string mu_input_file, bool force_mu, bool use_simple_preconditioner, vector3 grid_size);
   ~mode_solver();
 
   void init(int p, bool reset_fields);

--- a/libpympb/pympb.hpp
+++ b/libpympb/pympb.hpp
@@ -41,6 +41,7 @@ struct mode_solver {
   bool force_mu;
   bool use_simple_preconditioner;
   vector3 grid_size;
+  bool use_eigensolver_davidson;
 
   int n[3];
   int local_N;
@@ -48,7 +49,6 @@ struct mode_solver {
   int alloc_N;
   int nwork_alloc;
 
-  // TODO: Get from python ?
   int eigensolver_nwork;
   int eigensolver_block_size;
 
@@ -93,7 +93,8 @@ struct mode_solver {
               int mesh_size, meep_geom::material_data *_default_material, geometric_object_list geom,
               bool reset_fields, bool deterministic, double target_freq, int dims, bool verbose,
               bool periodicity, double flops, bool negative_epsilon_ok, std::string epsilon_input_file,
-              std::string mu_input_file, bool force_mu, bool use_simple_preconditioner, vector3 grid_size);
+              std::string mu_input_file, bool force_mu, bool use_simple_preconditioner, vector3 grid_size,
+              bool use_eigensolver_davidson, int eigensolver_nwork, int eigensolver_block_size);
   ~mode_solver();
 
   void init(int p, bool reset_fields);

--- a/libpympb/pympb.hpp
+++ b/libpympb/pympb.hpp
@@ -135,7 +135,6 @@ struct mode_solver {
   void set_curfield_cmplx(std::complex<mpb_real> *cdata, int size);
 
   void get_lattice(double data[3][3]);
-  vector3 get_cur_kvector();
   void get_eigenvectors(int p_start, int p, std::complex<mpb_real> *cdata, int size);
   std::vector<int> get_eigenvectors_slice_dims(int num_bands);
   void set_eigenvectors(int b_start, std::complex<mpb_real> *cdata, int size);

--- a/python/solver.py
+++ b/python/solver.py
@@ -188,7 +188,7 @@ class ModeSolver(object):
         self.mode_solver.set_curfield_cmplx(flat_res)
         self.mode_solver.set_curfield_type('v')
 
-        return MPBArray(res, self.get_lattice, self.get_current_kpoint)
+        return MPBArray(res, self.get_lattice, self.current_k)
 
     def get_epsilon(self):
         self.mode_solver.get_epsilon()
@@ -250,7 +250,7 @@ class ModeSolver(object):
         self.mode_solver.get_curfield_cmplx(arr)
 
         arr = np.reshape(arr, dims)
-        res = MPBArray(arr, self.get_lattice(), self.get_current_kpoint())
+        res = MPBArray(arr, self.get_lattice(), self.current_k)
 
         return res
 
@@ -293,13 +293,13 @@ class ModeSolver(object):
         self.mode_solver.set_curfield(tot_pwr.ravel())
         self.mode_solver.set_curfield_type('R')
 
-        return MPBArray(tot_pwr, self.get_lattice(), self.get_current_kpoint())
+        return MPBArray(tot_pwr, self.get_lattice(), self.current_k)
 
     def get_eigenvectors(self, first_band, num_bands):
         dims = self.mode_solver.get_eigenvectors_slice_dims(num_bands)
         ev = np.zeros(np.prod(dims), dtype=np.complex128)
         self.mode_solver.get_eigenvectors(first_band - 1, num_bands, ev)
-        return MPBArray(ev.reshape(dims), self.get_lattice(), self.get_current_kpoint())
+        return MPBArray(ev.reshape(dims), self.get_lattice(), self.current_k)
 
     def set_eigenvectors(self, ev, first_band):
         self.mode_solver.set_eigenvectors(first_band - 1, ev.flatten())
@@ -414,9 +414,6 @@ class ModeSolver(object):
         self.mode_solver.get_lattice(lattice)
 
         return lattice
-
-    def get_current_kpoint(self):
-        return self.mode_solver.get_cur_kvector()
 
     def output_field(self):
         self.output_field_to_file(mp.ALL, self.get_filename_prefix())

--- a/python/solver.py
+++ b/python/solver.py
@@ -151,6 +151,10 @@ class ModeSolver(object):
             t = type(val)
             raise TypeError("resolution must be a number or a Vector3: Got {}".format(t))
 
+    def allow_negative_epsilon(self):
+        self.is_negative_epsilon_ok = True
+        self.target_freq = 1 / mp.inf
+
     def get_filename_prefix(self):
         if self.filename_prefix:
             return self.filename_prefix + '-'

--- a/python/solver.py
+++ b/python/solver.py
@@ -72,9 +72,6 @@ class ModeSolver(object):
                  resolution=10,
                  is_negative_epsilon_ok=False,
                  eigensolver_flops=0,
-                 is_eigensolver_davidson=False,
-                 eigensolver_nwork=3,
-                 eigensolver_block_size=-11,
                  eigensolver_flags=68,
                  use_simple_preconditioner=False,
                  force_mu=False,
@@ -95,12 +92,14 @@ class ModeSolver(object):
                  filename_prefix='',
                  deterministic=False,
                  verbose=False,
-                 optimize_grid_size=True):
+                 optimize_grid_size=True,
+                 use_eigensolver_davidson=False,
+                 eigensolver_nwork=3,
+                 eigensolver_block_size=-11):
 
         self.resolution = resolution
         self.is_negative_epsilon_ok = is_negative_epsilon_ok
         self.eigensolver_flops = eigensolver_flops
-        self.is_eigensolver_davidson = is_eigensolver_davidson
         self.eigensolver_nwork = eigensolver_nwork
         self.eigensolver_block_size = eigensolver_block_size
         self.eigensolver_flags = eigensolver_flags
@@ -124,6 +123,9 @@ class ModeSolver(object):
         self.deterministic = deterministic
         self.verbose = verbose
         self.optimize_grid_size = optimize_grid_size
+        self.use_eigensolver_davidson = use_eigensolver_davidson
+        self.eigensolver_nwork = eigensolver_nwork
+        self.eigensolver_block_size = eigensolver_block_size
         self.parity = ''
         self.iterations = 0
         self.all_freqs = None
@@ -725,6 +727,9 @@ class ModeSolver(object):
             self.force_mu,
             self.use_simple_preconditioner,
             self.grid_size,
+            self.use_eigensolver_davidson,
+            self.eigensolver_nwork,
+            self.eigensolver_block_size,
         )
 
     def set_parity(self, p):

--- a/python/solver.py
+++ b/python/solver.py
@@ -93,7 +93,6 @@ class ModeSolver(object):
                  deterministic=False,
                  verbose=False,
                  optimize_grid_size=True,
-                 use_eigensolver_davidson=False,
                  eigensolver_nwork=3,
                  eigensolver_block_size=-11):
 
@@ -123,7 +122,6 @@ class ModeSolver(object):
         self.deterministic = deterministic
         self.verbose = verbose
         self.optimize_grid_size = optimize_grid_size
-        self.use_eigensolver_davidson = use_eigensolver_davidson
         self.eigensolver_nwork = eigensolver_nwork
         self.eigensolver_block_size = eigensolver_block_size
         self.parity = ''
@@ -727,7 +725,6 @@ class ModeSolver(object):
             self.force_mu,
             self.use_simple_preconditioner,
             self.grid_size,
-            self.use_eigensolver_davidson,
             self.eigensolver_nwork,
             self.eigensolver_block_size,
         )

--- a/python/solver.py
+++ b/python/solver.py
@@ -666,7 +666,7 @@ class ModeSolver(object):
         mean_time = self.total_run_time / (mean_iters * num_runs)
         print("mean time per iteration = {} s".format(mean_time))
 
-    def _optimize_grid_size(self):
+    def _get_grid_size(self):
         grid_size = mp.Vector3(self.resolution[0] * self.geometry_lattice.size.x,
                                self.resolution[1] * self.geometry_lattice.size.y,
                                self.resolution[2] * self.geometry_lattice.size.z)
@@ -675,12 +675,14 @@ class ModeSolver(object):
         grid_size.y = max(math.ceil(grid_size.y), 1)
         grid_size.z = max(math.ceil(grid_size.z), 1)
 
-        grid_size.x = self.next_factor2457(grid_size.x)
-        grid_size.y = self.next_factor2457(grid_size.y)
-        grid_size.z = self.next_factor2457(grid_size.z)
         return grid_size
 
-    def next_factor2457(self, n):
+    def _optimize_grid_size(self):
+        self.grid_size.x = self.next_factor2357(self.grid_size.x)
+        self.grid_size.y = self.next_factor2357(self.grid_size.y)
+        self.grid_size.z = self.next_factor2357(self.grid_size.z)
+
+    def next_factor2357(self, n):
 
         def is_factor2357(n):
 
@@ -695,10 +697,10 @@ class ModeSolver(object):
         return self.next_factor2357(n + 1)
 
     def init_params(self, p, reset_fields):
+        self.grid_size = self._get_grid_size()
+
         if self.optimize_grid_size:
-            self.grid_size = self._optimize_grid_size()
-        else:
-            self.grid_size = mp.resolution
+            self._optimize_grid_size()
 
         self.mode_solver = mode_solver(
             self.num_bands,

--- a/python/tests/mpb.py
+++ b/python/tests/mpb.py
@@ -1287,6 +1287,33 @@ class TestModeSolver(unittest.TestCase):
         field_integral = ms.compute_field_integral(f2)
         self.assertAlmostEqual(field_integral, 02.0735366548785272e-18 - 3.0259168624899837e-6j)
 
+    def test_eigensolver_davidson(self):
+        ms = self.init_solver()
+        ms.use_eigensolver_davidson = True
+        ms.eigensolver_nwork = 4
+        ms.run_te()
+
+        expected_brd = [
+            ((0.0, mp.Vector3(0.0, 0.0, 0.0)),
+             (0.49683586474483926, mp.Vector3(0.5, 0.5, 0.0))),
+            ((0.4415884497223785, mp.Vector3(0.5, 0.0, 0.0)),
+             (0.5931405141160137, mp.Vector3(0.5, 0.5, 0.0))),
+            ((0.5931535863117459, mp.Vector3(0.5, 0.5, 0.0)),
+             (0.7732265593069207, mp.Vector3(0.0, 0.0, 0.0))),
+            ((0.6791690130756873, mp.Vector3(0.5, 0.5, 0.0)),
+             (0.809689155167664, mp.Vector3(0.30000000000000004, 0.30000000000000004, 0.0))),
+            ((0.8241814443501433, mp.Vector3(0.5, 0.30000000000000004, 0.0)),
+             (0.92299651958537, mp.Vector3(0.0, 0.0, 0.0))),
+            ((0.8819770916659235, mp.Vector3(0.5, 0.5, 0.0)),
+             (1.0291597050646561, mp.Vector3(0.5, 0.0, 0.0))),
+            ((0.8819818134421394, mp.Vector3(0.5, 0.5, 0.0)),
+             (1.0860729324208933, mp.Vector3(0.5, 0.0, 0.0))),
+            ((1.087868963504984, mp.Vector3(0.5, 0.0, 0.0)),
+             (1.1119173707824965, mp.Vector3(0.5, 0.5, 0.0))),
+        ]
+
+        self.check_band_range_data(expected_brd, ms.band_range_data)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/tests/mpb.py
+++ b/python/tests/mpb.py
@@ -1287,33 +1287,6 @@ class TestModeSolver(unittest.TestCase):
         field_integral = ms.compute_field_integral(f2)
         self.assertAlmostEqual(field_integral, 02.0735366548785272e-18 - 3.0259168624899837e-6j)
 
-    def test_eigensolver_davidson(self):
-        ms = self.init_solver()
-        ms.use_eigensolver_davidson = True
-        ms.eigensolver_nwork = 4
-        ms.run_te()
-
-        expected_brd = [
-            ((0.0, mp.Vector3(0.0, 0.0, 0.0)),
-             (0.49683586474483926, mp.Vector3(0.5, 0.5, 0.0))),
-            ((0.4415884497223785, mp.Vector3(0.5, 0.0, 0.0)),
-             (0.5931405141160137, mp.Vector3(0.5, 0.5, 0.0))),
-            ((0.5931535863117459, mp.Vector3(0.5, 0.5, 0.0)),
-             (0.7732265593069207, mp.Vector3(0.0, 0.0, 0.0))),
-            ((0.6791690130756873, mp.Vector3(0.5, 0.5, 0.0)),
-             (0.809689155167664, mp.Vector3(0.30000000000000004, 0.30000000000000004, 0.0))),
-            ((0.8241814443501433, mp.Vector3(0.5, 0.30000000000000004, 0.0)),
-             (0.92299651958537, mp.Vector3(0.0, 0.0, 0.0))),
-            ((0.8819770916659235, mp.Vector3(0.5, 0.5, 0.0)),
-             (1.0291597050646561, mp.Vector3(0.5, 0.0, 0.0))),
-            ((0.8819818134421394, mp.Vector3(0.5, 0.5, 0.0)),
-             (1.0860729324208933, mp.Vector3(0.5, 0.0, 0.0))),
-            ((1.087868963504984, mp.Vector3(0.5, 0.0, 0.0)),
-             (1.1119173707824965, mp.Vector3(0.5, 0.5, 0.0))),
-        ]
-
-        self.check_band_range_data(expected_brd, ms.band_range_data)
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
* `optimize_grid_size` is true by default
* Added `allow_negative_epsilon`
* Use Python's `current_k` and remove C++ `get_cur_kvector`
* Add ability to use `eigensolver_davdison`.
* Allow passing `eigensolver_nwork` and `eigensolver_block_size` from Python to C++

@stevengj @oskooi 