### PR TITLE
import before_time into meep.py

### DIFF
--- a/python/meep.i
+++ b/python/meep.i
@@ -1170,6 +1170,7 @@ kpoint_list get_eigenmode_coefficients_and_kpoints(meep::fields *f, meep::dft_fl
         at_end,
         at_every,
         at_time,
+        before_time,
         dft_ldos,
         display_progress,
         during_sources,


### PR DESCRIPTION
The `before_time` step modifier is not available in the Python interface.  This is fixed by adding the import to `meep.i`.