### PR TITLE
Enable kpoint_func from python

### DIFF
--- a/python/simulation.py
+++ b/python/simulation.py
@@ -933,13 +933,13 @@ class Simulation(object):
         else:
             raise ValueError("Invalid type of dft object: {}".format(dft_obj))
 
-    def get_eigenmode_coefficients(self, flux, bands):
+    def get_eigenmode_coefficients(self, flux, bands, kpoint_func=None):
         if self.fields is None:
             raise ValueError("Fields must be initialized before calling get_eigenmode_coefficients")
 
         num_bands = len(bands)
         coeffs = np.zeros(2 * num_bands, dtype=np.complex128)
-        self.fields.get_eigenmode_coefficients(flux, np.array(bands, dtype=np.intc), coeffs, None)
+        self.fields.get_eigenmode_coefficients(flux, np.array(bands, dtype=np.intc), coeffs, None, kpoint_func)
 
         return coeffs
 

--- a/python/tests/mode_coeffs.py
+++ b/python/tests/mode_coeffs.py
@@ -6,9 +6,9 @@ import unittest
 import numpy as np
 import meep as mp
 
-class ModeCoeffs(unittest.TestCase):
+class TestModeCoeffs(unittest.TestCase):
 
-    def run_mode_coeffs(self, mode_num):
+    def run_mode_coeffs(self, mode_num, kpoint_func):
 
         resolution = 15
 
@@ -53,7 +53,7 @@ class ModeCoeffs(unittest.TestCase):
         sim.run(until_after_sources=100)
 
         modes_to_check = [1,2]  # indices of modes for which to compute expansion coefficients
-        alpha = sim.get_eigenmode_coefficients(mflux, modes_to_check)
+        alpha = sim.get_eigenmode_coefficients(mflux, modes_to_check, kpoint_func=kpoint_func)
 
         mode_power = mp.get_fluxes(mode_flux)[0]
 
@@ -71,8 +71,15 @@ class ModeCoeffs(unittest.TestCase):
         self.assertAlmostEqual(mode_power / abs(c0**2), 1.0, places=1) # test 2: |mode coeff|^2 = power
 
     def test_modes(self):
-        self.run_mode_coeffs(1)
-        self.run_mode_coeffs(2)
+        self.run_mode_coeffs(1, None)
+        self.run_mode_coeffs(2, None)
+
+    def test_kpoint_func(self):
+
+        def kpoint_func(freq, mode):
+            return mp.Vector3()
+
+        self.run_mode_coeffs(1, kpoint_func)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Example usage is in the `mode_coeffs.py` test.
@stevengj @oskooi @HomerReid 