### PR TITLE
Fix libmeepgeom test linking behavior

### DIFF
--- a/libmeepgeom/Makefile.am
+++ b/libmeepgeom/Makefile.am
@@ -34,6 +34,7 @@ dft_fields_SOURCES = dft-fields.cpp
 dft_fields_LDADD   = libmeepgeom.la $(MEEPLIBS)
 
 TESTS           = cyl-ellipsoid-ll array-slice-ll
+TESTS_ENVIRONMENT = export LD_PRELOAD=$(abs_top_builddir)/src/.libs/libmeep.so;
 
 #LOG_COMPILER = $(RUNCODE)
 


### PR DESCRIPTION
Ardavan has been having issues building meep on his laptop lately and we found that when running `make check`, the libmeepgeom tests actually link with a `libmeep.so` that's already installed in `/usr/local/lib` (or whatever your PREFIX is) instead of with the one that `make` just built in `$(top_builddir)/src/.libs`.  I tried many different ways of fixing this, but this was the only option that worked. I verified that the python tests don't exhibit the same problem.
@stevengj @oskooi @HomerReid  