### PR TITLE
Only restore fields that were backed up during synchronized_magnetic

### DIFF
--- a/python/tests/simulation.py
+++ b/python/tests/simulation.py
@@ -372,6 +372,31 @@ class TestSimulation(unittest.TestCase):
         np.testing.assert_allclose(energy, energy_arr)
         np.testing.assert_allclose(efield, efield_arr)
 
+    def test_synchronized_magnetic(self):
+        # Issue 309
+        cell = mp.Vector3(16, 8, 0)
+
+        geometry = [mp.Block(mp.Vector3(1e20, 1, 1e20),
+                             center=mp.Vector3(0, 0),
+                             material=mp.Medium(epsilon=12))]
+
+        sources = [mp.Source(mp.ContinuousSource(frequency=0.15),
+                             component=mp.Ez,
+                             center=mp.Vector3(-7, 0))]
+
+        pml_layers = [mp.PML(1.0)]
+        resolution = 10
+
+        sim = mp.Simulation(
+            cell_size=cell,
+            boundary_layers=pml_layers,
+            geometry=geometry,
+            sources=sources,
+            resolution=resolution
+        )
+
+        sim.run(mp.synchronized_magnetic(mp.output_bfield_y), until=10)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/energy_and_flux.cpp
+++ b/src/energy_and_flux.cpp
@@ -127,9 +127,9 @@ void fields_chunk::backup_component(component c) {
 }
 
 void fields_chunk::restore_component(component c) {
-  DOCMP if (f_backup[c][cmp]) {
-#define RESTORE(f)							\
-    if (f[c][cmp])							\
+  DOCMP  {
+#define RESTORE(f)                                                      \
+    if (f##_backup[c][cmp] && f[c][cmp])                                \
       memcpy(f[c][cmp], f##_backup[c][cmp], gv.ntot()*sizeof(realnum));
 
     RESTORE(f);


### PR DESCRIPTION
I'm not sure if this retains the correct semantics, but it seems correct logically: we only want to restore a field if it was previously backed up. Fixes #309, where `RESTORE(f_u)` expanded to
```C
if (f_u[c][cmp])
    memcpy(f_u[c][cmp], NULL, gv.ntot()*sizeof(realnum));
```
and caused a crash (a NULL argument to `memcpy` is undefined behavior).
@stevengj @oskooi 