### PR TITLE
fix center arg of prisms

### DIFF
--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -504,6 +504,14 @@ The prism thickness, extruded in the direction of `axis`. `mp.inf` can be used f
 —
 The axis perpendicular to the prism. Defaults to `Vector3(x=0, y=0, z=1)`.
 
+**`center` [`Vector3`]**
+—
+If `center` is *not* specified, then the coordinates of the `vertices` define the *bottom* of the prism
+(with the top of the prism being at the same coordinates shifted by `height*axis`).
+If `center` *is* specified, then `center` is the coordinates of the [centroid](https://en.wikipedia.org/wiki/Centroid)
+of all the vertices (top and bottom) the resulting 3d prism (so that the coordinates of the `vertices` are
+shifted accordingly).
+
 These are some examples of geometric objects created using the above classes:
 
 ```py

--- a/python/geom.py
+++ b/python/geom.py
@@ -334,11 +334,18 @@ class Ellipsoid(Block):
 
 class Prism(GeometricObject):
 
-    def __init__(self, vertices, height, axis=Vector3(z=1), **kwargs):
+    def __init__(self, vertices, height, axis=Vector3(z=1), center=None, **kwargs):
+        centroid = sum(vertices, Vector3(0)) * (1.0 / len(vertices)) + (0.5*height)*axis
+        if center is not None and len(vertices): # shift centroid to center
+            shift = center - centroid
+            vertices = map(lambda v: v + shift, vertices)
+        else:
+            center = centroid
         self.vertices = vertices
         self.height = height
         self.axis = axis
-        super(Prism, self).__init__(**kwargs)
+
+        super(Prism, self).__init__(center=center, **kwargs)
 
 
 class Matrix(object):


### PR DESCRIPTION
Now you can pass a `center` argument to a `Prism` object and it becomes the centroid of the resulting prism (or at least, of its vertices).  Alternatively, if you use the default `center=None` then the `center` property is computed to be the centroid and the vertices specify the bottom of the prism.   This is also documented.