### PR TITLE
Account for symmetries in fragment stats

### DIFF
--- a/python/simulation.py
+++ b/python/simulation.py
@@ -662,6 +662,17 @@ class Simulation(object):
             self.ensure_periodicity
         )
 
+        mirror_symmetries = [sym for sym in self.symmetries if isinstance(sym, Mirror)]
+        for sym in mirror_symmetries:
+            for fs in stats:
+                fs.num_anisotropic_eps_pixels //= 2
+                fs.num_anisotropic_mu_pixels //= 2
+                fs.num_nonlinear_pixels //= 2
+                fs.num_susceptibility_pixels //= 2
+                fs.num_nonzero_conductivity_pixels //= 2
+                fs.num_dft_pixels //= 2
+                fs.num_pixels_in_box //= 2
+
         return stats
 
     def _init_structure(self, k=False):

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -670,7 +670,6 @@ class Simulation(object):
                 fs.num_nonlinear_pixels //= 2
                 fs.num_susceptibility_pixels //= 2
                 fs.num_nonzero_conductivity_pixels //= 2
-                fs.num_dft_pixels //= 2
                 fs.num_pixels_in_box //= 2
 
         return stats

--- a/python/tests/fragment_stats.py
+++ b/python/tests/fragment_stats.py
@@ -87,9 +87,9 @@ class TestFragmentStats(unittest.TestCase):
                          cond=300 / sym_factor)
 
         # Check DFT regions
-        self.assertEqual(fs[0].num_dft_pixels, 10240 / sym_factor)
-        self.assertEqual(fs[1].num_dft_pixels, 17120 / sym_factor)
-        self.assertEqual(fs[2].num_dft_pixels, 23840 / sym_factor)
+        self.assertEqual(fs[0].num_dft_pixels, 10240)
+        self.assertEqual(fs[1].num_dft_pixels, 17120)
+        self.assertEqual(fs[2].num_dft_pixels, 23840)
 
     def test_1d(self):
         self._test_1d([])
@@ -238,13 +238,13 @@ class TestFragmentStats(unittest.TestCase):
         for i in [0, 3, 6]:
             self.assertEqual(fs[i].num_dft_pixels, 0)
 
-        self.assertEqual(fs[1].num_dft_pixels, 10240 / sym_factor)
-        self.assertEqual(fs[4].num_dft_pixels, 17120 / sym_factor)
-        self.assertEqual(fs[7].num_dft_pixels, 23840 / sym_factor)
+        self.assertEqual(fs[1].num_dft_pixels, 10240)
+        self.assertEqual(fs[4].num_dft_pixels, 17120)
+        self.assertEqual(fs[7].num_dft_pixels, 23840)
 
-        self.assertEqual(fs[2].num_dft_pixels, 51200 / sym_factor)
-        self.assertEqual(fs[5].num_dft_pixels, 85600 / sym_factor)
-        self.assertEqual(fs[8].num_dft_pixels, 119200 / sym_factor)
+        self.assertEqual(fs[2].num_dft_pixels, 51200)
+        self.assertEqual(fs[5].num_dft_pixels, 85600)
+        self.assertEqual(fs[8].num_dft_pixels, 119200)
 
     def test_2d(self):
         self._test_2d([])
@@ -363,9 +363,9 @@ class TestFragmentStats(unittest.TestCase):
                          cond=30000 / sym_factor)
 
         # Check DFT regions
-        self.assertEqual(fs[0].num_dft_pixels, 256000 / sym_factor)
-        self.assertEqual(fs[1].num_dft_pixels, 428000 / sym_factor)
-        self.assertEqual(fs[2].num_dft_pixels, 596000 / sym_factor)
+        self.assertEqual(fs[0].num_dft_pixels, 256000)
+        self.assertEqual(fs[1].num_dft_pixels, 428000)
+        self.assertEqual(fs[2].num_dft_pixels, 596000)
 
     def test_3d(self):
         self._test_3d([])


### PR DESCRIPTION
Only supports `Mirror` symmetries for now.
@stevengj @oskooi 