### PR TITLE
updates to ensure correct calculation of eigenmode coefficients with symmetries

### DIFF
--- a/libmeepgeom/Makefile.am
+++ b/libmeepgeom/Makefile.am
@@ -42,10 +42,11 @@ TESTS_ENVIRONMENT = export LD_PRELOAD=$(abs_top_builddir)/src/.libs/libmeep.so;
 
 #LOG_COMPILER = $(RUNCODE)
 
-noinst_PROGRAMS = bend-flux-ll SIEPICCoupler
+noinst_PROGRAMS = bend-flux-ll
 
-SIEPICCoupler_SOURCES = SIEPICCoupler.cpp
-SIEPICCoupler_LDADD   = libmeepgeom.la $(MEEPLIBS)
+#noinst_PROGRAMS = bend-flux-ll SIEPICCoupler
+#SIEPICCoupler_SOURCES = SIEPICCoupler.cpp
+#SIEPICCoupler_LDADD   = libmeepgeom.la $(MEEPLIBS)
 
 bend_flux_ll_SOURCES = bend-flux-ll.cpp
 bend_flux_ll_LDADD   = libmeepgeom.la $(MEEPLIBS)

--- a/libmeepgeom/Makefile.am
+++ b/libmeepgeom/Makefile.am
@@ -42,7 +42,10 @@ TESTS_ENVIRONMENT = export LD_PRELOAD=$(abs_top_builddir)/src/.libs/libmeep.so;
 
 #LOG_COMPILER = $(RUNCODE)
 
-noinst_PROGRAMS = bend-flux-ll
+noinst_PROGRAMS = bend-flux-ll SIEPICCoupler
+
+SIEPICCoupler_SOURCES = SIEPICCoupler.cpp
+SIEPICCoupler_LDADD   = libmeepgeom.la $(MEEPLIBS)
 
 bend_flux_ll_SOURCES = bend-flux-ll.cpp
 bend_flux_ll_LDADD   = libmeepgeom.la $(MEEPLIBS)

--- a/libmeepgeom/Makefile.am
+++ b/libmeepgeom/Makefile.am
@@ -44,10 +44,6 @@ TESTS_ENVIRONMENT = export LD_PRELOAD=$(abs_top_builddir)/src/.libs/libmeep.so;
 
 noinst_PROGRAMS = bend-flux-ll
 
-#noinst_PROGRAMS = bend-flux-ll SIEPICCoupler
-#SIEPICCoupler_SOURCES = SIEPICCoupler.cpp
-#SIEPICCoupler_LDADD   = libmeepgeom.la $(MEEPLIBS)
-
 bend_flux_ll_SOURCES = bend-flux-ll.cpp
 bend_flux_ll_LDADD   = libmeepgeom.la $(MEEPLIBS)
 

--- a/src/dft.cpp
+++ b/src/dft.cpp
@@ -348,19 +348,15 @@ void load_dft_hdf5(dft_chunk *dft_chunks, component c, h5file *file,
   load_dft_hdf5(dft_chunks, component_name(c), file, dprefix);
 }
 
-dft_flux::dft_flux(const component cE_, const component cH_,
-		   dft_chunk *E_, dft_chunk *H_,
-		   double fmin, double fmax, int Nf,
-		   const volume &where_,
-                   direction normal_direction_) : where(where_)
+dft_flux::dft_flux(const component cE_, const component cH_, dft_chunk *E_, dft_chunk *H_,
+		   double fmin, double fmax, int Nf, const volume &where_,
+                   direction normal_direction_, bool use_symmetry_) :
+ Nfreq(Nf), E(E_), H(H_), cE(cE_), cH(cH_), where(where_),
+ normal_direction(normal_direction_), use_symmetry(use_symmetry_)
 {
   if (Nf <= 1) fmin = fmax = (fmin + fmax) * 0.5;
   freq_min = fmin;
-  Nfreq = Nf;
   dfreq = Nf <= 1 ? 0.0 : (fmax - fmin) / (Nf - 1);
-  E = E_; H = H_;
-  cE = cE_; cH = cH_;
-  normal_direction = normal_direction_;
 }
 
 dft_flux::dft_flux(const dft_flux &f) : where(f.where) {
@@ -368,6 +364,7 @@ dft_flux::dft_flux(const dft_flux &f) : where(f.where) {
   E = f.E; H = f.H;
   cE = f.cE; cH = f.cH;
   normal_direction = f.normal_direction;
+  use_symmetry=f.use_symmetry;
 }
 
 double *dft_flux::flux() {
@@ -417,10 +414,11 @@ void dft_flux::scale_dfts(complex<double> scale) {
 }
 
 dft_flux fields::add_dft_flux(const volume_list *where_,
-			      double freq_min, double freq_max, int Nfreq, bool use_symmetry)
+			      double freq_min, double freq_max, int Nfreq, 
+                              bool use_symmetry)
 {
   if (!where_) // handle empty list of volumes
-    return dft_flux(Ex, Hy, NULL, NULL, freq_min, freq_max, Nfreq, v, NO_DIRECTION);
+   return dft_flux(Ex, Hy, NULL, NULL, freq_min, freq_max, Nfreq, v, NO_DIRECTION, use_symmetry);
 
   dft_chunk *E = 0, *H = 0;
   component cE[2] = {Ex,Ey}, cH[2] = {Hy,Hx};
@@ -466,7 +464,7 @@ dft_flux fields::add_dft_flux(const volume_list *where_,
   // if the volume list has only one entry, store its component's direction.
   // if the volume list has > 1 entry, store NO_DIRECTION.
   direction flux_dir = (where_->next ? NO_DIRECTION : component_direction(where_->c));
-  return dft_flux(cE[0], cH[0], E, H, freq_min, freq_max, Nfreq, firstvol, flux_dir);
+  return dft_flux(cE[0], cH[0], E, H, freq_min, freq_max, Nfreq, firstvol, flux_dir, use_symmetry);
 }
 
 
@@ -499,7 +497,7 @@ dft_flux fields::add_dft_flux(direction d, const volume &where,
 
 dft_flux fields::add_mode_monitor(direction d, const volume &where,
                                   double freq_min, double freq_max, int Nfreq)
-{ return add_dft_flux(d,where,freq_min,freq_max,Nfreq,false); }
+{ return add_dft_flux(d,where,freq_min,freq_max,Nfreq, /*use_symmetry=*/false); }
 
 dft_flux fields::add_dft_flux_box(const volume &where,
 				  double freq_min, double freq_max, int Nfreq){

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1539,14 +1539,18 @@ class fields {
 		     double freq_min, double freq_max, int Nfreq,
 		     bool include_dV = true);
   void update_dfts();
+  dft_flux add_dft_flux(const volume_list *where,
+			double freq_min, double freq_max, int Nfreq, bool use_symmetry=true);
   dft_flux add_dft_flux(direction d, const volume &where,
-			double freq_min, double freq_max, int Nfreq);
+			double freq_min, double freq_max, int Nfreq, bool use_symmetry=true);
   dft_flux add_dft_flux_box(const volume &where,
 			    double freq_min, double freq_max, int Nfreq);
   dft_flux add_dft_flux_plane(const volume &where,
 			      double freq_min, double freq_max, int Nfreq);
-  dft_flux add_dft_flux(const volume_list *where,
-			double freq_min, double freq_max, int Nfreq);
+
+  // a "mode monitor" is just a dft_flux with symmetry reduction turned off.
+  dft_flux add_mode_monitor(direction d, const volume &where,
+                            double freq_min, double freq_max, int Nfreq);
 
   dft_fields add_dft_fields(component *components, int num_components,
                             const volume where,

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -935,7 +935,8 @@ public:
   dft_flux(const component cE_, const component cH_,
 	   dft_chunk *E_, dft_chunk *H_,
 	   double fmin, double fmax, int Nf,
-	   const volume &where_, direction normal_direction_);
+	   const volume &where_, direction normal_direction_,
+	   bool use_symmetry_);
   dft_flux(const dft_flux &f);
 
   double *flux();
@@ -960,6 +961,7 @@ public:
   component cE, cH;
   volume where;
   direction normal_direction;
+  bool use_symmetry;
 };
 
 // stress.cpp (normally created with fields::add_dft_force)

--- a/src/mpb.cpp
+++ b/src/mpb.cpp
@@ -230,10 +230,10 @@ void *fields::get_eigenmode(double omega_src,
   // in any direction, set the corresponding component of the eigenmode initial-guess
   // k-vector to be the (real part of the) bloch vector in that direction.
   vec kpoint(_kpoint);
-  LOOP_OVER_DIRECTIONS(v.dim, d)
-    if (float(eig_vol.in_direction(d) == float(v.in_direction(d))))
-      if (boundaries[High][d]==Periodic && boundaries[Low][d]==Periodic)
-        kpoint.set_direction(d, real(k[d]));
+  LOOP_OVER_DIRECTIONS(v.dim, dd)
+   if (float(eig_vol.in_direction(dd) == float(v.in_direction(dd))))
+      if (boundaries[High][dd]==Periodic && boundaries[Low][dd]==Periodic)
+        kpoint.set_direction(dd, real(k[dd]));
 
   //bool verbose=true;
   if (resolution <= 0.0) resolution = 2 * gv.a; // default to twice resolution
@@ -634,8 +634,8 @@ void fields::get_eigenmode_coefficients(dft_flux flux,
   if (d==NO_DIRECTION)
    abort("cannot determine normal direction in get_eigenmode_coefficients");
 
-  //if (S.multiplicity() > 1)
-  // abort("symmetries are not yet supported in get_eigenmode_coefficients");
+  if (flux.use_symmetry && S.multiplicity() > 1)
+   abort("flux regions for eigenmode projection must be created by add_mode_monitor()");
 
   vec kpoint(0.0,0.0,0.0); // default guess
 

--- a/src/mpb.cpp
+++ b/src/mpb.cpp
@@ -634,8 +634,8 @@ void fields::get_eigenmode_coefficients(dft_flux flux,
   if (d==NO_DIRECTION)
    abort("cannot determine normal direction in get_eigenmode_coefficients");
 
-  if (S.multiplicity() > 1)
-   abort("symmetries are not yet supported in get_eigenmode_coefficients");
+  //if (S.multiplicity() > 1)
+  // abort("symmetries are not yet supported in get_eigenmode_coefficients");
 
   vec kpoint(0.0,0.0,0.0); // default guess
 


### PR DESCRIPTION
The only API modification is the addition of a new method `fields::add_mode_monitor` with the same calling convention as `add_dft_flux.` This instantiates a `dft_flux` object in which symmetry reduction is turned off. Existing code that calls `add_dft_flux` to create a flux region for subsequent passage to `get_eigenmode_coefficients` should now call `add_mode_monitor` instead.  