### PR TITLE
Added kvec and vgrp output for get_eigenmode_coefficient

### DIFF
--- a/python/examples/materials_library.py
+++ b/python/examples/materials_library.py
@@ -1,40 +1,12 @@
 # Materials Library
 
 import meep as mp
-import numpy as np
 
 # default unit length is 1 um
 um_scale = 1.0
 
 # conversion factor for eV to 1/um [=1/hc]
 eV_um_scale = um_scale/1.23984193
-
-# ------------------------------------------------------------------ #
-# Silicon (Si)
-# ------------------------------------------------------------------ #
-# silicon (Si) from Palik's Handbook & Lukas's book
-# wavelength range: 1.15 - 1.8 um
-
-# Reference:
-# H. H. Li. Refractive index of silicon and germanium and its wavelength and
-# temperature derivatives, J. Phys. Chem. Ref. Data 9, 561-658 (1993)
-# Speed of light in vacuum, m/s
-c = 299792458
-
-Si_range = mp.FreqRange(min=1/1.8, max=1/1.15)
-
-eps = 7.9874
-eps_lorentz = 3.6880
-omega0 = 3.9328e15
-delta0 = 0
-
-Si_frq1 = omega0 / (2 * np.pi * c) * 1e-6
-Si_gam1 = 0
-Si_sig1 = eps_lorentz
-
-Si_susc = [ mp.LorentzianSusceptibility(frequency=Si_frq1, gamma=Si_gam1, sigma=Si_sig1) ]
-
-Si = mp.Medium(epsilon=eps, E_susceptibilities=Si_susc, valid_freq_range=Si_range)
 
 #------------------------------------------------------------------
 

--- a/python/meep.i
+++ b/python/meep.i
@@ -694,6 +694,7 @@ meep::volume_list *make_volume_list(const meep::volume &v, int c,
 //--------------------------------------------------
 %apply (int *IN_ARRAY1, int DIM1) {(int *bands, int num_bands)};
 
+// coefficients
 %typecheck(SWIG_TYPECHECK_POINTER, fragment="NumPy_Fragments") std::complex<double>* coeffs {
     $1 = is_array($input);
 }
@@ -702,12 +703,31 @@ meep::volume_list *make_volume_list(const meep::volume &v, int c,
     $1 = (std::complex<double> *)array_data($input);
 }
 
+// k mag
+%typecheck(SWIG_TYPECHECK_POINTER, fragment="NumPy_Fragments") double* kmag {
+    $1 = is_array($input);
+}
+
+%typemap(in, fragment="NumPy_Macros") double* kmag {
+    $1 = (double *)array_data($input);
+}
+
+// group velocity
+%typecheck(SWIG_TYPECHECK_POINTER, fragment="NumPy_Fragments") double* vgrp {
+    $1 = is_array($input);
+}
+
+%typemap(in, fragment="NumPy_Macros") double* vgrp {
+    $1 = (double *)array_data($input);
+}
+
+
 //--------------------------------------------------
 // end typemaps for get_eigenmode_coefficients
 //--------------------------------------------------
 
 //--------------------------------------------------
-// typemaps needed for add_dft_fields
+  // typemaps needed for add_dft_fields
 //--------------------------------------------------
 %typemap(in) (meep::component *components, int num_components) {
     if (!PyList_Check($input)) {

--- a/python/meep.i
+++ b/python/meep.i
@@ -727,7 +727,7 @@ meep::volume_list *make_volume_list(const meep::volume &v, int c,
 //--------------------------------------------------
 
 //--------------------------------------------------
-  // typemaps needed for add_dft_fields
+// typemaps needed for add_dft_fields
 //--------------------------------------------------
 %typemap(in) (meep::component *components, int num_components) {
     if (!PyList_Check($input)) {

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -1280,9 +1280,8 @@ class Simulation(object):
 
         num_bands = len(bands)
         coeffs = np.zeros(2 * num_bands * flux.Nfreq, dtype=np.complex128)
-<<<<<<< HEAD
         vgrp   = np.zeros(num_bands * flux.Nfreq, dtype=np.float64)
-        kmag = np.zeros(num_bands * flux.Nfreq * 3, dtype=np.float64)
+        kmag   = np.zeros(num_bands * flux.Nfreq * 3, dtype=np.float64)
         self.fields.get_eigenmode_coefficients(flux, eig_vol, np.array(bands, dtype=np.intc),
                                                eig_parity, eig_resolution, eig_tolerance, coeffs,
                                                kmag,vgrp, kpoint_func)
@@ -1291,12 +1290,6 @@ class Simulation(object):
         vgrp   = np.reshape(vgrp, (num_bands, flux.Nfreq))
         kmag   = np.reshape(kmag, (num_bands, flux.Nfreq, 3))
         return coeffs, kmag, vgrp
-=======
-        self.fields.get_eigenmode_coefficients(flux.swigobj, eig_vol, np.array(bands, dtype=np.intc), eig_parity,
-                                               eig_resolution, eig_tolerance, coeffs, None, kpoint_func)
-
-        return np.reshape(coeffs, (num_bands, flux.Nfreq, 2))
->>>>>>> 588f58abb975069624d86916d63ba72fdbb819d9
 
     def output_field_function(self, name, cs, func, real_only=False, h5file=None):
         if self.fields is None:

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -1056,12 +1056,18 @@ class Simulation(object):
         else:
             eig_vol = self._volume_from_kwargs(vol=eig_vol)
 
-        num_bands = len(bands)
+        num_bands = int(len(bands))
         coeffs = np.zeros(2 * num_bands * flux.Nfreq, dtype=np.complex128)
-        self.fields.get_eigenmode_coefficients(flux, eig_vol, np.array(bands, dtype=np.intc), eig_parity,
-                                               eig_resolution, eig_tolerance, coeffs, None, kpoint_func)
+        vgrp   = np.zeros(num_bands * flux.Nfreq, dtype=np.float64)
+        kmag = np.zeros(num_bands * flux.Nfreq * 3, dtype=np.float64)
+        self.fields.get_eigenmode_coefficients(flux, eig_vol, np.array(bands, dtype=np.intc),
+                                               eig_parity, eig_resolution, eig_tolerance, coeffs,
+                                               kmag,vgrp, kpoint_func)
 
-        return np.reshape(coeffs, (num_bands, flux.Nfreq, 2))
+        coeffs = np.reshape(coeffs, (num_bands, flux.Nfreq, 2))
+        vgrp   = np.reshape(vgrp, (num_bands, flux.Nfreq))
+        kmag   = np.reshape(kmag, (num_bands, flux.Nfreq, 3))
+        return coeffs, kmag, vgrp
 
     def output_field_function(self, name, cs, func, real_only=False, h5file=None):
         if self.fields is None:

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -1056,7 +1056,7 @@ class Simulation(object):
         else:
             eig_vol = self._volume_from_kwargs(vol=eig_vol)
 
-        num_bands = int(len(bands))
+        num_bands = len(bands)
         coeffs = np.zeros(2 * num_bands * flux.Nfreq, dtype=np.complex128)
         vgrp   = np.zeros(num_bands * flux.Nfreq, dtype=np.float64)
         kmag = np.zeros(num_bands * flux.Nfreq * 3, dtype=np.float64)

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1461,16 +1461,18 @@ class fields {
                                   int *bands, int num_bands, int parity,
                   			          double eig_resolution, double eigensolver_tol,
                                   std::complex<double> *coeffs,
+                                  double *kmag,
                                   double *vgrp, kpoint_func user_kpoint_func=0,
                                   void *user_kpoint_data=0);
 
   void get_eigenmode_coefficients(dft_flux flux,
                                   int *bands, int num_bands, int parity,
                                   std::complex<double> *coeffs,
+                                  double *kmag,
                                   double *vgrp, kpoint_func user_kpoint_func=0,
                                   void *user_kpoint_data=0) {
       get_eigenmode_coefficients(flux, flux.where, bands, num_bands, parity,
-          0.0, 1e-7, coeffs, vgrp, user_kpoint_func, user_kpoint_data);
+          0.0, 1e-7, coeffs, kmag, vgrp, user_kpoint_func, user_kpoint_data);
   }
 
   // initialize.cpp:

--- a/src/mpb.cpp
+++ b/src/mpb.cpp
@@ -603,6 +603,7 @@ void fields::get_eigenmode_coefficients(dft_flux flux,
                                         int *bands, int num_bands, int parity,
                                         double eig_resolution, double eigensolver_tol,
                                         std::complex<double> *coeffs,
+                                        double *kmag,
                                         double *vgrp, kpoint_func user_kpoint_func,
                                         void *user_kpoint_data)
 {
@@ -638,8 +639,38 @@ void fields::get_eigenmode_coefficients(dft_flux flux,
         continue;
       }
 
+      // Calculate and store the group velocity if requested
       double vg=get_group_velocity(mode_data);
       if (vgrp) vgrp[nb*num_freqs + nf]=vg;
+
+      // Calculate and store the k vector magnitude if requested
+      vec km=get_k(mode_data);
+      if (kmag) {
+        double x = 0, y = 0, z = 0;
+
+        switch (km.dim) {
+          case meep::D1:
+            z = km.z();
+            break;
+          case meep::D2:
+            x = km.x();
+            y = km.y();
+            break;
+          case meep::D3:
+            x = km.x();
+            y = km.y();
+            z = km.z();
+            break;
+          case meep::Dcyl:
+            x = km.r();
+            z = km.z();
+            break;
+        }
+
+        kmag[3*nb*num_freqs + 3*nf + 0] = x;
+        kmag[3*nb*num_freqs + 3*nf + 1] = y;
+        kmag[3*nb*num_freqs + 3*nf + 2] = z;
+      }
 
       /*--------------------------------------------------------------*/
       /*--------------------------------------------------------------*/
@@ -698,12 +729,13 @@ void fields::get_eigenmode_coefficients(dft_flux flux,
                                         int *bands, int num_bands, int parity,
                                         double eig_resolution, double eigensolver_tol,
                                         std::complex<double> *coeffs,
+                                        double *kmag,
                                         double *vgrp, kpoint_func user_kpoint_func,
                                         void *user_kpoint_data)
 
 { (void) flux; (void) eig_vol; (void) bands; (void)num_bands;
   (void) parity; (void) eig_resolution; (void) eigensolver_tol;
-  (void) coeffs; (void) vgrp; (void) user_kpoint_func; (void) user_kpoint_data;
+  (void) coeffs; (void) kmag; (void) vgrp; (void) user_kpoint_func; (void) user_kpoint_data;
   abort("Meep must be configured/compiled with MPB for get_eigenmode_coefficient");
 }
 


### PR DESCRIPTION
This is my solution to my feature request (#363). The C interface returns an array of doubles, similar to what's done with the group velocities. The python interface returns a 3D numpy array where the 1st column is the band, the second column is frequency, and the third column is the dimension (i.e mp.X, mp.Y, mp.Z).

After reviewing #368, I think my array is in the reciprocal basis as well. I can work on a fix.