### PR TITLE
Fix memory issue in h5file::set_cur

### DIFF
--- a/src/h5file.cpp
+++ b/src/h5file.cpp
@@ -239,7 +239,7 @@ void h5file::set_cur(const char *dataname, void *data_id) {
 #endif
   HID(cur_id) = HID(data_id);
   if (!is_cur(dataname)) {
-    if (!cur_dataname || strlen(dataname) < strlen(cur_dataname))
+    if (!cur_dataname || strlen(dataname) > strlen(cur_dataname))
       cur_dataname = (char *) realloc(cur_dataname, strlen(dataname) + 1);
     strcpy(cur_dataname, dataname);
   }


### PR DESCRIPTION
Since the idea is to grow `cur_dataname` to accommodate the size of `dataname`, the comparison should check if `dataname` is greater than `cur_dataname`. 

#### Reproducer
```c++
#include "meep.hpp"
using namespace meep;

int main(int argc, char **argv) {
    initialize mpi(argc, argv);
    h5file f("test.h5", h5file::WRITE, true);
    size_t dim = 1;
    f.create_data("A", 1, &dim);
    f.create_data("AA", 1, &dim);
    return 0;
}
``` 
Running valgrind on the program above reports
```
Invalid write of size 1
   at 0x4C30AD0: strcpy (vg_replace_strmem.c:506)
   by 0x4E98781: meep::h5file::set_cur(char const*, void*) (h5file.cpp:244)
   by 0x4E9986B: meep::h5file::create_data(char const*, int, unsigned long const*, bool, bool) (h5file.cpp:561)
   by 0x400B00: main (h5test.cpp:9)
Address 0xb3f35d2 is 0 bytes after a block of size 2 alloc'd
   at 0x4C2DB00: malloc (vg_replace_malloc.c:298)
   by 0x4C2FACC: realloc (vg_replace_malloc.c:785)
   by 0x4E9875F: meep::h5file::set_cur(char const*, void*) (h5file.cpp:243)
   by 0x4E9986B: meep::h5file::create_data(char const*, int, unsigned long const*, bool, bool) (h5file.cpp:561)
   by 0x400AD7: main (h5test.cpp:8)
```
This error disappears with the change in this PR.

@stevengj @oskooi 