### PR TITLE
Convert iterator to list for python 3

### DIFF
--- a/python/geom.py
+++ b/python/geom.py
@@ -338,7 +338,7 @@ class Prism(GeometricObject):
         centroid = sum(vertices, Vector3(0)) * (1.0 / len(vertices)) + (0.5*height)*axis
         if center is not None and len(vertices): # shift centroid to center
             shift = center - centroid
-            vertices = map(lambda v: v + shift, vertices)
+            vertices = list(map(lambda v: v + shift, vertices))
         else:
             center = centroid
         self.vertices = vertices


### PR DESCRIPTION
Fixes #446. `map` returns an iterator in python 3. The C layer should probably accept iterators instead of just lists at some point, but this is a much simpler fix for the time being.
@stevengj @oskooi 