### PR TITLE
Validate material frequencies.

### DIFF
--- a/python/geom.py
+++ b/python/geom.py
@@ -4,11 +4,15 @@ import functools
 import math
 import numbers
 import operator
+from collections import namedtuple
 from copy import deepcopy
 from numbers import Number
 
 import numpy as np
 import meep as mp
+
+
+FreqRange = namedtuple('FreqRange', ['min', 'max'])
 
 
 def check_nonnegative(prop, val):
@@ -151,7 +155,8 @@ class Medium(object):
                  E_chi2=None,
                  E_chi3=None,
                  H_chi2=None,
-                 H_chi3=None):
+                 H_chi3=None,
+                 valid_freq_range=None):
 
         if epsilon:
             epsilon_diag = Vector3(epsilon, epsilon, epsilon)
@@ -188,6 +193,7 @@ class Medium(object):
         self.H_chi3_diag = H_chi3_diag
         self.D_conductivity_diag = D_conductivity_diag
         self.B_conductivity_diag = B_conductivity_diag
+        self.valid_freq_range = valid_freq_range
 
 
 class Susceptibility(object):

--- a/python/meep.i
+++ b/python/meep.i
@@ -988,6 +988,7 @@ void display_geometric_object_info(int indentby, GEOMETRIC_OBJECT o);
         Cylinder,
         DrudeSusceptibility,
         Ellipsoid,
+        FreqRange,
         GeometricObject,
         Lattice,
         LorentzianSusceptibility,

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -564,6 +564,8 @@ class Simulation(object):
         if self.fields is None:
             self.init_fields()
 
+        self._check_material_frequencies()
+
         if isinstance(cond, numbers.Number):
             stop_time = cond
             t0 = self.round_time()
@@ -597,6 +599,7 @@ class Simulation(object):
         if self.fields is None:
             self.init_fields()
 
+        self._check_material_frequencies()
         ts = self.fields.last_source_time()
 
         if isinstance(cond, numbers.Number):
@@ -1050,8 +1053,6 @@ class Simulation(object):
             self.init_fields()
 
     def run(self, *step_funcs, **kwargs):
-        self._check_material_frequencies()
-
         until = kwargs.pop('until', None)
         until_after_sources = kwargs.pop('until_after_sources', None)
 

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -354,7 +354,7 @@ class Simulation(object):
 
         min_freq, max_freq = self._get_valid_material_frequencies()
 
-        source_freqs = [(s.src.frequency, 1 / s.src.width)
+        source_freqs = [(s.src.frequency, 0 if s.src.width == 0 else 1 / s.src.width)
                         for s in self.sources
                         if hasattr(s.src, 'frequency')]
 

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -354,7 +354,7 @@ class Simulation(object):
 
         min_freq, max_freq = self._get_valid_material_frequencies()
 
-        source_freqs = [(s.src.frequency, s.src.width if s.src._using_fwidth else 1 / s.src.width)
+        source_freqs = [(s.src.frequency, 1 / s.src.width)
                         for s in self.sources
                         if hasattr(s.src, 'frequency')]
 

--- a/python/source.py
+++ b/python/source.py
@@ -45,7 +45,6 @@ class ContinuousSource(SourceTime):
         self.swigobj = mp.continuous_src_time(self.frequency, self.width, self.start_time,
                                               self.end_time, self.cutoff)
         self.swigobj.is_integrated = self.is_integrated
-        self._using_fwidth = 1 / fwidth > width
 
 
 class GaussianSource(SourceTime):
@@ -62,7 +61,6 @@ class GaussianSource(SourceTime):
         self.swigobj = mp.gaussian_src_time(self.frequency, self.width, self.start_time,
                                             self.start_time + 2 * self.width * self.cutoff)
         self.swigobj.is_integrated = self.is_integrated
-        self._using_fwidth = 1 / fwidth > width
 
 
 class CustomSource(SourceTime):

--- a/python/source.py
+++ b/python/source.py
@@ -45,6 +45,7 @@ class ContinuousSource(SourceTime):
         self.swigobj = mp.continuous_src_time(self.frequency, self.width, self.start_time,
                                               self.end_time, self.cutoff)
         self.swigobj.is_integrated = self.is_integrated
+        self._using_fwidth = 1 / fwidth > width
 
 
 class GaussianSource(SourceTime):
@@ -61,6 +62,7 @@ class GaussianSource(SourceTime):
         self.swigobj = mp.gaussian_src_time(self.frequency, self.width, self.start_time,
                                             self.start_time + 2 * self.width * self.cutoff)
         self.swigobj.is_integrated = self.is_integrated
+        self._using_fwidth = 1 / fwidth > width
 
 
 class CustomSource(SourceTime):

--- a/python/tests/geom.py
+++ b/python/tests/geom.py
@@ -306,13 +306,14 @@ class TestMedium(unittest.TestCase):
                 else:
                     self.assertEqual(len(w), 0)
 
+        geom = [mp.Sphere(0.2, material=mat)]
+
         for s in invalid_sources:
             # Check for invalid extra_materials
             sim = mp.Simulation(cell_size=cell_size, resolution=resolution, sources=s, extra_materials=[mat])
             check_warnings(sim)
 
             # Check for invalid geometry materials
-            geom = [mp.Sphere(0.2, material=mat)]
             sim = mp.Simulation(cell_size=cell_size, resolution=resolution, sources=s, geometry=geom)
             check_warnings(sim)
 
@@ -326,10 +327,18 @@ class TestMedium(unittest.TestCase):
             check_warnings(sim, False)
 
         # Check DFT frequencies
-        # sim = mp.Simulation(cell_size=cell_size, resolution=resolution, sources=s)
-        # fregion = mp.FluxRegion(center=mp.Vector3(), size=mp.Vector3(2, 2))
-        # sim.add_flux(15, 5, 1, fregion)
-        # check_warnings(sim)
+
+        # Invalid extra_materials
+        sim = mp.Simulation(cell_size=cell_size, resolution=resolution, sources=valid_sources[0],
+                            extra_materials=[mat])
+        fregion = mp.FluxRegion(center=mp.Vector3(0, 1), size=mp.Vector3(2, 2), direction=mp.X)
+        sim.add_flux(15, 6, 2, fregion)
+        check_warnings(sim)
+
+        # Invalid geometry material
+        sim = mp.Simulation(cell_size=cell_size, resolution=resolution, sources=valid_sources[0], geometry=geom)
+        sim.add_flux(15, 6, 2, fregion)
+        check_warnings(sim)
 
 
 class TestVector3(unittest.TestCase):

--- a/python/vec.i
+++ b/python/vec.i
@@ -46,6 +46,7 @@
 %warnfilter(509) meep::symmetry::transform;
 %warnfilter(509) meep::symmetry::phase_shift;
 %warnfilter(509) meep::structure::structure;
+%warnfilter(509) meep::fields::get_eigenmode_coefficients;
 %warnfilter(451) meep::structure::outdir;
 %warnfilter(451) meep::fields_chunk::outdir;
 %warnfilter(325) meep::h5file::extending_s;


### PR DESCRIPTION
Fixes #319.
To enable validation for the materials library, each `Medium` will need to be passed a `FreqRange` namedtuple via the `valid_freq_range` keyword argument. For example:
```python
mat = mp.Medium(epsilon=12, valid_freq_range=mp.FreqRange(min=2, max=8))
```
I can take care of this if someone gives me a list of valid frequencies for each material.

To check DFT frequencies, it was necessary to store all dft objects created by the user (via `add_flux`, etc.) in `Simulation.dft_objects`. I couldn't find another way to get that information.
@stevengj @oskooi 