### PR TITLE
Load and dump structure for dispersive materials

### DIFF
--- a/python/tests/simulation.py
+++ b/python/tests/simulation.py
@@ -311,17 +311,16 @@ class TestSimulation(unittest.TestCase):
                             geometry=[geometry],
                             sources=[sources])
 
+        sample_point = mp.Vector3(0.12, -0.29)
         ref_field_points = []
 
         def get_ref_field_point(sim):
-            p = sim.get_field_point(mp.Ez, mp.Vector3(0.12, -0.29))
+            p = sim.get_field_point(mp.Ez, sample_point)
             ref_field_points.append(p.real)
 
         sim.run(mp.at_every(5, get_ref_field_point), until=50)
         dump_fn = 'test_load_dump_structure.h5'
         sim.dump_structure(dump_fn)
-
-        sim.reset_meep()
 
         sim = mp.Simulation(resolution=resolution,
                             cell_size=cell,
@@ -331,7 +330,7 @@ class TestSimulation(unittest.TestCase):
         field_points = []
 
         def get_field_point(sim):
-            p = sim.get_field_point(mp.Ez, mp.Vector3(0.12, -0.29))
+            p = sim.get_field_point(mp.Ez, sample_point)
             field_points.append(p.real)
 
         sim.run(mp.at_every(5, get_field_point), until=50)

--- a/python/tests/simulation.py
+++ b/python/tests/simulation.py
@@ -297,7 +297,7 @@ class TestSimulation(unittest.TestCase):
         sim.field_energy_in_box(v)
 
     def test_load_dump_structure(self):
-        from materials_library import Al
+        from meep.materials_library import Al
         resolution = 50
         cell = mp.Vector3(5, 5)
         sources = mp.Source(src=mp.GaussianSource(1, fwidth=0.2), center=mp.Vector3(), component=mp.Ez)

--- a/python/tests/simulation.py
+++ b/python/tests/simulation.py
@@ -304,11 +304,14 @@ class TestSimulation(unittest.TestCase):
 
         sources = mp.Source(src=mp.GaussianSource(1, fwidth=0.2), center=mp.Vector3(),
                             component=mp.Ez)
-        geometry = mp.Block(material=Al, size=mp.Vector3(1, 1, mp.inf))
+        geometry = [mp.Block(material=Al, center=mp.Vector3(-1.5, -1.5), size=mp.Vector3(1, 1, mp.inf))]
+
+        pml_layers = [mp.PML(0.5)]
 
         sim = mp.Simulation(resolution=resolution,
                             cell_size=cell,
-                            geometry=[geometry],
+                            boundary_layers=pml_layers,
+                            geometry=geometry,
                             sources=[sources])
 
         sample_point = mp.Vector3(0.12, -0.29)
@@ -325,6 +328,7 @@ class TestSimulation(unittest.TestCase):
         sim = mp.Simulation(resolution=resolution,
                             cell_size=cell,
                             sources=[sources],
+                            boundary_layers=pml_layers,
                             load_structure=dump_fn)
 
         field_points = []

--- a/python/tests/simulation.py
+++ b/python/tests/simulation.py
@@ -6,7 +6,7 @@ import warnings
 import h5py
 import numpy as np
 import meep as mp
-from utils import compare_arrays
+
 
 try:
     unicode
@@ -298,14 +298,12 @@ class TestSimulation(unittest.TestCase):
 
     def test_load_dump_structure(self):
         from materials_library import Al
-
         resolution = 50
         cell = mp.Vector3(5, 5)
-
-        sources = mp.Source(src=mp.GaussianSource(1, fwidth=0.2), center=mp.Vector3(),
-                            component=mp.Ez)
-        geometry = [mp.Block(material=Al, center=mp.Vector3(-1.5, -1.5), size=mp.Vector3(1, 1, mp.inf))]
-
+        sources = mp.Source(src=mp.GaussianSource(1, fwidth=0.2), center=mp.Vector3(), component=mp.Ez)
+        one_by_one = mp.Vector3(1, 1, mp.inf)
+        geometry = [mp.Block(material=Al, center=mp.Vector3(-1.5, -1.5), size=one_by_one),
+                    mp.Block(material=mp.Medium(epsilon=13), center=mp.Vector3(1.5, 1.5), size=one_by_one)]
         pml_layers = [mp.PML(0.5)]
 
         sim = mp.Simulation(resolution=resolution,
@@ -327,8 +325,8 @@ class TestSimulation(unittest.TestCase):
 
         sim = mp.Simulation(resolution=resolution,
                             cell_size=cell,
-                            sources=[sources],
                             boundary_layers=pml_layers,
+                            sources=[sources],
                             load_structure=dump_fn)
 
         field_points = []

--- a/python/tests/simulation.py
+++ b/python/tests/simulation.py
@@ -335,7 +335,8 @@ class TestSimulation(unittest.TestCase):
 
         sim.run(mp.at_every(5, get_field_point), until=50)
 
-        compare_arrays(self, np.array(ref_field_points), np.array(field_points), tol=1e-5)
+        for ref_pt, pt in zip(ref_field_points, field_points):
+            self.assertAlmostEqual(ref_pt, pt)
 
         mp.all_wait()
         if mp.am_master():

--- a/src/h5file.cpp
+++ b/src/h5file.cpp
@@ -93,22 +93,21 @@ static int h5io_critical_section_tag = 0;
 
 /*****************************************************************************/
 
-#ifdef HAVE_HDF5
-static bool dataset_exists(hid_t id, const char *name)
-{
-     hid_t data_id;
-     SUPPRESS_HDF5_ERRORS(data_id = H5Dopen(id, name));
-     if (data_id >= 0)
-          H5Dclose(data_id);
-     return (data_id >= 0);
-}
-#endif
-
-/*****************************************************************************/
-
 using namespace std;
 
 namespace meep {
+
+bool h5file::dataset_exists(const char *name) {
+#if HAVE_HDF5
+  hid_t data_id;
+  SUPPRESS_HDF5_ERRORS(data_id = H5Dopen(HID(get_id()), name));
+  if (data_id >= 0)
+    H5Dclose(data_id);
+  return (data_id >= 0);
+#else
+  return false;
+#endif
+}
 
 // lazy file creation & locking
 void *h5file::get_id() {
@@ -256,7 +255,7 @@ void h5file::read_size(const char *dataname, int *rank, size_t *dims, int maxran
     if (is_cur(dataname))
       data_id = HID(cur_id);
     else {
-      CHECK(dataset_exists(file_id, dataname),
+      CHECK(dataset_exists(dataname),
 	    "missing dataset in HDF5 file");
       data_id = H5Dopen(file_id, dataname);
       set_cur(dataname, &data_id);
@@ -332,7 +331,7 @@ realnum *h5file::read(const char *dataname,
 	close_data_id = false;
       }
       else {
-        if (!dataset_exists(file_id, dataname)) {
+        if (!dataset_exists(dataname)) {
           abort("missing dataset in HDF5 file: %s", dataname);
         }
 	data_id = H5Dopen(file_id, dataname);
@@ -406,7 +405,7 @@ char *h5file::read(const char *dataname)
     if (is_cur(dataname))
       unset_cur();
 
-    CHECK(dataset_exists(file_id, dataname),
+    CHECK(dataset_exists(dataname),
 	  "missing dataset in HDF5 file");
 
     data_id = H5Dopen(file_id, dataname);
@@ -467,7 +466,7 @@ void h5file::remove_data(const char *dataname)
     delete cur;
   }
 
-  if (dataset_exists(file_id, dataname)) {
+  if (dataset_exists(dataname)) {
     /* this is hackish ...need to pester HDF5 developers to make
        H5Gunlink a collective operation for parallel mode */
     if (!parallel || am_master()) {

--- a/src/h5file.cpp
+++ b/src/h5file.cpp
@@ -93,22 +93,22 @@ static int h5io_critical_section_tag = 0;
 
 /*****************************************************************************/
 
+#ifdef HAVE_HDF5
+static bool dataset_exists(hid_t id, const char *name)
+{
+     hid_t data_id;
+     SUPPRESS_HDF5_ERRORS(data_id = H5Dopen(id, name));
+     if (data_id >= 0)
+          H5Dclose(data_id);
+     return (data_id >= 0);
+}
+#endif
+
+/*****************************************************************************/
+
 using namespace std;
 
 namespace meep {
-
-bool h5file::dataset_exists(const char *name) {
-#ifdef HAVE_HDF5
-  hid_t id = HID(get_id());
-  hid_t data_id;
-  SUPPRESS_HDF5_ERRORS(data_id = H5Dopen(id, name));
-  if (data_id >= 0)
-    H5Dclose(data_id);
-  return (data_id >= 0);
-#else
-  return false;
-#endif
-}
 
 // lazy file creation & locking
 void *h5file::get_id() {
@@ -256,7 +256,7 @@ void h5file::read_size(const char *dataname, int *rank, size_t *dims, int maxran
     if (is_cur(dataname))
       data_id = HID(cur_id);
     else {
-      CHECK(dataset_exists(dataname),
+      CHECK(dataset_exists(file_id, dataname),
 	    "missing dataset in HDF5 file");
       data_id = H5Dopen(file_id, dataname);
       set_cur(dataname, &data_id);
@@ -332,7 +332,7 @@ realnum *h5file::read(const char *dataname,
 	close_data_id = false;
       }
       else {
-        if (!dataset_exists(dataname)) {
+        if (!dataset_exists(file_id, dataname)) {
           abort("missing dataset in HDF5 file: %s", dataname);
         }
 	data_id = H5Dopen(file_id, dataname);
@@ -406,7 +406,7 @@ char *h5file::read(const char *dataname)
     if (is_cur(dataname))
       unset_cur();
 
-    CHECK(dataset_exists(dataname),
+    CHECK(dataset_exists(file_id, dataname),
 	  "missing dataset in HDF5 file");
 
     data_id = H5Dopen(file_id, dataname);
@@ -467,7 +467,7 @@ void h5file::remove_data(const char *dataname)
     delete cur;
   }
 
-  if (dataset_exists(dataname)) {
+  if (dataset_exists(file_id, dataname)) {
     /* this is hackish ...need to pester HDF5 developers to make
        H5Gunlink a collective operation for parallel mode */
     if (!parallel || am_master()) {

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -342,8 +342,6 @@ public:
 
   void prevent_deadlock(); // hackery for exclusive mode
 
-  bool dataset_exists(const char *name);
-
 private:
   access_mode mode;
   char *filename;

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -153,8 +153,12 @@ public:
     (void) inotowned; (void) n; (void) c; (void) cmp; (void) P_internal_data;
     return 0; }
 
-  virtual void dump(h5file *h5f, const char *prefix);
-  virtual void load(h5file *h5f, const char *prefix);
+  void dump(h5file *h5f, size_t *start);
+  virtual void dump_params(h5file *h5f, size_t *start) { (void)h5f; (void)start; }
+  virtual void load(h5file *h5f, size_t *start, size_t num_sigmas, size_t *cd_vals);
+  virtual int get_num_params() { return 0; }
+  // This should only be used when dumping and loading susceptibility data to hdf5
+  void set_id(int new_id) { id = new_id; };
 
   susceptibility *next;
   size_t ntot;
@@ -205,8 +209,8 @@ public:
 					  int n,
 					  void *P_internal_data) const;
 
-  virtual void dump(h5file *h5f, const char *prefix);
-  virtual void load(h5file *h5f, const char *prefix);
+  virtual void dump_params(h5file *h5f, size_t *start);
+  virtual int get_num_params() { return 4; }
 
 protected:
   double omega_0, gamma;
@@ -226,8 +230,8 @@ public:
 			double dt, const grid_volume &gv,
 			void *P_internal_data) const;
 
-  virtual void dump(h5file *h5f, const char *prefix);
-  virtual void load(h5file *h5f, const char *prefix);
+  virtual void dump_params(h5file *h5f, size_t *start);
+  virtual int get_num_params() { return 5; }
 
 protected:
   double noise_amp;
@@ -678,6 +682,7 @@ class structure {
 			     const boundary_region &br, const symmetry &s);
   void check_chunks();
   void changing_chunks();
+  void set_chiP_from_file(h5file *file, const char *dataset, field_type ft);
 };
 
 class src_vol;

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -341,7 +341,6 @@ public:
   const char *file_name() const { return filename; }
 
   void prevent_deadlock(); // hackery for exclusive mode
-
 private:
   access_mode mode;
   char *filename;

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -54,6 +54,8 @@ const double nan = NAN;
 const double nan = -7.0415659787563146e103; // ideally, a value never encountered in practice
 #endif
 
+class h5file;
+
 /* generic base class, only used by subclassing: represents susceptibility
    polarizability vector P = chi(omega) W  (where W = E or H). */
 class susceptibility {
@@ -151,6 +153,9 @@ public:
     (void) inotowned; (void) n; (void) c; (void) cmp; (void) P_internal_data;
     return 0; }
 
+  virtual void dump(h5file *h5f, const char *prefix);
+  virtual void load(h5file *h5f, const char *prefix);
+
   susceptibility *next;
   size_t ntot;
   realnum *sigma[NUM_FIELD_COMPONENTS][5];
@@ -199,6 +204,10 @@ public:
   virtual realnum *cinternal_notowned_ptr(int inotowned, component c, int cmp,
 					  int n,
 					  void *P_internal_data) const;
+
+  virtual void dump(h5file *h5f, const char *prefix);
+  virtual void load(h5file *h5f, const char *prefix);
+
 protected:
   double omega_0, gamma;
   bool no_omega_0_denominator;
@@ -216,6 +225,9 @@ public:
 			realnum *W_prev[NUM_FIELD_COMPONENTS][2],
 			double dt, const grid_volume &gv,
 			void *P_internal_data) const;
+
+  virtual void dump(h5file *h5f, const char *prefix);
+  virtual void load(h5file *h5f, const char *prefix);
 
 protected:
   double noise_amp;
@@ -325,6 +337,9 @@ public:
   const char *file_name() const { return filename; }
 
   void prevent_deadlock(); // hackery for exclusive mode
+
+  bool dataset_exists(const char *name);
+
 private:
   access_mode mode;
   char *filename;

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -682,7 +682,18 @@ class structure {
 			     const boundary_region &br, const symmetry &s);
   void check_chunks();
   void changing_chunks();
+  // Helper methods for dumping and loading susceptibilities
   void set_chiP_from_file(h5file *file, const char *dataset, field_type ft);
+  void write_num_susceptibilites(h5file *file, const char *dname, size_t *source);
+  void write_num_sigmas(h5file *file, const char *dname, size_t num_sus, size_t *num_sigmas);
+  void write_component_direction_data(h5file *file, const char* dname, size_t *num_sus, size_t **num_sigmas,
+                                      size_t ***sigma_cd, int EorH);
+  void write_sigma_data(h5file *file, const char *dname, size_t *num_sus, size_t **num_sigmas, int EorH);
+  void write_susceptibility_params(h5file *file, const char *dname, int EorH);
+  size_t read_num_susceptibilities(h5file *file, const char *dname);
+  size_t *read_num_sigmas(h5file *file, const char *dname, size_t num_sus);
+  size_t **read_component_direction_data(h5file *file, const char *dname, size_t num_sus, size_t *num_sigmas);
+  void read_sigma(h5file *file, const char *dname, size_t num_sus, size_t *num_sigmas, size_t **sigma_cd, int EorH);
 };
 
 class src_vol;

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -212,7 +212,7 @@ public:
   virtual void dump_params(h5file *h5f, size_t *start);
   virtual int get_num_params() { return 4; }
 
-protected:
+// protected:
   double omega_0, gamma;
   bool no_omega_0_denominator;
 };
@@ -341,6 +341,8 @@ public:
   const char *file_name() const { return filename; }
 
   void prevent_deadlock(); // hackery for exclusive mode
+  bool dataset_exists(const char *name);
+
 private:
   access_mode mode;
   char *filename;
@@ -668,6 +670,7 @@ class structure {
   double get_eps(const vec &loc) const;
   double get_mu(const vec &loc) const;
   double max_eps() const;
+  void print_disp_materials(const char *filename, int rank);
 
   friend class boundary_region;
 

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -153,9 +153,7 @@ public:
     (void) inotowned; (void) n; (void) c; (void) cmp; (void) P_internal_data;
     return 0; }
 
-  void dump(h5file *h5f, size_t *start);
   virtual void dump_params(h5file *h5f, size_t *start) { (void)h5f; (void)start; }
-  virtual void load(h5file *h5f, size_t *start, size_t num_sigmas, size_t *cd_vals);
   virtual int get_num_params() { return 0; }
   // This should only be used when dumping and loading susceptibility data to hdf5
   void set_id(int new_id) { id = new_id; };
@@ -212,7 +210,7 @@ public:
   virtual void dump_params(h5file *h5f, size_t *start);
   virtual int get_num_params() { return 4; }
 
-// protected:
+protected:
   double omega_0, gamma;
   bool no_omega_0_denominator;
 };
@@ -670,7 +668,6 @@ class structure {
   double get_eps(const vec &loc) const;
   double get_mu(const vec &loc) const;
   double max_eps() const;
-  void print_disp_materials(const char *filename, int rank);
 
   friend class boundary_region;
 
@@ -684,16 +681,7 @@ class structure {
   void changing_chunks();
   // Helper methods for dumping and loading susceptibilities
   void set_chiP_from_file(h5file *file, const char *dataset, field_type ft);
-  void write_num_susceptibilites(h5file *file, const char *dname, size_t *source);
-  void write_num_sigmas(h5file *file, const char *dname, size_t num_sus, size_t *num_sigmas);
-  void write_component_direction_data(h5file *file, const char* dname, size_t *num_sus, size_t **num_sigmas,
-                                      size_t ***sigma_cd, int EorH);
-  void write_sigma_data(h5file *file, const char *dname, size_t *num_sus, size_t **num_sigmas, int EorH);
   void write_susceptibility_params(h5file *file, const char *dname, int EorH);
-  size_t read_num_susceptibilities(h5file *file, const char *dname);
-  size_t *read_num_sigmas(h5file *file, const char *dname, size_t num_sus);
-  size_t **read_component_direction_data(h5file *file, const char *dname, size_t num_sus, size_t *num_sigmas);
-  void read_sigma(h5file *file, const char *dname, size_t num_sus, size_t *num_sigmas, size_t **sigma_cd, int EorH);
 };
 
 class src_vol;

--- a/src/structure_dump.cpp
+++ b/src/structure_dump.cpp
@@ -184,7 +184,13 @@ void structure::dump(const char *filename) {
   }
 
   // Allocate space for component and direction of non-null sigmas
-  size_t *sigma_cd[2] = {NULL, NULL}; 
+  size_t *my_sigma_cd[2] = {NULL, NULL};
+  my_sigma_cd[E_stuff] = new size_t[num_E_sigmas * 2];
+  memset(my_sigma_cd[E_stuff], 0, sizeof(size_t) * num_E_sigmas * 2);
+  my_sigma_cd[H_stuff] = new size_t[num_H_sigmas * 2];
+  memset(my_sigma_cd[H_stuff], 0, sizeof(size_t) * num_H_sigmas * 2);
+
+  size_t *sigma_cd[2] = {NULL, NULL};
   sigma_cd[E_stuff] = new size_t[num_E_sigmas * 2];
   memset(sigma_cd[E_stuff], 0, sizeof(size_t) * num_E_sigmas * 2);
   sigma_cd[H_stuff] = new size_t[num_H_sigmas * 2];
@@ -205,8 +211,8 @@ void structure::dump(const char *filename) {
             for (int c = 0; c < NUM_FIELD_COMPONENTS; ++c) {
               for (int d = 0; d < 5; ++d) {
                 if (sus->sigma[c][d]) {
-                  sigma_cd[E_stuff][j] = c;
-                  sigma_cd[E_stuff][j + 1] = d;
+                  my_sigma_cd[E_stuff][j] = c;
+                  my_sigma_cd[E_stuff][j + 1] = d;
                   j += 2;
                   done = true;
                 }
@@ -216,8 +222,8 @@ void structure::dump(const char *filename) {
         }
       }
     }
-    sum_to_all(sigma_cd[E_stuff], sigma_cd[E_stuff], num_E_sigmas * 2);
-    sum_to_all(sigma_cd[H_stuff], sigma_cd[H_stuff], num_H_sigmas * 2);
+    sum_to_all(my_sigma_cd[E_stuff], sigma_cd[E_stuff], num_E_sigmas * 2);
+    sum_to_all(my_sigma_cd[H_stuff], sigma_cd[H_stuff], num_H_sigmas * 2);
   }
 
   // Write location (component and direction) data of non-null sigmas (sigma[c][d])
@@ -269,6 +275,7 @@ void structure::dump(const char *filename) {
 
   for (int ft = 0; ft < 2; ++ft) {
     delete[] sigma_cd[ft];
+    delete[] my_sigma_cd[ft];
     delete[] num_sigmas[ft];
     delete[] my_num_sigmas[ft];
   }

--- a/src/structure_dump.cpp
+++ b/src/structure_dump.cpp
@@ -489,7 +489,6 @@ void structure::load(const char *filename) {
   file.read_size("num_chi1inv", &rank, dims, 3);
   if (rank != 3 || _dims[0] != dims[0] || _dims[1] != dims[1] || _dims[2] != dims[2])
     abort("chunk mismatch in structure::load");
-
   if (am_master())
     file.read_chunk(3, start, dims, num_chi1inv);
 

--- a/src/structure_dump.cpp
+++ b/src/structure_dump.cpp
@@ -73,22 +73,354 @@ void structure::dump(const char *filename) {
               my_start += ntot;
             }
     }
+  file.prevent_deadlock();
 
-  // dump the susceptibilities
+  // Get sizes of susceptibility lists for chiP[E_stuff] and chiP[H_stuff]
+  size_t my_num_sus[2] = {0, 0};
+  for (int i = 0; i < num_chunks; ++i) {
+    if (chunks[i]->is_mine()) {
+      susceptibility *Esus = chunks[i]->chiP[E_stuff];
+      while (Esus) {
+        my_num_sus[0] += 1;
+        Esus = Esus->next;
+      }
+      susceptibility *Hsus = chunks[i]->chiP[H_stuff];
+      while (Hsus) {
+        my_num_sus[1] += 1;
+        Hsus = Hsus->next;
+      }
+    }
+  }
+
+  // Write susceptibility list sizes
+  size_t E_sus_len = my_num_sus[0] == 0 ? 0 : num_chunks;
+  file.create_data("num_E_sus", 1, &E_sus_len);
+  for (size_t i = 0; i < E_sus_len; i++)
+    if (chunks[i]->is_mine()) {
+      size_t my_start = i;
+      size_t ntot = 1;
+      file.write_chunk(1, &my_start, &ntot, &my_num_sus[0]);
+    }
+
+  size_t H_sus_len = my_num_sus[1] == 0 ? 0 : num_chunks;
+  file.create_data("num_H_sus", 1, &H_sus_len);
+  for (size_t i = 0; i < H_sus_len; i++)
+    if (chunks[i]->is_mine()) {
+      size_t my_start = i;
+      size_t ntot = 1;
+      file.write_chunk(1, &my_start, &ntot, &my_num_sus[1]);
+    }
+  file.prevent_deadlock();
+
+  // Get number of non-null sigma entries for each susceptibility of each chiP
+  size_t *num_sigmas[2];
+  num_sigmas[0] = new size_t[my_num_sus[0]];
+  num_sigmas[1] = new size_t[my_num_sus[1]];
+  memset(num_sigmas[0], 0, sizeof(size_t) * my_num_sus[0]);
+  memset(num_sigmas[1], 0, sizeof(size_t) * my_num_sus[1]);
+
+  for (int i = 0; i < num_chunks; ++i) {
+    if (chunks[i]->is_mine()) {
+      for (int ft = 0; ft < 2; ++ft) {
+        susceptibility *sus = chunks[i]->chiP[ft];
+        size_t n = 0;
+        while (sus) {
+          for (int c = 0; c < NUM_FIELD_COMPONENTS; ++c) {
+            for (int d = 0; d < 5; ++d) {
+              if (sus->sigma[c][d]) {
+                num_sigmas[ft][n] += 1;
+              }
+            }
+          }
+          n++;
+          sus = sus->next;
+        }
+      }
+    }
+  }
+
+  // Write num_sigmas data
+  size_t sus_ntot[2] = {0, 0};
+  sum_to_all(my_num_sus, sus_ntot, 2);
+  size_t my_E_sigma_start = partial_sum_to_all(my_num_sus[0]) - my_num_sus[0];
+  size_t my_H_sigma_start = partial_sum_to_all(my_num_sus[1]) - my_num_sus[1];
+
+  file.create_data("num_E_sigmas", 1, &sus_ntot[0]);
+  for (int i = 0; i < num_chunks; ++i) {
+    if (chunks[i]->is_mine()) {
+      file.write_chunk(1, &my_E_sigma_start, &my_num_sus[0], num_sigmas[0]);
+    }
+  }
+
+  file.create_data("num_H_sigmas", 1, &sus_ntot[1]);
+  for (int i = 0; i < num_chunks; ++i) {
+    if (chunks[i]->is_mine()) {
+      file.write_chunk(1, &my_H_sigma_start, &my_num_sus[1], num_sigmas[1]);
+    }
+  }
+  file.prevent_deadlock();
+
+  // Get component and direction of non-null sigmas
+  size_t **sigma_cd[2] = {NULL, NULL};
+  sigma_cd[0] = new size_t*[my_num_sus[0]];
+  sigma_cd[1] = new size_t*[my_num_sus[1]];
+
+  for (int ft = 0; ft < 2; ++ft) {
+    for (size_t i = 0; i < my_num_sus[ft]; ++i) {
+      sigma_cd[ft][i] = new size_t[num_sigmas[ft][i] * 2];
+      memset(sigma_cd[ft][i], 0, sizeof(size_t) * num_sigmas[ft][i] * 2);
+    }
+  }
+
+  for (int i = 0; i < num_chunks; ++i) {
+    if (chunks[i]->is_mine()) {
+      for (int ft = 0; ft < 2; ++ft) {
+        susceptibility *sus = chunks[i]->chiP[ft];
+        size_t n = 0;
+        while (sus) {
+          int j = 0;
+          for (int c = 0; c < NUM_FIELD_COMPONENTS; ++c) {
+            for (int d = 0; d < 5; ++d) {
+              if (sus->sigma[c][d]) {
+                sigma_cd[ft][n][j] = c;
+                sigma_cd[ft][n][j + 1] = d;
+                j += 2;
+              }
+            }
+          }
+          sus = sus->next;
+          n++;
+        }
+      }
+    }
+  }
+
+  size_t my_sigma_cd_E_ntot = 0;
+  for (size_t i = 0; i < my_num_sus[E_stuff]; ++i) {
+    my_sigma_cd_E_ntot += num_sigmas[E_stuff][i] * 2;
+  }
+
+  size_t my_sigma_cd_H_ntot = 0;
+  for (size_t i = 0; i < my_num_sus[H_stuff]; ++i) {
+    my_sigma_cd_H_ntot += num_sigmas[H_stuff][i] * 2;
+  }
+
+  size_t sigma_cd_E_ntot = sum_to_all(my_sigma_cd_E_ntot);
+  size_t sigma_cd_H_ntot = sum_to_all(my_sigma_cd_H_ntot);
+
+  size_t my_sigma_cd_E_start = partial_sum_to_all(my_sigma_cd_E_ntot) - my_sigma_cd_E_ntot;
+  size_t my_sigma_cd_H_start = partial_sum_to_all(my_sigma_cd_H_ntot) - my_sigma_cd_H_ntot;
+
+  // Write location (component and direction) of each non-null sigma
+  file.create_data("sigma_cd_E", 1, &sigma_cd_E_ntot);
+  for (int i = 0; i < num_chunks; ++i) {
+    if (chunks[i]->is_mine() && chunks[i]->chiP[E_stuff]) {
+      for (size_t j = 0; j < my_num_sus[E_stuff]; ++j) {
+        size_t cd_count = num_sigmas[E_stuff][j] * 2;
+        file.write_chunk(1, &my_sigma_cd_E_start, &cd_count, sigma_cd[E_stuff][j]);
+        my_sigma_cd_E_start += cd_count;
+      }
+    }
+  }
+
+  file.create_data("sigma_cd_H", 1, &sigma_cd_H_ntot);
+  for (int i = 0; i < num_chunks; ++i) {
+    if (chunks[i]->is_mine() && chunks[i]->chiP[H_stuff]) {
+      for (size_t j = 0; j < my_num_sus[H_stuff]; ++j) {
+        size_t cd_count = num_sigmas[H_stuff][j];
+        file.write_chunk(1, &my_sigma_cd_H_start, &cd_count, sigma_cd[H_stuff][j]);
+        my_sigma_cd_H_start += cd_count;
+      }
+    }
+  }
+  file.prevent_deadlock();
+
+  size_t my_tot_E_sus_points = 0;
+  for (int i = 0; i < num_chunks; ++i) {
+    if (chunks[i]->is_mine() && chunks[i]->chiP[E_stuff]) {
+      for (size_t j = 0; j < my_num_sus[E_stuff]; ++j) {
+        my_tot_E_sus_points += num_sigmas[E_stuff][j] * chunks[i]->chiP[0]->ntot;
+      }
+    }
+  }
+  size_t my_tot_H_sus_points = 0;
+  for (int i = 0; i < num_chunks; ++i) {
+    if (chunks[i]->is_mine() && chunks[i]->chiP[H_stuff]) {
+      for (size_t j = 0; j < my_num_sus[H_stuff]; ++j) {
+        my_tot_H_sus_points += num_sigmas[H_stuff][j] * chunks[i]->chiP[0]->ntot;
+      }
+    }
+  }
+
+  size_t my_E_sus_start = partial_sum_to_all(my_tot_E_sus_points) - my_tot_E_sus_points;
+  size_t my_H_sus_start = partial_sum_to_all(my_tot_H_sus_points) - my_tot_H_sus_points;
+  size_t E_sus_ntotal = sum_to_all(my_tot_E_sus_points);
+  size_t H_sus_ntotal = sum_to_all(my_tot_H_sus_points);
+
+  // Write sigma data
+  file.create_data("E_sigma", 1, &E_sus_ntotal);
+  for (int i = 0; i < num_chunks; ++i) {
+    if (chunks[i]->is_mine() && chunks[i]->chiP[E_stuff]) {
+      susceptibility *sus = chunks[i]->chiP[E_stuff];
+      while (sus) {
+        sus->dump(&file, &my_E_sus_start);
+        sus = sus->next;
+      }
+    }
+  }
+
+  file.create_data("H_sigma", 1, &H_sus_ntotal);
+  for (int i = 0; i < num_chunks; ++i) {
+    if (chunks[i]->is_mine() && chunks[i]->chiP[H_stuff]) {
+      susceptibility *sus = chunks[i]->chiP[H_stuff];
+      while (sus) {
+        sus->dump(&file, &my_H_sus_start);
+        sus = sus->next;
+      }
+    }
+  }
+
+  for (int ft = 0; ft < 2; ++ft) {
+    for (size_t i = 0; i < my_num_sus[ft]; ++i) {
+      delete[] sigma_cd[ft][i];
+    }
+    delete[] sigma_cd[ft];
+    delete[] num_sigmas[ft];
+  }
+
+  // Get number of susceptibility params
+  size_t E_params_ntotal = 0;
+  size_t H_params_ntotal = 0;
   for (int i = 0; i < num_chunks; ++i) {
     if (chunks[i]->is_mine()) {
       for (int ft = 0; ft < NUM_FIELD_TYPES; ++ft) {
         if (chunks[i]->chiP[ft]) {
-          susceptibility *susc = chunks[i]->chiP[ft];
-          int n = 0;
-          while (susc) {
-            char prefix[12];
-            snprintf(prefix, 12, "%d_%d_%d_", i, ft, n);
-            susc->dump(&file, prefix);
-            susc = susc->next;
-            n++;
+          susceptibility *sus = chunks[i]->chiP[ft];
+          while (sus) {
+            if (ft == 0)
+              E_params_ntotal += sus->get_num_params() + 1;
+            else if (ft == 1)
+              H_params_ntotal += sus->get_num_params() + 1;
+            sus = sus->next;
           }
         }
+      }
+    }
+  }
+
+  // Write params for E_stuff susceptibilities
+  size_t params_start = 0;
+  file.create_data("E_params", 1, &E_params_ntotal);
+  if (am_master()) {
+    for (int i = 0; i < num_chunks; ++i) {
+      if (chunks[i]->chiP[E_stuff] && chunks[i]->is_mine()) {
+        susceptibility *sus = chunks[i]->chiP[E_stuff];
+        while (sus) {
+          sus->dump_params(&file, &params_start);
+          sus = sus->next;
+        }
+      }
+    }
+  }
+
+  // Write params for H_stuff susceptibilities
+  params_start = 0;
+  file.create_data("H_params", 1, &H_params_ntotal);
+  if (am_master()) {
+    for (int i = 0; i < num_chunks; ++i) {
+      if (chunks[i]->chiP[H_stuff] && chunks[i]->is_mine()) {
+        susceptibility *sus = chunks[i]->chiP[H_stuff];
+        while (sus) {
+          sus->dump_params(&file, &params_start);
+          sus = sus->next;
+        }
+      }
+    }
+  }
+}
+
+susceptibility *make_sus_list_from_params(h5file *file, int rank, size_t *start, size_t dims[3], size_t ntot) {
+  susceptibility *sus = NULL;
+  susceptibility *res = NULL;
+  while (*start < dims[0] - 1) {
+    size_t num_params_dims[3] = {1, 0, 0};
+    realnum num_params;
+    file->read_chunk(rank, start, num_params_dims, &num_params);
+    *start += num_params_dims[0];
+
+    if (num_params == 4) {
+      // This is a lorentzian_susceptibility and the next 4 values in the dataset
+      // are id, omega_0, gamma, and no_omega_0_denominator.
+      size_t lorentzian_dims[3] = {4, 0, 0};
+      realnum lorentzian_params[4];
+      file->read_chunk(rank, start, lorentzian_dims, lorentzian_params);
+      *start += lorentzian_dims[0];
+
+      int id = (int)lorentzian_params[0];
+      double omega_0 = lorentzian_params[1];
+      double gamma = lorentzian_params[2];
+      bool no_omega_0_denominator = (bool)lorentzian_params[3];
+      if (sus) {
+        sus->next = new lorentzian_susceptibility(omega_0, gamma, no_omega_0_denominator);
+        sus->next->ntot = ntot;
+        sus->next->set_id(id);
+      }
+      else {
+        sus = new lorentzian_susceptibility(omega_0, gamma, no_omega_0_denominator);
+        sus->ntot = ntot;
+        sus->set_id(id);
+        res = sus;
+      }
+      if (sus->next)
+        sus = sus->next;
+    }
+    else if (num_params == 5) {
+      // This is a noisy_lorentzian_susceptibility and the next 5 values in the dataset
+      // are id, noise_amp, omega_0, gamma, and no_omega_0_denominator.
+      size_t noisy_lorentzian_dims[3] = {5, 0, 0};
+      realnum noisy_lorentzian_params[5];
+      file->read_chunk(rank, start, noisy_lorentzian_dims, noisy_lorentzian_params);
+      *start += noisy_lorentzian_dims[0];
+
+      int id = (int)noisy_lorentzian_params[0];
+      double noise_amp = noisy_lorentzian_params[1];
+      double omega_0 = noisy_lorentzian_params[2];
+      double gamma = noisy_lorentzian_params[3];
+      bool no_omega_0_denominator = (bool)noisy_lorentzian_params[4];
+      if (sus) {
+        sus->next = new noisy_lorentzian_susceptibility(noise_amp, omega_0, gamma, no_omega_0_denominator);
+        sus->next->ntot = ntot;
+        sus->next->set_id(id);
+      }
+      else {
+        sus = new noisy_lorentzian_susceptibility(noise_amp, omega_0, gamma, no_omega_0_denominator);
+        sus->ntot = ntot;
+        sus->set_id(id);
+        res = sus;
+      }
+      if (sus->next)
+        sus = sus->next;
+    }
+    else {
+      abort("Invalid number of susceptibility parameters in structure::load");
+    }
+  }
+  return res;
+}
+
+void structure::set_chiP_from_file(h5file *file, const char *dataset, field_type ft) {
+  int rank = 0;
+  size_t dims[3] = {0, 0, 0};
+  size_t start = 0;
+
+  file->read_size(dataset, &rank, dims, 1);
+  if (rank != 1)
+    abort("inconsistent data size in structure::load");
+
+  if (dims[0] != 0) {
+    for (int i = 0; i < num_chunks; ++i) {
+      if (chunks[i]->is_mine()) {
+        chunks[i]->chiP[ft] = make_sus_list_from_params(file, rank, &start, dims, chunks[i]->gv.ntot());
       }
     }
   }
@@ -155,78 +487,202 @@ void structure::load(const char *filename) {
             }
     }
 
-  // load the susceptibilities
-  for (int i = 0; i < num_chunks; ++i) {
-    if (chunks[i]->is_mine()) {
-      for (int ft = 0; ft < NUM_FIELD_TYPES; ++ft) {
-        int n = 0;
-        char params_dset[25];
-        snprintf(params_dset, 25, "%d_%d_%d_", i, ft, 0);
-        strcat(params_dset, "params");
-        susceptibility *susc_ptr;
+  // Create susceptibilites from params datasets
+  set_chiP_from_file(&file, "E_params", E_stuff);
+  set_chiP_from_file(&file, "H_params", H_stuff);
 
-        while (file.dataset_exists(params_dset)) {
-          int params_rank;
-          size_t params_start[1] = {0};
-          size_t params_dims[1] = {0};
-          file.read_size(params_dset, &params_rank, params_dims, 1);
+  // Get number of H and E susceptibilites on this processor
+  size_t my_num_E_sus = 0;
+  int num_E_sus_rank = 0;
+  size_t num_E_sus_dims[] = {0, 0, 0};
+  file.read_size("num_E_sus", &num_E_sus_rank, num_E_sus_dims, 1);
+  if (num_E_sus_dims[0] > 0) {
+    for (int i = 0; i < num_chunks; ++i) {
+      if (chunks[i]->is_mine()) {
+        size_t start = i;
+        size_t count = 1;
+        file.read_chunk(num_E_sus_rank, &start, &count, &my_num_E_sus);
+      }
+    }
+  }
+  size_t my_num_H_sus = 0;
+  int num_H_sus_rank = 0;
+  size_t num_H_sus_dims[] = {0, 0, 0};
+  file.read_size("num_H_sus", &num_H_sus_rank, num_H_sus_dims, 1);
+  if (num_H_sus_dims[0] > 0) {
+    for (int i = 0; i < num_chunks; ++i) {
+      if (chunks[i]->is_mine()) {
+        size_t start = i;
+        size_t count = 1;
+        file.read_chunk(num_H_sus_rank, &start, &count, &my_num_H_sus);
+      }
+    }
+  }
+  file.prevent_deadlock();
 
-          if (params_rank != 1 || params_dims[0] > 4 || params_dims[0] < 3)
-            abort("inconsistent data size in structure::load");
+  // Get non-null sigma entry data
+  size_t *num_E_sigmas = new size_t[my_num_E_sus];
+  size_t my_E_sigma_start = partial_sum_to_all(my_num_E_sus) - my_num_E_sus;
 
-          if (params_dims[0] == 3) {
-            realnum params[3] = {0};
+  int num_E_sigma_rank = 0;
+  size_t num_E_sigma_dims[] = {0, 0, 0};
+  file.read_size("num_E_sigmas", &num_E_sigma_rank, num_E_sigma_dims, 1);
+  if (num_E_sigma_dims[0] != num_chunks * my_num_E_sus)
+    abort("inconsistent data size in structure::load");
 
-            if (am_master())
-              file.read_chunk(1, params_start, params_dims, params);
-            file.prevent_deadlock();
-            broadcast(0, params, 3);
+  if (my_num_E_sus > 0) {
+    for (int i = 0; i < num_chunks; ++i) {
+      if (chunks[i]->is_mine()) {
+        file.read_chunk(num_E_sigma_rank, &my_E_sigma_start, &my_num_E_sus, num_E_sigmas);
+      }
+    }
+  }
 
-            if (n == 0) {
-              chunks[i]->chiP[ft] = new lorentzian_susceptibility(params[0], params[1], (bool)params[2]);
-              susc_ptr = chunks[i]->chiP[ft];
-            }
-            else
-              susc_ptr->next = new lorentzian_susceptibility(params[0], params[1], (bool)params[2]);
-          }
-          else {
-            realnum params[4] = {0};
+  file.prevent_deadlock();
 
-            if (am_master())
-              file.read_chunk(1, params_start, params_dims, params);
-            file.prevent_deadlock();
-            broadcast(0, params, 4);
+  size_t *num_H_sigmas = new size_t[my_num_H_sus];
+  size_t my_H_sigma_start = partial_sum_to_all(my_num_H_sus) - my_num_H_sus;
 
-            if (n == 0) {
-              chunks[i]->chiP[ft] = new noisy_lorentzian_susceptibility(params[0], params[1], params[2],
-                                                                   (bool)params[3]);
-              susc_ptr = chunks[i]->chiP[ft];
-            }
-            else
-              susc_ptr->next = new noisy_lorentzian_susceptibility(params[0], params[1], params[2],
-                                                                   (bool)params[3]);
-          }
+  int num_H_sigma_rank = 0;
+  size_t num_H_sigma_dims[] = {0, 0, 0};
+  file.read_size("num_H_sigmas", &num_H_sigma_rank, num_H_sigma_dims, 1);
+  if (num_H_sigma_dims[0] != num_chunks * my_num_H_sus)
+    abort("inconsistent data size in structure::load");
 
-          size_t ntot = chunks[i]->gv.ntot();
-          if (n == 0)
-            susc_ptr->ntot = ntot;
-          else
-            susc_ptr->next->ntot = ntot;
-          char prefix[12];
-          snprintf(prefix, 12, "%d_%d_%d_", i, ft, n);
-          if (n == 0)
-            susc_ptr->load(&file, prefix);
-          else
-            susc_ptr->next->load(&file, prefix);
+  if (my_num_H_sus > 0) {
+    for (int i = 0; i < num_chunks; ++i) {
+      if (chunks[i]->is_mine()) {
+        file.read_chunk(num_H_sigma_rank, &my_H_sigma_start, &my_num_H_sus, num_H_sigmas);
+      }
+    }
+  }
+  file.prevent_deadlock();
 
-          if (n != 0)
-            susc_ptr = susc_ptr->next;
-          n++;
-          snprintf(params_dset, 25, "%d_%d_%d_", i, ft, n);
-          strcat(params_dset, "params");
+  // Get component and direction data of the non-null susceptibilities
+  size_t **sigma_cd_E = new size_t*[my_num_E_sus];
+  for (size_t i = 0; i < my_num_E_sus; ++i) {
+    sigma_cd_E[i] = new size_t[num_E_sigmas[i] * 2];
+  }
+
+  size_t my_num_E_cd_pairs = 0;
+  for (size_t i = 0; i < my_num_E_sus; ++i) {
+    my_num_E_cd_pairs += num_E_sigmas[i];
+  }
+
+  size_t my_sigma_cd_E_start = partial_sum_to_all(my_num_E_cd_pairs * 2) - my_num_E_cd_pairs * 2;
+
+  int sigma_cd_E_rank = 0;
+  size_t sigma_cd_E_dims[] = {0, 0, 0};
+  file.read_size("sigma_cd_E", &sigma_cd_E_rank, sigma_cd_E_dims, 1);
+
+  if (my_num_E_sus > 0) {
+    for (int i = 0; i < num_chunks; ++i) {
+      if (chunks[i]->is_mine()) {
+        for (size_t j = 0; j < my_num_E_sus; ++j) {
+          size_t count = num_E_sigmas[j] * 2;
+          file.read_chunk(sigma_cd_E_rank, &my_sigma_cd_E_start, &count, sigma_cd_E[j]);
+          my_sigma_cd_E_start += count;
         }
       }
     }
   }
+  file.prevent_deadlock();
+
+  size_t **sigma_cd_H = new size_t*[my_num_H_sus];
+  for (size_t i = 0; i < my_num_H_sus; ++i) {
+    sigma_cd_H[i] = new size_t[num_H_sigmas[i] * 2];
+  }
+
+  size_t my_num_H_cd_pairs = 0;
+  for (size_t i = 0; i < my_num_H_sus; ++i) {
+    my_num_H_cd_pairs += num_H_sigmas[i];
+  }
+
+  size_t my_sigma_cd_H_start = partial_sum_to_all(my_num_H_cd_pairs * 2) - my_num_H_cd_pairs * 2;
+
+  int sigma_cd_H_rank = 0;
+  size_t sigma_cd_H_dims[] = {0, 0, 0};
+  file.read_size("sigma_cd_H", &sigma_cd_H_rank, sigma_cd_H_dims, 1);
+
+  if (my_num_H_sus > 0) {
+    for (int i = 0; i < num_chunks; ++i) {
+      if (chunks[i]->is_mine()) {
+        for (size_t j = 0; j < my_num_H_sus; ++j) {
+          size_t count = num_H_sigmas[j] * 2;
+          file.read_chunk(sigma_cd_H_rank, &my_sigma_cd_H_start, &count, sigma_cd_H[j]);
+          my_sigma_cd_H_start += count;
+        }
+      }
+    }
+  }
+  file.prevent_deadlock();
+
+  // Get total sigma size on this processor
+  size_t my_E_sigma_ntot = 0;
+  for (int i = 0; i < num_chunks; ++i) {
+    if (chunks[i]->is_mine() && chunks[i]->chiP[E_stuff]) {
+      for (size_t j = 0; j < my_num_E_sus; ++j) {
+        my_E_sigma_ntot += num_E_sigmas[j] * chunks[i]->chiP[E_stuff]->ntot;
+      }
+    }
+  }
+
+  size_t my_H_sigma_ntot = 0;
+  for (int i = 0; i < num_chunks; ++i) {
+    if (chunks[i]->is_mine() && chunks[i]->chiP[H_stuff]) {
+      for (size_t j = 0; j < my_num_H_sus; ++j) {
+        my_H_sigma_ntot += num_H_sigmas[j] * chunks[i]->chiP[H_stuff]->ntot;
+      }
+    }
+  }
+
+  size_t E_sigma_start = partial_sum_to_all(my_E_sigma_ntot) - my_E_sigma_ntot;
+  size_t H_sigma_start = partial_sum_to_all(my_H_sigma_ntot) - my_H_sigma_ntot;
+
+  // Load sigma data into susceptibilites
+  int E_sigma_rank = 0;
+  size_t E_sigma_dims[3] = {0, 0, 0};
+  file.read_size("E_sigma", &E_sigma_rank, E_sigma_dims, 1);
+  if (E_sigma_dims[0] > 0) {
+    for (int i = 0; i < num_chunks; ++i) {
+      if (chunks[i]->is_mine()) {
+        susceptibility *sus = chunks[i]->chiP[E_stuff];
+        size_t n = 0;
+        while (sus) {
+          sus->load(&file, &E_sigma_start, num_E_sigmas[n], sigma_cd_E[n]);
+          sus = sus->next;
+          n++;
+        }
+      }
+    }
+  }
+
+  int H_sigma_rank = 0;
+  size_t H_sigma_dims[3] = {0, 0, 0};
+  file.read_size("H_sigma", &H_sigma_rank, H_sigma_dims, 1);
+  if (H_sigma_dims[0] > 0) {
+    for (int i = 0; i < num_chunks; ++i) {
+      if (chunks[i]->is_mine()) {
+        susceptibility *sus = chunks[i]->chiP[H_stuff];
+        size_t n = 0;
+        while (sus) {
+          sus->load(&file, &H_sigma_start, num_H_sigmas[n], sigma_cd_H[n]);
+          sus = sus->next;
+          n++;
+        }
+      }
+    }
+  }
+
+  delete[] num_E_sigmas;
+  delete[] num_H_sigmas;
+  for (size_t i = 0; i < my_num_E_sus; ++i) {
+    delete[] sigma_cd_E[i];
+  }
+  delete[] sigma_cd_E;
+  for (size_t i = 0; i < my_num_H_sus; ++i) {
+    delete[] sigma_cd_H[i];
+  }
+  delete[] sigma_cd_H;
 }
-}
+} // namespace meep

--- a/src/structure_dump.cpp
+++ b/src/structure_dump.cpp
@@ -96,7 +96,6 @@ void structure::dump(const char *filename) {
               my_start += ntot;
             }
     }
-  file.prevent_deadlock();
 
   // Get the sizes of susceptibility lists for chiP[E_stuff] and chiP[H_stuff]
   // Since this info is copied to each chunk, we can just get it from the first chunk
@@ -122,7 +121,6 @@ void structure::dump(const char *filename) {
       file.write_chunk(1, &start, &ntot, num_sus);
     }
   }
-  file.prevent_deadlock();
 
   // Get number of non-null sigma entries for each chiP in each chunk.
   // Assumes each susceptibility in the chiP[E_stuff] list has the
@@ -167,9 +165,9 @@ void structure::dump(const char *filename) {
         }
       }
     }
-    file.prevent_deadlock();
   }
 
+  file.prevent_deadlock();
   for (int ft = 0; ft < 2; ++ft) {
     sum_to_all(my_num_sigmas[ft], num_sigmas[ft], num_chunks);
   }
@@ -234,7 +232,6 @@ void structure::dump(const char *filename) {
         start += count;
       }
     }
-    file.prevent_deadlock();
   }
 
   // Write the actual data in a particular non-null sigma[c][d] for each susceptibility in this

--- a/src/structure_dump.cpp
+++ b/src/structure_dump.cpp
@@ -54,49 +54,6 @@ void structure::write_susceptibility_params(h5file *file, const char *dname, int
   }
 }
 
-// TODO: temp
-void structure::print_disp_materials(const char *filename, int rank) {
-  if (my_rank() == rank) {
-    char fname[15];
-    snprintf(fname, 15, "%s_%d.txt", filename, rank);
-    FILE *f = fopen(fname, "w");
-    for (int ft = 0; ft < 2; ++ft) {
-      for (int i = 0; i < num_chunks; ++i) {
-        fprintf(f, "chunk: %d\n", i);
-        lorentzian_susceptibility *sus = (lorentzian_susceptibility*)chunks[i]->chiP[ft];
-        int n = 0;
-        while (sus) {
-          fprintf(f, " sus: %d\n", n);
-          fprintf(f, " omega: %e\n", sus->omega_0);
-          fprintf(f, " gamma: %e\n", sus->gamma);
-          fprintf(f, " drude: %s\n", sus->no_omega_0_denominator ? "true" : "false");
-          fprintf(f, " ntot: %zu\n", sus->ntot);
-          fprintf(f, " id: %d\n", sus->get_id());
-          for (int c = 0; c < NUM_FIELD_COMPONENTS; ++c) {
-            for (int d = 0; d < 5; ++d) {
-              if (!sus->trivial_sigma[c][d]) {
-                fprintf(f, " non-trivial sigma: [%d][%d]\n", c, d);
-              }
-              if (sus->sigma[c][d]) {
-                fprintf(f, " sigma[%d][%d], ntot: %zu", c, d, sus->ntot);
-                for (size_t j = 0; j < sus->ntot; ++j) {
-                  if (j % 10 == 0) fprintf(f, "\n   ");
-                  fprintf(f, "%g, ", sus->sigma[c][d][j]);
-                }
-                fprintf(f, "\n\n");
-              }
-            }
-          }
-          fprintf(f, "\n");
-          sus = (lorentzian_susceptibility*)sus->next;
-          n++;
-        }
-      }
-    }
-    fclose(f);
-  }
-}
-
 void structure::dump(const char *filename) {
   // make/save a num_chunks x NUM_FIELD_COMPONENTS x 5 array counting
   // the number of entries in the chi1inv array for each chunk.
@@ -146,12 +103,12 @@ void structure::dump(const char *filename) {
   size_t num_sus[2] = {0, 0};
   susceptibility *Esus = chunks[0]->chiP[E_stuff];
   while (Esus) {
-    num_sus[0] += 1;
+    num_sus[E_stuff] += 1;
     Esus = Esus->next;
   }
   susceptibility *Hsus = chunks[0]->chiP[H_stuff];
   while (Hsus) {
-    num_sus[1] += 1;
+    num_sus[H_stuff] += 1;
     Hsus = Hsus->next;
   }
 

--- a/src/susceptibility.cpp
+++ b/src/susceptibility.cpp
@@ -100,7 +100,7 @@ void susceptibility::dump(h5file *h5f, size_t *start) {
 }
 
 void susceptibility::load(h5file *h5f, size_t *start, size_t num_sigmas, size_t *cd_vals) {
-  for (int i = 0; i < num_sigmas; ++i) {
+  for (size_t i = 0; i < num_sigmas; ++i) {
     size_t c = cd_vals[i * 2];
     size_t d = cd_vals[(i * 2) + 1];
     sigma[c][d] = new realnum[ntot];

--- a/src/susceptibility.cpp
+++ b/src/susceptibility.cpp
@@ -90,6 +90,109 @@ bool susceptibility::needs_W_notowned(component c,
   return false;
 }
 
+void susceptibility::dump(h5file *h5f, const char *prefix) {
+  size_t sz = NUM_FIELD_COMPONENTS * 5;
+  size_t *num_sigma_ = new size_t[sz];
+  memset(num_sigma_, 0, sizeof(size_t) * sz);
+  size_t my_ntot = 0;
+
+  for (int c = 0; c < NUM_FIELD_COMPONENTS; ++c)
+    for (int d = 0; d < 5; ++d)
+      if (sigma[c][d])
+        my_ntot += (num_sigma_[c * 5 + d] = ntot);
+
+  size_t *num_sigma = new size_t[sz];
+  sum_to_master(num_sigma_, num_sigma, sz);
+  delete[] num_sigma_;
+
+  // determine total dataset size and offset of this process's data
+  size_t my_start = partial_sum_to_all(my_ntot) - my_ntot;
+  size_t ntotal = sum_to_all(my_ntot);
+
+  size_t dims[3] = {1, NUM_FIELD_COMPONENTS, 5};
+  char num_sigma_dset[25];
+  strcpy(num_sigma_dset, prefix);
+  strcat(num_sigma_dset, "num_sigma");
+  h5f->create_data(num_sigma_dset, 3, dims);
+  if (am_master()) {
+    size_t start[3] = {0, 0, 0};
+    h5f->write_chunk(3, start, dims, num_sigma);
+  }
+  delete[] num_sigma;
+
+  // write sigma data
+  char sigma_dset[25];
+  strcpy(sigma_dset, prefix);
+  strcat(sigma_dset, "sigma");
+  h5f->create_data(sigma_dset, 1, &ntotal);
+  for (int c = 0; c < NUM_FIELD_COMPONENTS; ++c)
+    for (int d = 0; d < 5; ++d)
+      if (sigma[c][d]) {
+        h5f->write_chunk(1, &my_start, &ntot, sigma[c][d]);
+        my_start += ntot;
+      }
+
+}
+
+void susceptibility::load(h5file *h5f, const char *prefix) {
+  size_t sz = NUM_FIELD_COMPONENTS * 5;
+  size_t *num_sigma = new size_t[sz];
+  int rank;
+  size_t dims[3], _dims[3] = {1, NUM_FIELD_COMPONENTS, 5};
+
+  char num_sigma_dset[25];
+  strcpy(num_sigma_dset, prefix);
+  strcat(num_sigma_dset, "num_sigma");
+  h5f->read_size(num_sigma_dset, &rank, dims, 3);
+  if (rank != 3 || _dims[0] != dims[0] || _dims[1] != dims[1] || _dims[2] != dims[2])
+    abort("chunk mismatch in susceptibility::load");
+  if (am_master()) {
+    size_t sigma_start[3] = {0, 0, 0};
+    h5f->read_chunk(3, sigma_start, dims, num_sigma);
+  }
+
+  h5f->prevent_deadlock();
+  broadcast(0, num_sigma, dims[0] * dims[1] * dims[2]);
+
+  // allocate data as needed and check sizes
+  size_t my_ntot = 0;
+  for (int c = 0; c < NUM_FIELD_COMPONENTS; ++c)
+    for (int d = 0; d < 5; ++d) {
+      size_t n = num_sigma[c * 5 + d];
+      if (n == 0) {
+        delete[] sigma[c][d];
+        sigma[c][d] = NULL;
+      }
+      else {
+        if (n != ntot)
+          abort("grid size mismatch %zd vs %zd in susceptibility::load", n, ntot);
+        sigma[c][d] = new realnum[ntot];
+        my_ntot += ntot;
+      }
+    }
+
+  // determine total dataset size and offset of this process's data
+  size_t my_start = partial_sum_to_all(my_ntot) - my_ntot;
+  size_t ntotal = sum_to_all(my_ntot);
+
+  // read the data
+  char sigma_dset[25];
+  strcpy(sigma_dset, prefix);
+  strcat(sigma_dset, "sigma");
+  h5f->read_size(sigma_dset, &rank, dims, 1);
+
+  if (rank != 1 || dims[0] != ntotal)
+    abort("inconsistent data size in susceptibility::load");
+
+  for (int c = 0; c < NUM_FIELD_COMPONENTS; ++c)
+    for (int d = 0; d < 5; ++d)
+      if (sigma[c][d]) {
+        h5f->read_chunk(1, &my_start, &ntot, sigma[c][d]);
+        trivial_sigma[c][d] = false;
+        my_start += ntot;
+      }
+}
+
 typedef struct {
   size_t sz_data;
   size_t ntot;
@@ -274,6 +377,29 @@ realnum *lorentzian_susceptibility::cinternal_notowned_ptr(
   return d->P[c][cmp] + n;
 }
 
+void lorentzian_susceptibility::dump(h5file *h5f, const char *prefix) {
+  susceptibility::dump(h5f, prefix);
+
+  // write params data
+  char params_dset[25];
+  strcpy(params_dset, prefix);
+  strcat(params_dset, "params");
+  size_t params_dims[1] = {3};
+  h5f->create_data(params_dset, 1, params_dims);
+  double params_data[3] = {omega_0, gamma, (double)no_omega_0_denominator};
+  size_t params_start[1] = {0};
+  h5f->write_chunk(1, params_start, params_dims, params_data);
+}
+
+void lorentzian_susceptibility::load(h5file *h5f, const char *prefix) {
+  susceptibility::load(h5f, prefix);
+
+  // TODO: load params
+  char params_dset[25];
+  strcpy(params_dset, prefix);
+  strcat(params_dset, "params");
+
+}
 
 void noisy_lorentzian_susceptibility::update_P
        (realnum *W[NUM_FIELD_COMPONENTS][2],
@@ -299,4 +425,24 @@ void noisy_lorentzian_susceptibility::update_P
   }
 }
 
+void noisy_lorentzian_susceptibility::dump(h5file *h5f, const char *prefix) {
+  susceptibility::dump(h5f, prefix);
+
+  // write params data
+  char params_dset[25];
+  strcpy(params_dset, prefix);
+  strcat(params_dset, "params");
+  size_t params_dims[1] = {4};
+  h5f->create_data(params_dset, 1, params_dims);
+  double params_data[4] = {noise_amp, omega_0, gamma, (double)no_omega_0_denominator};
+  size_t params_start[1] = {0};
+  h5f->write_chunk(1, params_start, params_dims, params_data);
+}
+
+void noisy_lorentzian_susceptibility::load(h5file *h5f, const char *prefix) {
+  susceptibility::load(h5f, prefix);
+
+  // load params
+  // TODO
+}
 } // namespace meep

--- a/src/susceptibility.cpp
+++ b/src/susceptibility.cpp
@@ -104,7 +104,6 @@ void susceptibility::load(h5file *h5f, size_t *start, size_t num_sigmas, size_t 
     size_t c = cd_vals[i * 2];
     size_t d = cd_vals[(i * 2) + 1];
     sigma[c][d] = new realnum[ntot];
-    // TODO: Is this right?
     trivial_sigma[c][d] = false;
 
     // Populate sigma[c][d]

--- a/src/susceptibility.cpp
+++ b/src/susceptibility.cpp
@@ -90,28 +90,6 @@ bool susceptibility::needs_W_notowned(component c,
   return false;
 }
 
-void susceptibility::dump(h5file *h5f, size_t *start) {
-  for (int c = 0; c < NUM_FIELD_COMPONENTS; ++c)
-    for (int d = 0; d < 5; ++d)
-      if (sigma[c][d]) {
-        h5f->write_chunk(1, start, &ntot, sigma[c][d]);
-        *start += ntot;
-      }
-}
-
-void susceptibility::load(h5file *h5f, size_t *start, size_t num_sigmas, size_t *cd_vals) {
-  for (size_t i = 0; i < num_sigmas; ++i) {
-    size_t c = cd_vals[i * 2];
-    size_t d = cd_vals[(i * 2) + 1];
-    sigma[c][d] = new realnum[ntot];
-    trivial_sigma[c][d] = false;
-
-    // Populate sigma[c][d]
-    h5f->read_chunk(1, start, &ntot, sigma[c][d]);
-    *start += ntot;
-  }
-}
-
 typedef struct {
   size_t sz_data;
   size_t ntot;


### PR DESCRIPTION
Fixes #418. 

I modified `test_load_dump_structure` to mimic Ardavan's example from #418.

This was the most straight-forward way I could figure out how to do this, although it still seems overly complicated. Since `chunks[i]->chiP` only uses `E_stuff` and `H_stuff` (according to `meep.hpp:471`), I create separate data sets for `chiP[E_stuff]` and `chiP[H_stuff]` to keep the dataset dimensions lower. Here's a list of the datasets and their descriptions.

#### num_E_sus (size: num_chunks)

The length of the susceptibility list for each chunk's `chiP[E_stuff]`.

#### num_H_sus (size: num_chunks)

Same as above but for `chiP[H_stuff]`.

#### num_E_sigmas (size: num_chunks * num_E_sus)

A list of `num_E_sus`  values (1 for each in the chiP list), representing the number of non-null entries in `chunks[i]->chiP[E_stuff]->sigma`.

#### num_H_sigmas (size: num_chunks * num_E_sus)

Same as above but for `chunks[i]->chiP[H_stuff]->sigma`.

#### sigma_cd_E

The `component` and `direction` indices into the `chunks[i]->chiP[E_stuff]->sigma` array for each non-null `sigma` entry, for each susceptibility in the `chiP[E_stuff]` list.
 
#### sigma_cd_H

Same as above but for `chunks[i]->chiP[H_stuff]->sigma.

#### E_params

The list of parameters needed to reconstruct the `chunks[i]->chiP[E_stuff]` array, in the order `id`, [`noise_amp] (if `noisy_lorentzian_susceptibility`), `omega_0`, `gamma`, `no_omega_0_denominator`.

#### H_params

Same as above but for `chunks[i]->chiP[H_stuff]`.

#### E_sigma

The actual data from `chunks[i]->chiP[E_stuff]->sigma[c][d]` for each non-null `sigma[c][d]` for each susceptibility in the list.
 
#### H_sigma

Same as above but for `chunks[i]->chiP[H_stuff]->sigma[c][d]`.

@stevengj @oskooi 