### PR TITLE
Adjust tolerance for eigenmode_amplitude test

### DIFF
--- a/python/tests/mode_coeffs.py
+++ b/python/tests/mode_coeffs.py
@@ -96,8 +96,8 @@ class TestModeCoeffs(unittest.TestCase):
         eval_point = mp.Vector3(0.7, -0.2, 0.3)
         ex_at_eval_point = emdata.amplitude(eval_point, mp.Ex)
         hz_at_eval_point = emdata.amplitude(eval_point, mp.Hz)
-        self.assertAlmostEqual(ex_at_eval_point, 6.568131761292562e-05 + 0.4258364121372713j)
-        self.assertAlmostEqual(hz_at_eval_point, 3.011392520908835 - 9.889032702825595e-06j)
+        self.assertAlmostEqual(ex_at_eval_point, 6.568131761292562e-05 + 0.4258364121372713j, places=4)
+        self.assertAlmostEqual(hz_at_eval_point, 3.011392520908835 - 9.889032702825595e-06j, places=4)
 
     def test_kpoint_func(self):
 


### PR DESCRIPTION
Ardavan reported that this test failed on his machine. Is accuracy to 4 places reasonable for `eigenmode_amplitude`?
@stevengj @oskooi 