### PR TITLE
Fix change_sources bug and update docs

### DIFF
--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -845,7 +845,7 @@ Change the `k_point` (the Bloch periodicity).
 
 **`change_sources(new_sources)`**  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-Change the `Sources` input variable to `new_sources`, and changes the sources used for the current simulation.
+Change the list of sources in `Simulation.sources` to `new_sources`, and changes the sources used for the current simulation. `new_sources` must be a list of `Source` objects.
 
 **`set_materials(geometry=None, default_material=None)`**  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -1088,10 +1088,10 @@ class Simulation(object):
                     self.fields.use_bloch(py_v3_to_vec(self.dimensions, self.k_point, self.is_cylindrical))
 
     def change_sources(self, new_sources):
-        self.sources = new_sources if type(new_sources) is list else [new_sources]
+        self.sources = new_sources
         if self.fields:
             self.fields.remove_sources()
-            for s in new_sources:
+            for s in self.sources:
                 self.add_source(s)
 
     def reset_meep(self):


### PR DESCRIPTION
`change_sources` was originally designed to accept either a list of `Source`s, or a single `Source`, but since a bug was preventing the latter case from working anyway and the Scheme version only accepts a list, I've changed Python to only accept a list too.
@stevengj @oskooi 