### PR TITLE
Fixed Harminv result column headers

### DIFF
--- a/python/simulation.py
+++ b/python/simulation.py
@@ -194,7 +194,7 @@ class Harminv(object):
         return _collect1
 
     def _analyze_harminv(self, sim, maxbands):
-        harminv_cols = ['frequency', 'imag.', 'freq.', 'Q', '|amp|', 'amplitude', 'error']
+        harminv_cols = ['frequency', 'imag. freq.', 'Q', '|amp|', 'amplitude', 'error']
         display_run_data(sim, 'harminv', harminv_cols)
 
         dt = self.data_dt if self.data_dt is not None else sim.fields.dt


### PR DESCRIPTION
The output from Harminv writes 7 column headers when there should only be 6. Fixed by combining the two incorrect column headers 'imag.' and 'freq.' into a single column header 'imag. freq.'.