### PR TITLE
Add high level get_eigenmode and EigenmodeData class

### DIFF
--- a/python/simulation.py
+++ b/python/simulation.py
@@ -338,14 +338,14 @@ Mode = namedtuple('Mode', ['freq', 'decay', 'Q', 'amp', 'err'])
 
 class EigenmodeData(object):
 
-    def __init__(self, band_num, omega, group_velocity, Gk, swigobj):
+    def __init__(self, band_num, omega, group_velocity, k, swigobj):
         self.band_num = band_num
         self.omega = omega
         self.group_velocity = group_velocity
-        self.Gk = Gk
+        self.k = k
         self.swigobj = swigobj
 
-    def eigenmode_amplitude(self, point, component):
+    def amplitude(self, point, component):
         swig_point = mp.vec(point.x, point.y, point.z)
         return mp.eigenmode_amplitude(self.swigobj, swig_point, component)
 

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -336,6 +336,20 @@ class DftFields(DftObj):
 Mode = namedtuple('Mode', ['freq', 'decay', 'Q', 'amp', 'err'])
 
 
+class EigenmodeData(object):
+
+    def __init__(self, band_num, omega, group_velocity, Gk, swigobj):
+        self.band_num = band_num
+        self.omega = omega
+        self.group_velocity = group_velocity
+        self.Gk = Gk
+        self.swigobj = swigobj
+
+    def eigenmode_amplitude(self, point, component):
+        swig_point = mp.vec(point.x, point.y, point.z)
+        return mp.eigenmode_amplitude(self.swigobj, swig_point, component)
+
+
 class Harminv(object):
 
     def __init__(self, c, pt, fcen, df, mxbands=None):
@@ -1309,6 +1323,24 @@ class Simulation(object):
         )
 
         return np.reshape(coeffs, (num_bands, flux.Nfreq, 2)), vgrp, kpoints
+
+    def get_eigenmode(self, omega_src, direction, where, band_num, kpoint, eig_vol=None, match_frequency=True,
+                      parity=mp.NO_PARITY, resolution=0, eigensolver_tol=1e-7, verbose=False):
+
+        if self.fields is None:
+            raise ValueError("Fields must be initialized before calling get_eigenmode")
+
+        where = self._volume_from_kwargs(vol=where)
+        if eig_vol is None:
+            eig_vol = where
+        else:
+            eig_vol = self._volume_from_kwargs(vol=eig_vol)
+
+        swig_kpoint = mp.vec(kpoint.x, kpoint.y, kpoint.z)
+        emdata = mp._get_eigenmode(self.fields, omega_src, direction, where, eig_vol, band_num, swig_kpoint,
+                                   match_frequency, parity, resolution, eigensolver_tol, verbose)
+
+        return EigenmodeData(emdata.band_num, emdata.omega, emdata.group_velocity, emdata.Gk, emdata.data)
 
     def output_field_function(self, name, cs, func, real_only=False, h5file=None):
         if self.fields is None:

--- a/python/tests/mode_coeffs.py
+++ b/python/tests/mode_coeffs.py
@@ -78,10 +78,23 @@ class TestModeCoeffs(unittest.TestCase):
         self.assertTrue(TestPassed) # test 1: coefficient of excited mode >> coeffs of all other modes
 
         self.assertAlmostEqual(mode_power / abs(c0**2), 1.0, places=1) # test 2: |mode coeff|^2 = power
+        self.sim = sim
 
     def test_modes(self):
         self.run_mode_coeffs(1, None)
         self.run_mode_coeffs(2, None)
+
+        # Test mp.get_eigenmode and EigenmodeData
+        vol = mp.Volume(center=mp.Vector3(5), size=mp.Vector3(y=7))
+        emdata = self.sim.get_eigenmode(0.2, mp.X, vol, 2, mp.Vector3())
+        self.assertEqual(emdata.omega, 0.2)
+        self.assertEqual(emdata.band_num, 2)
+
+        eval_point = mp.Vector3(0.7, -0.2, 0.3)
+        ex_at_eval_point = emdata.eigenmode_amplitude(eval_point, mp.Ex)
+        hz_at_eval_point = emdata.eigenmode_amplitude(eval_point, mp.Hz)
+        self.assertAlmostEqual(ex_at_eval_point, 6.568131761292562e-05 + 0.4258364121372713j)
+        self.assertAlmostEqual(hz_at_eval_point, 3.011392520908835 - 9.889032702825595e-06j)
 
     def test_kpoint_func(self):
 

--- a/python/tests/mode_coeffs.py
+++ b/python/tests/mode_coeffs.py
@@ -91,8 +91,8 @@ class TestModeCoeffs(unittest.TestCase):
         self.assertEqual(emdata.band_num, 2)
 
         eval_point = mp.Vector3(0.7, -0.2, 0.3)
-        ex_at_eval_point = emdata.eigenmode_amplitude(eval_point, mp.Ex)
-        hz_at_eval_point = emdata.eigenmode_amplitude(eval_point, mp.Hz)
+        ex_at_eval_point = emdata.amplitude(eval_point, mp.Ex)
+        hz_at_eval_point = emdata.amplitude(eval_point, mp.Hz)
         self.assertAlmostEqual(ex_at_eval_point, 6.568131761292562e-05 + 0.4258364121372713j)
         self.assertAlmostEqual(hz_at_eval_point, 3.011392520908835 - 9.889032702825595e-06j)
 


### PR DESCRIPTION
* Added high level `Simulation.get_eigenmode`. The default arguments probably need double checked. 
* Added python EigenmodeData class that wraps the `eigenmode_data` info, and has an `eigenmode_amplitude` method.
@stevengj @oskooi 