### PR TITLE
Nicer kvals printing and return proper kvals list

### DIFF
--- a/python/solver.py
+++ b/python/solver.py
@@ -926,7 +926,7 @@ class ModeSolver(object):
 
         self.num_bands = num_bands_save
         self.k_points = kpoints_save
-        ks = reversed(ks)
+        ks = list(reversed(ks))
         print("{}kvals:, {}, {}, {}".format(self.parity, omega, band_min, band_max), end='')
         for k in korig:
             print(", {}".format(k), end='')

--- a/python/tests/mpb.py
+++ b/python/tests/mpb.py
@@ -856,10 +856,10 @@ class TestModeSolver(unittest.TestCase):
                           mpb.display_yparities, mpb.display_group_velocities)
 
         expected_kvals = [
-            1.066321795284513,
-            1.0186792189943261,
-            0.8398943502679427,
-            0.7990426389486213
+            1.03584503595498,
+            0.9776221778906993,
+            0.8358057689930384,
+            0.788801145849691
         ]
 
         for e, r in zip(expected_kvals, kvals):


### PR DESCRIPTION
Fixes stevengj/mpb#49.
* `ks` should be a list. Previously, the printing exhausted the `reversed` iterator and it returned an empty list.

@stevengj @oskooi 