### PR TITLE
Warn epsilon < 1 in init_sim instead of Medium constructor

### DIFF
--- a/python/geom.py
+++ b/python/geom.py
@@ -165,15 +165,6 @@ class Medium(object):
             i2 = index * index
             epsilon_diag = Vector3(i2, i2, i2)
 
-        if ((epsilon_diag.x < 1 and epsilon_diag.x > -mp.inf) or
-            (epsilon_diag.y < 1 and epsilon_diag.y > -mp.inf) or
-            (epsilon_diag.z < 1 and epsilon_diag.z > -mp.inf)):
-
-            eps_warning = ("Epsilon < 1 may require adjusting the Courant parameter. " +
-                           "See the 'Numerical Stability' entry under the 'Materials' " +
-                           "section of the documentation")
-            warnings.warn(eps_warning, RuntimeWarning)
-
         if mu:
             mu_diag = Vector3(mu, mu, mu)
 

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -712,7 +712,7 @@ class Simulation(object):
 
     def init_sim(self):
 
-        materials = [g.material for g in self.geometry]
+        materials = [g.material for g in self.geometry if isinstance(g.material, mp.Medium)]
         if isinstance(self.default_material, mp.Medium):
             materials.append(self.default_material)
         for med in materials:

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -712,6 +712,19 @@ class Simulation(object):
 
     def init_sim(self):
 
+        materials = [g.material for g in self.geometry]
+        if isinstance(self.default_material, mp.Medium):
+            materials.append(self.default_material)
+        for med in materials:
+            if ((med.epsilon_diag.x < 1 and med.epsilon_diag.x > -mp.inf) or
+                (med.epsilon_diag.y < 1 and med.epsilon_diag.y > -mp.inf) or
+                (med.epsilon_diag.z < 1 and med.epsilon_diag.z > -mp.inf)):
+
+                eps_warning = ("Epsilon < 1 may require adjusting the Courant parameter. " +
+                               "See the 'Numerical Stability' entry under the 'Materials' " +
+                               "section of the documentation")
+                warnings.warn(eps_warning, RuntimeWarning)
+
         if self.structure is None:
             self._init_structure(self.k_point)
 

--- a/python/tests/simulation.py
+++ b/python/tests/simulation.py
@@ -14,6 +14,10 @@ except NameError:
     unicode = str
 
 
+examples_dir = os.path.realpath(os.path.join(os.path.dirname(__file__), '..', 'examples'))
+sys.path.insert(0, examples_dir)
+
+
 class TestSimulation(unittest.TestCase):
 
     fname = 'simulation-ez-000200.00.h5'
@@ -473,6 +477,31 @@ class TestSimulation(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             mp.vec(1, [2, 3])
+
+    def test_epsilon_warning(self):
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            from materials_library import Si
+            self.assertEqual(len(w), 0)
+
+        from materials_library import Mo
+        geom = [mp.Sphere(radius=0.2, material=Mo)]
+        sim = self.init_simple_simulation(geometry=geom)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            sim.run(until=5)
+            self.assertGreater(len(w), 0)
+            self.assertIn("Epsilon", str(w[0].message))
+
+        from materials_library import SiO2
+        geom = [mp.Sphere(radius=0.2, material=SiO2)]
+        sim = self.init_simple_simulation(geometry=geom)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            sim.run(until=5)
+            self.assertEqual(len(w), 1)
+            self.assertNotIn("Epsilon", str(w[0].message))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
As pointed out in the mailing list, `from materials_library import Si` was triggering the "epsilon < 1" warning even though `Si` has epsilon == 1. This is because the import causes the whole file to be executed, which triggers the warning for other materials with epsilon < 1.

To prevent apparent false positives like this, I am moving the warning check to `init_sim` instead of in the Medium constructor. This way it will only trigger if the material is actually used in a simulation instead of when the material is instantiated.
@stevengj @oskooi 