### PR TITLE
Fix bug in material_type_list typemap

### DIFF
--- a/python/meep.i
+++ b/python/meep.i
@@ -836,6 +836,7 @@ meep::volume_list *make_volume_list(const meep::volume &v, int c,
                 SWIG_fail;
             }
         }
+        $1 = mtl;
     }
 }
 


### PR DESCRIPTION
The typemap failed to actually assign the newly-created `material_type_list` to a SWIG variable. This affects setting `extra_materials` from python.
@stevengj @oskooi 