### PR TITLE
Sync python material dispersion doc to example

### DIFF
--- a/doc/docs/Python_Tutorials/Material_Dispersion.md
+++ b/doc/docs/Python_Tutorials/Material_Dispersion.md
@@ -176,7 +176,7 @@ sim = mp.Simulation(cell_size=cell, geometry=[], sources=sources, default_materi
 all_freqs = sim.run_k_points(200, kpts)  # a list of lists of frequencies
 ```
 
-The `k_points` function returns a *list of lists* of frequencies &mdash; one list of complex frequencies for each *k* point &mdash; which we store in the `all_freqs` variable. Finally, we want to loop over this list and print out the corresponding ε via the ratio (ck/ω)$^2$ as described above. To do this, we will use Python's `zip` function which combines multiple lists into one:
+The `run_k_points` function returns a *list of lists* of frequencies &mdash; one list of complex frequencies for each *k* point &mdash; which we store in the `all_freqs` variable. Finally, we want to loop over this list and print out the corresponding ε via the ratio (ck/ω)$^2$ as described above. To do this, we will use Python's `zip` function which combines multiple lists into one:
 
 ```py
 for fs, kx in zip(all_freqs, [v.x for v in kpts]):

--- a/doc/docs/Python_Tutorials/Material_Dispersion.md
+++ b/doc/docs/Python_Tutorials/Material_Dispersion.md
@@ -173,7 +173,7 @@ kpts = mp.interpolate(k_interp, [mp.Vector3(kmin), mp.Vector3(kmax)])
 
 sim = mp.Simulation(cell_size=cell, geometry=[], sources=sources, default_material=default_material, resolution=resolution)
 
-all_freqs = sim.run(kpts, k_points=200)  # a list of lists of frequencies
+all_freqs = sim.run_k_points(200, kpts)  # a list of lists of frequencies
 ```
 
 The `k_points` function returns a *list of lists* of frequencies &mdash; one list of complex frequencies for each *k* point &mdash; which we store in the `all_freqs` variable. Finally, we want to loop over this list and print out the corresponding ε via the ratio (ck/ω)$^2$ as described above. To do this, we will use Python's `zip` function which combines multiple lists into one:


### PR DESCRIPTION
The second example in the docs doesn't run, updated it to follow the code in the examples.