### PR TITLE
Copy casimir.scm to builddir for out-of-tree builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -527,6 +527,9 @@ fi # with_python
 AC_SUBST(PYTHON_INCLUDES)
 AM_CONDITIONAL(WITH_PYTHON, test x"$have_python" = "xyes")
 
+# Copy/symlink casimir.scm to builddir for out-of-tree builds
+AC_CONFIG_LINKS(scheme/casimir.scm:scheme/casimir.scm)
+
 ##############################################################################
 
 AC_CONFIG_FILES([


### PR DESCRIPTION
When I do an out-of-tree build and then try to run a scheme example from the build directory, I'm forced to manually copy `casimir.scm` to the build directory. This fixes that.
@stevengj @oskooi 