### PR TITLE
Fix encoding of materials_library.py for python 2

### DIFF
--- a/python/examples/materials_library.py
+++ b/python/examples/materials_library.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Materials Library
 
 import meep as mp


### PR DESCRIPTION
This is why the build was failing for py 2.7 in #430. `absorber_1d.py` imports the materials library, and a unicode literal was added.
@stevengj @oskooi 