### PR TITLE
WIP: Fix bugs in _get_dft_data and _load_dft_data

### DIFF
--- a/python/meep.i
+++ b/python/meep.i
@@ -377,40 +377,50 @@ PyObject *_get_dft_array(meep::fields *f, dft_type dft, meep::component c, int n
     return py_arr;
 }
 
-size_t _get_dft_data_size(meep::dft_chunk *dc) {
-    size_t istart;
-    return meep::dft_chunks_Ntotal(dc, &istart);
+size_t _get_dft_data_size(meep::dft_chunk *dft_chunks) {
+    size_t n = 0;
+    for (dft_chunk *cur = dft_chunks; cur; cur = cur->next_in_dft)
+        n += cur->N * cur->Nomega;
+    return sum_to_all(n);
 }
 
 void _get_dft_data(meep::dft_chunk *dc, std::complex<meep::realnum> *cdata, int size) {
-    size_t istart;
-    size_t n = meep::dft_chunks_Ntotal(dc, &istart);
-    if (n != (size_t)size) {
+    size_t my_ntot = 0;
+    for (dft_chunk *cur = dc; cur; cur = cur->next_in_dft)
+        my_ntot += cur->N * cur->Nomega;
+    size_t my_start = partial_sum_to_all(my_ntot) - my_ntot;
+    size_t ntot = sum_to_all(my_ntot);
+
+    if (ntot != (size_t)size) {
         meep::abort("Total dft_chunks size does not agree with size allocated for output array.\n");
     }
 
     for (meep::dft_chunk *cur = dc; cur; cur = cur->next_in_dft) {
         size_t Nchunk = cur->N * cur->Nomega;
         for (size_t i = 0; i < Nchunk; ++i) {
-            cdata[i + istart] = cur->dft[i];
+            cdata[i + my_start] = cur->dft[i];
         }
-        istart += Nchunk;
+        my_start += Nchunk;
     }
 }
 
 void _load_dft_data(meep::dft_chunk *dc, std::complex<meep::realnum> *cdata, int size) {
-    size_t istart;
-    size_t n = meep::dft_chunks_Ntotal(dc, &istart);
-    if (n != (size_t)size) {
+    size_t my_ntot = 0;
+    for (dft_chunk *cur = dc; cur; cur = cur->next_in_dft)
+        my_ntot += cur->N * cur->Nomega;
+    size_t my_start = partial_sum_to_all(my_ntot) - my_ntot;
+    size_t ntot = sum_to_all(my_ntot);
+
+    if (ntot != (size_t)size) {
         meep::abort("Total dft_chunks size does not agree with size allocated for output array.\n");
     }
 
     for (meep::dft_chunk *cur = dc; cur; cur = cur->next_in_dft) {
         size_t Nchunk = cur->N * cur->Nomega;
         for (size_t i = 0; i < Nchunk; ++i) {
-            cur->dft[i] = cdata[i + istart];
+            cur->dft[i] = cdata[i + my_start];
         }
-        istart += Nchunk;
+        my_start += Nchunk;
     }
 }
 
@@ -796,6 +806,8 @@ meep::volume_list *make_volume_list(const meep::volume &v, int c,
 }
 
 %apply int INPLACE_ARRAY1[ANY] { int [3] };
+// For sum_to_all
+%apply std::complex<double>* slice { std::complex<double>* in, std::complex<double>* out };
 
 //--------------------------------------------------
 // typemaps needed for get_eigenmode_coefficients

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -1030,9 +1030,11 @@ class Simulation(object):
 
     def get_dft_data(self, dft_chunk):
         n = mp._get_dft_data_size(dft_chunk)
-        arr = np.zeros(n, np.complex128)
-        mp._get_dft_data(dft_chunk, arr)
-        return arr
+        my_arr = np.zeros(n, np.complex128)
+        result = np.zeros(n, np.complex128)
+        mp._get_dft_data(dft_chunk, my_arr)
+        mp.sum_to_all(my_arr, result, n)
+        return result
 
     def add_near2far(self, fcen, df, nfreq, *near2fars):
         n2f = DftNear2Far(self._add_near2far, [fcen, df, nfreq, near2fars])

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -1030,11 +1030,9 @@ class Simulation(object):
 
     def get_dft_data(self, dft_chunk):
         n = mp._get_dft_data_size(dft_chunk)
-        my_arr = np.zeros(n, np.complex128)
-        result = np.zeros(n, np.complex128)
-        mp._get_dft_data(dft_chunk, my_arr)
-        mp.sum_to_all(my_arr, result, n)
-        return result
+        arr = np.zeros(n, np.complex128)
+        mp._get_dft_data(dft_chunk, arr)
+        return arr
 
     def add_near2far(self, fcen, df, nfreq, *near2fars):
         n2f = DftNear2Far(self._add_near2far, [fcen, df, nfreq, near2fars])


### PR DESCRIPTION
We can't use `dft_chunks_Ntotal` here because it counts twice the number of dft points since it separates real and complex for writing to hdf5.

~~With the first reproducer from #463, I now get the same results when saving/loading the flux to hdf5 via `save_flux` and `load_minus_flux`, and keeping the flux in a numpy array via `get_flux_data` and `load_minus_flux_data`.~~

~~However, I still see an inconsistency. Running Ardavan's reproducer serially, both the hdf5 and numpy versions give~~
```
taper:, 0.00140979, 0.00144195
```
~~But when running it with 2 processes, both the hdf5 and numpy versions give~~
```
taper:, 0.00125602, -3.40803651
``` 
~~Thus, this PR doesn't completely solve the problem yet, but makes the numpy version incorrect in a way that's consistent with the hdf5 version.~~
#463 turned out not to be a bug.
@stevengj @oskooi 