### PR TITLE
Add Python interface for add_mode_monitor

### DIFF
--- a/python/simulation.py
+++ b/python/simulation.py
@@ -1133,15 +1133,15 @@ class Simulation(object):
         if self.fields is None:
             self.init_sim()
 
-        if self.symmetries:
-            return self._add_fluxish_stuff(self.fields.add_dft_flux, fcen, df, nfreq, fluxes)
-        else:
-            region = fluxes[0]
-            v = mp.Volume(region.center, region.size, dims=self.dimensions, is_cylindrical=self.is_cylindrical)
-            d0 = region.direction
-            d = self.fields.normal_direction(v.swigobj) if d0 < 0 else d0
+        if len(fluxes) != 1:
+            raise ValueError("add_mode_monitor expected just one FluxRegion. Got {}".format(len(fluxes)))
 
-            return self.fields.add_mode_monitor(d, v.swigobj, fcen - df / 2, fcen + df / 2, nfreq)
+        region = fluxes[0]
+        v = mp.Volume(region.center, region.size, dims=self.dimensions, is_cylindrical=self.is_cylindrical)
+        d0 = region.direction
+        d = self.fields.normal_direction(v.swigobj) if d0 < 0 else d0
+
+        return self.fields.add_mode_monitor(d, v.swigobj, fcen - df / 2, fcen + df / 2, nfreq)
 
     def add_eigenmode(self, fcen, df, nfreq, *fluxes):
         warnings.warn('add_eigenmode is deprecated. Please use add_mode_monitor instead.', DeprecationWarning)

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -1124,11 +1124,28 @@ class Simulation(object):
             self.init_sim()
         return self._add_fluxish_stuff(self.fields.add_dft_flux, fcen, df, nfreq, fluxes)
 
-    add_mode_monitor = add_flux
+    def add_mode_monitor(self, fcen, df, nfreq, *fluxes):
+        flux = DftFlux(self._add_mode_monitor, [fcen, df, nfreq, fluxes])
+        self.dft_objects.append(flux)
+        return flux
+
+    def _add_mode_monitor(self, fcen, df, nfreq, fluxes):
+        if self.fields is None:
+            self.init_sim()
+
+        if self.symmetries:
+            return self._add_fluxish_stuff(self.fields.add_dft_flux, fcen, df, nfreq, fluxes)
+        else:
+            region = fluxes[0]
+            v = mp.Volume(region.center, region.size, dims=self.dimensions, is_cylindrical=self.is_cylindrical)
+            d0 = region.direction
+            d = self.fields.normal_direction(v.swigobj) if d0 < 0 else d0
+
+            return self.fields.add_mode_monitor(d, v.swigobj, fcen - df / 2, fcen + df / 2, nfreq)
 
     def add_eigenmode(self, fcen, df, nfreq, *fluxes):
         warnings.warn('add_eigenmode is deprecated. Please use add_mode_monitor instead.', DeprecationWarning)
-        return self.add_flux(fcen, df, nfreq, *fluxes)
+        return self.add_mode_monitor(fcen, df, nfreq, *fluxes)
 
     def display_fluxes(self, *fluxes):
         display_csv(self, 'flux', zip(get_flux_freqs(fluxes[0]), *[get_fluxes(f) for f in fluxes]))

--- a/python/tests/mode_coeffs.py
+++ b/python/tests/mode_coeffs.py
@@ -49,6 +49,7 @@ class TestModeCoeffs(unittest.TestCase):
                             boundary_layers=boundary_layers,
                             geometry=geometry,
                             sources=sources,
+                            symmetries=[mp.Mirror(mp.Y)] if mode_num == 1 else []
                             )
 
         xm = 0.5*sx - dpml  # x-coordinate of monitor
@@ -75,10 +76,13 @@ class TestModeCoeffs(unittest.TestCase):
                 cbrel = np.abs(alpha[nm - 1, 0, 1]) / np.abs(c0)
                 if cfrel > TOLERANCE or cbrel > TOLERANCE:
                     TestPassed = False
-        self.assertTrue(TestPassed) # test 1: coefficient of excited mode >> coeffs of all other modes
 
-        self.assertAlmostEqual(mode_power / abs(c0**2), 1.0, places=1) # test 2: |mode coeff|^2 = power
         self.sim = sim
+
+        # test 1: coefficient of excited mode >> coeffs of all other modes
+        self.assertTrue(TestPassed, msg="cfrel: {}, cbrel: {}".format(cfrel, cbrel))
+        # test 2: |mode coeff|^2 = power
+        self.assertAlmostEqual(mode_power / abs(c0**2), 1.0, places=1)
 
     def test_modes(self):
         self.run_mode_coeffs(1, None)

--- a/python/tests/mode_coeffs.py
+++ b/python/tests/mode_coeffs.py
@@ -49,8 +49,7 @@ class TestModeCoeffs(unittest.TestCase):
                             boundary_layers=boundary_layers,
                             geometry=geometry,
                             sources=sources,
-                            symmetries=[mp.Mirror(mp.Y)] if mode_num == 1 else [mp.Mirror(mp.Y, phase=-1)]
-                            )
+                            symmetries=[mp.Mirror(mp.Y, phase=1 if mode_num % 2 == 1 else -1)])
 
         xm = 0.5*sx - dpml  # x-coordinate of monitor
         mflux = sim.add_mode_monitor(fcen, 0, 1, mp.FluxRegion(center=mp.Vector3(xm,0), size=mp.Vector3(0,sy-2*dpml)))

--- a/python/tests/mode_coeffs.py
+++ b/python/tests/mode_coeffs.py
@@ -49,7 +49,7 @@ class TestModeCoeffs(unittest.TestCase):
                             boundary_layers=boundary_layers,
                             geometry=geometry,
                             sources=sources,
-                            symmetries=[mp.Mirror(mp.Y)] if mode_num == 1 else []
+                            symmetries=[mp.Mirror(mp.Y)] if mode_num == 1 else [mp.Mirror(mp.Y, phase=-1)]
                             )
 
         xm = 0.5*sx - dpml  # x-coordinate of monitor


### PR DESCRIPTION
This is work in progress of the Python side of #417.

The comment in #417 says to replace all calls to `fields::add_dft_flux` with `fields::add_mode_monitor`. But what if the simulation has symmetries. Don't we then want to call `fields::add_dft_flux`? What's the point of adding support for symmetry if it's always turned off? Here I call `fields::add_dft_flux` (with `symmetry` defaulting to `true`) if the simulation contains symmetries, otherwise I call `fields::add_mode_monitor`. Is that right?
@stevengj @HomerReid @oskooi 
