### PR TITLE
Fix filename_prefix bug

### DIFF
--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -780,13 +780,13 @@ Miscellaneous Functions
 
 ### Output File Names
 
-The output filenames used by Meep, e.g. for HDF5 files, are automatically prefixed by the input variable `filename_prefix`. If `filename_prefix` is empty (the default), however, then Meep constructs a default prefix based on the current Python filename with `".py"` replaced by `"-"`: e.g. `test.py` implies a prefix of `"test-"`. You can get this prefix by running:
+The output filenames used by Meep, e.g. for HDF5 files, are automatically prefixed by the input variable `filename_prefix`. If `filename_prefix` is `None` (the default), however, then Meep constructs a default prefix based on the current Python filename with `".py"` replaced by `"-"`: e.g. `test.py` implies a prefix of `"test-"`. You can get this prefix by running:
 
 **`Simulation.get_filename_prefix()`**
 —
 Return the current prefix string that is prepended, by default, to all file names.
 
-If you don't want to use any prefix, then you should set `filename_prefix` to `False`.
+If you don't want to use any prefix, then you should set `filename_prefix` to the empty string `''`.
 
 In addition to the filename prefix, you can also specify that all the output files be written into a newly-created directory (if it does not yet exist). This is done by running:
 

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -466,7 +466,7 @@ class Simulation(object):
                  num_chunks=0,
                  Courant=0.5,
                  accurate_fields_near_cylorigin=False,
-                 filename_prefix='',
+                 filename_prefix=None,
                  output_volume=None,
                  output_single_precision=False,
                  load_structure=''):
@@ -816,17 +816,17 @@ class Simulation(object):
         return self.fields.get_eps(v3)
 
     def get_filename_prefix(self):
-        if self.filename_prefix:
+        if isinstance(self.filename_prefix, str):
             return self.filename_prefix
-        elif self.filename_prefix is False:
-            return ''
-        else:
+        elif self.filename_prefix is None:
             _, filename = os.path.split(sys.argv[0])
 
             if filename == 'ipykernel_launcher.py' or filename == '__main__.py':
                 return ''
             else:
                 return re.sub(r'\.py$', '', filename)
+        else:
+            raise TypeError("Expected a string for filename_prefix, or None for the default.")
 
     def use_output_directory(self, dname=''):
         if not dname:

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -845,7 +845,7 @@ class Simulation(object):
 
         if self.fields is not None:
             hook()
-        self.filename_prefix = ''
+        self.filename_prefix = None
 
         return dname
 

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -818,6 +818,8 @@ class Simulation(object):
     def get_filename_prefix(self):
         if self.filename_prefix:
             return self.filename_prefix
+        elif self.filename_prefix is False:
+            return ''
         else:
             _, filename = os.path.split(sys.argv[0])
 

--- a/python/tests/simulation.py
+++ b/python/tests/simulation.py
@@ -503,6 +503,15 @@ class TestSimulation(unittest.TestCase):
             self.assertEqual(len(w), 1)
             self.assertNotIn("Epsilon", str(w[0].message))
 
+    def test_get_filename_prefix(self):
+        sim = self.init_simple_simulation()
+        self.assertEqual(sim.get_filename_prefix(), "simulation")
+        sim.filename_prefix = ''
+        self.assertEqual(sim.get_filename_prefix(), "")
+        sim.filename_prefix = False
+        with self.assertRaises(TypeError):
+            sim.get_filename_prefix()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This aligns with scheme and the documentation, which states
```
If you don't want to use any prefix, then you should set filename_prefix to False.
```
@stevengj @oskooi 

