### PR TITLE
Fix cast from negative int to size_t

### DIFF
--- a/src/dft.cpp
+++ b/src/dft.cpp
@@ -752,8 +752,12 @@ cdouble fields::process_dft_component(dft_chunk **chunklists, int num_chunklists
   size_t array_size=1;
   LOOP_OVER_DIRECTIONS(gv.dim, d) {
     if (rank >= 3) abort("too many dimensions in process_dft_component");
-    size_t n = (max_corner.in_direction(d)
-	              - min_corner.in_direction(d)) / 2 + 1;
+
+    size_t n = 0;
+    if ((max_corner.in_direction(d) - min_corner.in_direction(d)) / 2 + 1 > 0) {
+      n = (max_corner.in_direction(d) - min_corner.in_direction(d)) / 2 + 1;
+    }
+
     if (n > 1) {
       ds[rank] = d;
       dims[rank++] = n;

--- a/src/dft.cpp
+++ b/src/dft.cpp
@@ -19,6 +19,7 @@
 #include <stdlib.h>
 #include <math.h>
 #include <string.h>
+#include <algorithm>
 
 #include "meep.hpp"
 #include "meep_internals.hpp"
@@ -752,11 +753,7 @@ cdouble fields::process_dft_component(dft_chunk **chunklists, int num_chunklists
   size_t array_size=1;
   LOOP_OVER_DIRECTIONS(gv.dim, d) {
     if (rank >= 3) abort("too many dimensions in process_dft_component");
-
-    size_t n = 0;
-    if ((max_corner.in_direction(d) - min_corner.in_direction(d)) / 2 + 1 > 0) {
-      n = (max_corner.in_direction(d) - min_corner.in_direction(d)) / 2 + 1;
-    }
+    size_t n = std::max(0, (max_corner.in_direction(d) - min_corner.in_direction(d)) / 2 + 1);
 
     if (n > 1) {
       ds[rank] = d;

--- a/src/h5fields.cpp
+++ b/src/h5fields.cpp
@@ -239,8 +239,12 @@ void fields::output_hdf5(h5file *file, const char *dataname,
   size_t dims[3];
   LOOP_OVER_DIRECTIONS(gv.dim, d) {
     if (rank >= 3) abort("too many dimensions in output_hdf5");
-    size_t n = (data.max_corner.in_direction(d)
-	              - data.min_corner.in_direction(d)) / 2 + 1;
+
+    size_t n = 0;
+    if ((data.max_corner.in_direction(d) - data.min_corner.in_direction(d)) / 2 + 1 > 0) {
+        n = (data.max_corner.in_direction(d) - data.min_corner.in_direction(d)) / 2 + 1;
+    }
+
     if (n > 1) {
       data.ds[rank] = d;
       dims[rank++] = n;

--- a/src/h5fields.cpp
+++ b/src/h5fields.cpp
@@ -18,6 +18,7 @@
 /* HDF5 output of fields and arbitrary functions thereof.  Works
    very similarly to integrate.cpp (using fields::loop_in_chunks). */
 
+#include <algorithm>
 #include <stdio.h>
 #include <string.h>
 #include <math.h>
@@ -239,11 +240,7 @@ void fields::output_hdf5(h5file *file, const char *dataname,
   size_t dims[3];
   LOOP_OVER_DIRECTIONS(gv.dim, d) {
     if (rank >= 3) abort("too many dimensions in output_hdf5");
-
-    size_t n = 0;
-    if ((data.max_corner.in_direction(d) - data.min_corner.in_direction(d)) / 2 + 1 > 0) {
-        n = (data.max_corner.in_direction(d) - data.min_corner.in_direction(d)) / 2 + 1;
-    }
+    size_t n = std::max(0, (data.max_corner.in_direction(d) - data.min_corner.in_direction(d)) / 2 + 1);
 
     if (n > 1) {
       data.ds[rank] = d;


### PR DESCRIPTION
`n` was changed from an `int` to `size_t` in #261. Before #261, if `n` was negative, `dims` for that rank would not be assigned (due to the `if (n > 1)` clause.  After #261, a negative rvalue would be cast to size_t, resulting in a huge value. This caused `output_dft` to write huge datasets for all components to h5 files (this was the issue Erik Shipton encountered that I described in an email eariler this week). This PR keeps `n` at 0 if the rvalue would have been negative. Now the h5 files created by `output_dft` only contain the components specified in `add_dft_fields` instead of all components (as the email showed).
@stevengj @oskooi @HomerReid 