### PR TITLE
Get and load dft objects as numpy arrays

### DIFF
--- a/python/meep.i
+++ b/python/meep.i
@@ -367,28 +367,32 @@ size_t _get_dft_data_size(meep::dft_chunk *dc) {
 }
 
 void _get_dft_data(meep::dft_chunk *dc, std::complex<meep::realnum> *cdata, int size) {
-    (void)size;
     size_t istart;
-    meep::dft_chunks_Ntotal(dc, &istart);
+    size_t n = meep::dft_chunks_Ntotal(dc, &istart);
+    if (n != size) {
+        meep::abort("Total dft_chunks size does not agree with size allocated for output array.\n");
+    }
 
     for (meep::dft_chunk *cur = dc; cur; cur = cur->next_in_dft) {
         size_t Nchunk = cur->N * cur->Nomega;
         for (size_t i = 0; i < Nchunk; ++i) {
-            cdata[i + istart] = cur->dft[i + istart];
+            cdata[i + istart] = cur->dft[i];
         }
         istart += Nchunk;
     }
 }
 
 void _load_dft_data(meep::dft_chunk *dc, std::complex<meep::realnum> *cdata, int size) {
-    (void)size;
     size_t istart;
-    meep::dft_chunks_Ntotal(dc, &istart);
+    size_t n = meep::dft_chunks_Ntotal(dc, &istart);
+    if (n != size) {
+        meep::abort("Total dft_chunks size does not agree with size allocated for output array.\n");
+    }
 
     for (meep::dft_chunk *cur = dc; cur; cur = cur->next_in_dft) {
         size_t Nchunk = cur->N * cur->Nomega;
         for (size_t i = 0; i < Nchunk; ++i) {
-            cur->dft[i + istart] = cdata[i + istart];
+            cur->dft[i] = cdata[i + istart];
         }
         istart += Nchunk;
     }

--- a/python/meep.i
+++ b/python/meep.i
@@ -378,7 +378,6 @@ void _get_dft_data(meep::dft_chunk *dc, std::complex<meep::realnum> *cdata, int 
         }
         istart += Nchunk;
     }
-    // TODO: Get all of cdata on master when using MPI?
 }
 
 void _load_dft_data(meep::dft_chunk *dc, std::complex<meep::realnum> *cdata, int size) {
@@ -396,7 +395,6 @@ void _load_dft_data(meep::dft_chunk *dc, std::complex<meep::realnum> *cdata, int
         }
         istart += Nchunk;
     }
-    // TODO: MPI
 }
 
 %}

--- a/python/meep.i
+++ b/python/meep.i
@@ -382,11 +382,8 @@ void _get_dft_data(meep::dft_chunk *dc, std::complex<meep::realnum> *cdata, int 
 
 void _load_dft_data(meep::dft_chunk *dc, std::complex<meep::realnum> *cdata, int size) {
     (void)size;
-    size_t n = 0;
-    for (meep::dft_chunk *cur = dc; cur; cur = cur->next_in_dft)
-        n += cur->N * cur->Nomega;
-    size_t istart = partial_sum_to_all(n) - n; // sum(n) for processes before this
-    n = sum_to_all(n);
+    size_t istart;
+    meep::dft_chunks_Ntotal(dc, &istart);
 
     for (meep::dft_chunk *cur = dc; cur; cur = cur->next_in_dft) {
         size_t Nchunk = cur->N * cur->Nomega;

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -781,6 +781,18 @@ class Simulation(object):
         self.load_flux(fname, flux)
         flux.scale_dfts(complex(-1.0))
 
+    def get_flux_array_E(self, flux):
+        n = flux.get_flux_array_size(flux.E)
+        arr = np.zeros(n, np.complex128)
+        flux.get_flux_array(flux.E, arr)
+        return arr
+
+    def get_flux_array_H(self, flux):
+        n = flux.get_flux_array_size(flux.H)
+        arr = np.zeros(n, np.complex128)
+        flux.get_flux_array(flux.H, arr)
+        return arr
+
     def flux_in_box(self, d, box=None, center=None, size=None):
         if self.fields is None:
             raise RuntimeError('Fields must be initialized before using flux_in_box')

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -22,6 +22,11 @@ except NameError:
     basestring = str
 
 
+FluxData = namedtuple('FluxData', ['E', 'H'])
+ForceData = namedtuple('ForceData', ['offdiag1', 'offdiag2', 'diag'])
+NearToFarData = namedtuple('NearToFarData', ['F'])
+
+
 def get_num_args(func):
     if isinstance(func, Harminv):
         return 2
@@ -703,6 +708,12 @@ class Simulation(object):
 
         self.fields.output_dft(dft_fields, fname)
 
+    def get_dft_data(self, dft_chunk):
+        n = mp._get_dft_data_size(dft_chunk)
+        arr = np.zeros(n, np.complex128)
+        mp._get_dft_data(dft_chunk, arr)
+        return arr
+
     def add_near2far(self, fcen, df, nfreq, *near2fars):
         if self.fields is None:
             self.init_fields()
@@ -730,6 +741,16 @@ class Simulation(object):
         self.load_near2far(fname, n2f)
         n2f.scale_dfts(-1.0)
 
+    def get_near2far_data(self, n2f):
+        return NearToFarData(F=self.get_dft_data(n2f.F))
+
+    def load_near2far_data(self, n2f, n2fdata):
+        mp._load_dft_data(n2f.F, n2fdata.F)
+
+    def load_minus_near2far_data(self, n2f, n2fdata):
+        self.load_near2far_data(n2f, n2fdata)
+        n2f.scale_dfts(complex(1.0))
+
     def add_force(self, fcen, df, nfreq, *forces):
         if self.fields is None:
             self.init_fields()
@@ -753,6 +774,20 @@ class Simulation(object):
     def load_minus_force(self, fname, force):
         self.load_force(fname, force)
         force.scale_dfts(-1.0)
+
+    def get_force_data(self, force):
+        return ForceData(offdiag1=self.get_dft_data(force.offdiag1),
+                         offdiag2=self.get_dft_data(force.offdiag2),
+                         diag=self.get_dft_data(force.diag))
+
+    def load_force_data(self, force, fdata):
+        mp._load_dft_data(force.offdiag1, fdata.offdiag1)
+        mp._load_dft_data(force.offdiag2, fdata.offdiag2)
+        mp._load_dft_data(force.diag, fdata.diag)
+
+    def load_minus_force_data(self, force, fdata):
+        self.load_force_data(force, fdata)
+        force.scale_dfts(complex(-1.0))
 
     def add_flux(self, fcen, df, nfreq, *fluxes):
         if self.fields is None:
@@ -781,17 +816,16 @@ class Simulation(object):
         self.load_flux(fname, flux)
         flux.scale_dfts(complex(-1.0))
 
-    def get_flux_array_E(self, flux):
-        n = flux.get_flux_array_size(flux.E)
-        arr = np.zeros(n, np.complex128)
-        flux.get_flux_array(flux.E, arr)
-        return arr
+    def get_flux_data(self, flux):
+        return FluxData(E=self.get_dft_data(flux.E), H=self.get_dft_data(flux.H))
 
-    def get_flux_array_H(self, flux):
-        n = flux.get_flux_array_size(flux.H)
-        arr = np.zeros(n, np.complex128)
-        flux.get_flux_array(flux.H, arr)
-        return arr
+    def load_flux_data(self, flux, fdata):
+        mp._load_dft_data(flux.E, fdata.E)
+        mp._load_dft_data(flux.H, fdata.H)
+
+    def load_minus_flux_data(self, flux, fdata):
+        self.load_flux_data(flux, fdata)
+        flux.scale_dfts(complex(-1.0))
 
     def flux_in_box(self, d, box=None, center=None, size=None):
         if self.fields is None:

--- a/python/tests/antenna_radiation.py
+++ b/python/tests/antenna_radiation.py
@@ -101,15 +101,21 @@ class TestAntennaRadiation(unittest.TestCase):
         r = 1000
         npts = 100
 
+        # Test store and load of near2far as numpy array
+        n2fdata = self.sim.get_near2far_data(self.nearfield)
+        self.sim.load_near2far_data(self.nearfield, n2fdata)
+
         result = []
         for n in range(npts):
             ff = self.sim.get_farfield(
                 self.nearfield,
                 mp.Vector3(r * math.cos(2 * math.pi * (n / npts)),
-                           r * math.sin(2 * math.pi * (n / npts))))
+                           r * math.sin(2 * math.pi * (n / npts)))
+            )
             result.append(ff)
 
         np.testing.assert_allclose(expected, result[-10:])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/tests/bend_flux.py
+++ b/python/tests/bend_flux.py
@@ -56,19 +56,12 @@ class TestBendFlux(unittest.TestCase):
         else:
             self.pt = mp.Vector3(wvg_xcen, (sy / 2) - 1.5)
 
-    def run_with_straight_waveguide(self):
+    def test_bend_flux(self):
+        # Normalization run
         self.init(no_bend=True)
         self.sim.run(until_after_sources=mp.stop_when_fields_decayed(50, mp.Ez, self.pt, 1e-3))
-
-        self.sim.save_flux('refl-flux', self.refl)
-
-        arr = self.sim.get_dft_array(self.refl, mp.Ey, 100)
-
-        import h5py
-        with h5py.File('bend_flux-refl-flux.h5', 'r') as f:
-            ref = f['ey_dft'].value
-            np.testing.assert_allclose(ref, arr)
-
+        # Save flux data for use in real run below
+        fdata = self.sim.get_flux_data(self.refl)
 
         expected = [
             (0.1, 3.65231563251e-05, 3.68932495077e-05),
@@ -98,14 +91,11 @@ class TestBendFlux(unittest.TestCase):
 
         np.testing.assert_allclose(expected, res[:20])
 
-    def test_ninety_degree_bend(self):
-        # We have to run the straight waveguide version first to generate the 'refl-flux'
-        # file that this test uses. We can't just prepend run_with_straight_waveguide
-        # with 'test_' because execution order of unit tests isn't deterministic.
-        self.run_with_straight_waveguide()
+        # Real run
         self.sim = None
         self.init()
-        # self.sim.load_minus_flux('refl-flux', self.refl)
+        # Load flux data obtained from normalization run
+        self.sim.load_minus_flux_data(self.refl, fdata)
         self.sim.run(until_after_sources=mp.stop_when_fields_decayed(50, mp.Ez, self.pt, 1e-3))
 
         expected = [

--- a/python/tests/bend_flux.py
+++ b/python/tests/bend_flux.py
@@ -59,7 +59,16 @@ class TestBendFlux(unittest.TestCase):
     def run_with_straight_waveguide(self):
         self.init(no_bend=True)
         self.sim.run(until_after_sources=mp.stop_when_fields_decayed(50, mp.Ez, self.pt, 1e-3))
+
         self.sim.save_flux('refl-flux', self.refl)
+
+        arr = self.sim.get_dft_array(self.refl, mp.Ey, 100)
+
+        import h5py
+        with h5py.File('bend_flux-refl-flux.h5', 'r') as f:
+            ref = f['ey_dft'].value
+            np.testing.assert_allclose(ref, arr)
+
 
         expected = [
             (0.1, 3.65231563251e-05, 3.68932495077e-05),
@@ -96,7 +105,7 @@ class TestBendFlux(unittest.TestCase):
         self.run_with_straight_waveguide()
         self.sim = None
         self.init()
-        self.sim.load_minus_flux('refl-flux', self.refl)
+        # self.sim.load_minus_flux('refl-flux', self.refl)
         self.sim.run(until_after_sources=mp.stop_when_fields_decayed(50, mp.Ez, self.pt, 1e-3))
 
         expected = [

--- a/python/tests/force.py
+++ b/python/tests/force.py
@@ -27,10 +27,15 @@ class TestForce(unittest.TestCase):
 
         self.sim.run(until_after_sources=mp.stop_when_fields_decayed(50, mp.Ez, mp.Vector3(), 1e-6))
 
+        # Test store and load of force as numpy array
+        fdata = self.sim.get_force_data(self.myforce)
+        self.sim.load_force_data(self.myforce, fdata)
+
         self.sim.display_forces(self.myforce)
         f = mp.get_forces(self.myforce)
 
         self.assertAlmostEqual(f[0], -0.11039089113393187)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/dft.cpp
+++ b/src/dft.cpp
@@ -290,7 +290,7 @@ void dft_chunk::operator-=(const dft_chunk &chunk) {
   }
 }
 
-static size_t dft_chunks_Ntotal(dft_chunk *dft_chunks, size_t *my_start) {
+size_t dft_chunks_Ntotal(dft_chunk *dft_chunks, size_t *my_start) {
   size_t n = 0;
   for (dft_chunk *cur = dft_chunks; cur; cur = cur->next_in_dft)
     n += cur->N * cur->Nomega * 2;


### PR DESCRIPTION
Ardavan requested that `load_flux` accept a numpy array so that the `bend_flux.py` example could load the data from the normalization run into a `dft_flux` without having to save it to a file first. This PR adds such functionality to flux, near2far, and force objects.  Since the `save_hdf5` method of these objects outputs different datasets, I am using named tuples with each element being a numpy array for a specific dataset.
```python
FluxData = namedtuple('FluxData', ['E', 'H'])
ForceData = namedtuple('ForceData', ['offdiag1', 'offdiag2', 'diag'])
NearToFarData = namedtuple('NearToFarData', ['F'])
```

Currently the data for the numpy arrays obtained from the dft objects is split among processors when run in parallel mode. Is that an issue?
@stevengj @oskooi 