### PR TITLE
Add guile API for get-eigenmode-coefficients

### DIFF
--- a/scheme/examples/mode-coeffs.ctl
+++ b/scheme/examples/mode-coeffs.ctl
@@ -1,0 +1,95 @@
+(set-param! resolution 15)
+
+(define-param w 1)  ; width of waveguide
+(define-param L 10)  ; length of waveguide
+
+(define Si (make medium (epsilon 12.0)))
+
+(define-param dair 3.0)
+(define-param dpml 3.0)
+
+(define sx (+ dpml L dpml))
+(define sy (+ dpml dair w dair dpml))
+(set! geometry-lattice (make lattice (size sx sy no-size)))
+
+(define prism_x (+ sx 1))
+(define prism_y (/ w 2))
+(define verts
+  (list
+   (vector3 (* prism_x -1) prism_y)
+   (vector3 prism_x prism_y)
+   (vector3 prism_x (* prism_y -1))
+   (vector3 (* prism_x -1) (* prism_y -1))))
+
+(set! geometry
+      (list
+       (make prism
+         (center (vector3 0 0))
+         (vertices verts)
+         (height infinity)
+         (material (make medium (epsilon 12.0))))))
+
+(set! pml-layers (list (make pml (thickness dpml))))
+
+; mode frequency
+(define-param fcen 0.20)  ; > 0.5/sqrt(11) to have at least 2 modes
+
+(define-param mode-num 1)
+
+(set! sources (list
+               (make eigenmode-source
+                 (src (make gaussian-src (frequency fcen) (fwidth (* 0.5 fcen))))
+                 (center (vector3 (+ (* -0.5 sx) dpml) 0))
+                 (component ALL-COMPONENTS)
+                 (size (vector3 0 (- sy (* 2 dpml))))
+                 (eig-match-freq? true)
+                 (eig-band mode-num)
+                 (eig-resolution 32))))
+
+(set! symmetries
+      (list
+       (make mirror-sym (direction Y) (phase (if (odd? mode-num) 1 -1)))))
+
+(define xm (- (* 0.5 sx) dpml))  ; x-coordinate of monitor
+(define mflux
+  (add-mode-monitor fcen 0 1
+                    (make mode-region (center (vector3 xm 0)) (size (vector3 0 (- sy (* 2 dpml)))))))
+(define mode-flux
+  (add-flux fcen 0 1
+            (make flux-region (center (vector3 xm 0)) (size (vector3 0 (- sy (* 2 dpml)))))))
+(run-sources+ 100)
+
+(define modes-to-check '(1 2))  ; indices of modes for which to compute expansion coefficients
+(define alpha-vgrp-kpoints (get-eigenmode-coefficients mflux modes-to-check))
+(define alpha (first alpha-vgrp-kpoints))
+(define vgrp (second alpha-vgrp-kpoints))
+(define kpoints (third alpha-vgrp-kpoints))
+
+;; self.assertTrue(kpoints[0].close(mp.Vector3(0.604301, 0, 0)))
+;; self.assertTrue(kpoints[1].close(mp.Vector3(0.494353, 0, 0), tol=1e-2))
+
+(define mode-power (car (get-fluxes mode-flux)))
+
+(define test-passed #t)
+(define tolerance 5.0e-3)
+(define c0 (array-ref alpha (- mode-num 1) 0 0))  ; coefficient of forward-traveling wave for mode # mode_num
+
+(map (lambda (nm)
+       (if (not (= mode-num nm))
+           (let ((cfrel (/ (magnitude (array-ref alpha (- nm 1) 0 0)) (magnitude c0)))
+                 (cbrel (/ (magnitude (array-ref alpha (- nm 1) 0 1)) (magnitude c0))))
+             (if (or (> cfrel tolerance) (> cbrel tolerance))
+                 (set! test-passed #f)))))
+     modes-to-check)
+
+; test 1: coefficient of excited mode >> coeffs of all other modes
+(if (not test-passed)
+    (begin
+      (print "Test failed")
+      (exit 1)))
+
+; test 2: |mode coeff|^2 = power
+(if (> (abs (- 1 (/ mode-power (* (magnitude c0) (magnitude c0))))) 0.1)
+    (begin
+      (print "Test failed")
+      (exit 1)))

--- a/scheme/examples/mode-coeffs.ctl
+++ b/scheme/examples/mode-coeffs.ctl
@@ -68,8 +68,11 @@
                (tolerance 5.0e-3)
                (c0 (array-ref alpha (- mode-num 1) 0 0)))  ; coefficient of forward-traveling wave for mode # mode_num
 
-               ;; self.assertTrue(kpoints[0].close(mp.Vector3(0.604301, 0, 0)))
-               ;; self.assertTrue(kpoints[1].close(mp.Vector3(0.494353, 0, 0), tol=1e-2))
+          (if (or (not (vector3-close? (first kpoints) (vector3 0.604301 0 0) 1e-7))
+                  (not (vector3-close? (second kpoints) (vector3 0.494353 0 0) 1e-2)))
+              (begin
+                (print "Test failed")
+                (exit 1)))
 
           (map (lambda (nm)
                  (if (not (= mode-num nm))

--- a/scheme/examples/mode-coeffs.ctl
+++ b/scheme/examples/mode-coeffs.ctl
@@ -1,95 +1,96 @@
+
 (set-param! resolution 15)
 
 (define-param w 1)  ; width of waveguide
 (define-param L 10)  ; length of waveguide
 
-(define Si (make medium (epsilon 12.0)))
-
 (define-param dair 3.0)
 (define-param dpml 3.0)
 
-(define sx (+ dpml L dpml))
-(define sy (+ dpml dair w dair dpml))
-(set! geometry-lattice (make lattice (size sx sy no-size)))
-
-(define prism_x (+ sx 1))
-(define prism_y (/ w 2))
-(define verts
-  (list
-   (vector3 (* prism_x -1) prism_y)
-   (vector3 prism_x prism_y)
-   (vector3 prism_x (* prism_y -1))
-   (vector3 (* prism_x -1) (* prism_y -1))))
-
-(set! geometry
-      (list
-       (make prism
-         (center (vector3 0 0))
-         (vertices verts)
-         (height infinity)
-         (material (make medium (epsilon 12.0))))))
-
-(set! pml-layers (list (make pml (thickness dpml))))
-
-; mode frequency
+;; mode frequency
 (define-param fcen 0.20)  ; > 0.5/sqrt(11) to have at least 2 modes
 
-(define-param mode-num 1)
+(define (run-test mode-num kpoint-func)
+  (reset-meep)
 
-(set! sources (list
-               (make eigenmode-source
-                 (src (make gaussian-src (frequency fcen) (fwidth (* 0.5 fcen))))
-                 (center (vector3 (+ (* -0.5 sx) dpml) 0))
-                 (component ALL-COMPONENTS)
-                 (size (vector3 0 (- sy (* 2 dpml))))
-                 (eig-match-freq? true)
-                 (eig-band mode-num)
-                 (eig-resolution 32))))
+  (let* ((sx (+ dpml L dpml))
+        (sy (+ dpml dair w dair dpml))
+        (prism_x (+ sx 1))
+        (prism_y (/ w 2))
+        (verts
+         (list
+          (vector3 (* prism_x -1) prism_y)
+          (vector3 prism_x prism_y)
+          (vector3 prism_x (* prism_y -1))
+          (vector3 (* prism_x -1) (* prism_y -1))))
+        (modes-to-check '(1 2))  ; indices of modes for which to compute expansion coefficients
+        (xm (- (* 0.5 sx) dpml)))  ; x-coordinate of monitor
 
-(set! symmetries
-      (list
-       (make mirror-sym (direction Y) (phase (if (odd? mode-num) 1 -1)))))
+      (set! geometry-lattice (make lattice (size sx sy no-size)))
+      (set! geometry
+            (list
+             (make prism
+               (center (vector3 0 0))
+               (vertices verts)
+               (height infinity)
+               (material (make medium (epsilon 12.0))))))
 
-(define xm (- (* 0.5 sx) dpml))  ; x-coordinate of monitor
-(define mflux
-  (add-mode-monitor fcen 0 1
-                    (make mode-region (center (vector3 xm 0)) (size (vector3 0 (- sy (* 2 dpml)))))))
-(define mode-flux
-  (add-flux fcen 0 1
-            (make flux-region (center (vector3 xm 0)) (size (vector3 0 (- sy (* 2 dpml)))))))
-(run-sources+ 100)
+      (set! pml-layers (list (make pml (thickness dpml))))
 
-(define modes-to-check '(1 2))  ; indices of modes for which to compute expansion coefficients
-(define alpha-vgrp-kpoints (get-eigenmode-coefficients mflux modes-to-check))
-(define alpha (first alpha-vgrp-kpoints))
-(define vgrp (second alpha-vgrp-kpoints))
-(define kpoints (third alpha-vgrp-kpoints))
 
-;; self.assertTrue(kpoints[0].close(mp.Vector3(0.604301, 0, 0)))
-;; self.assertTrue(kpoints[1].close(mp.Vector3(0.494353, 0, 0), tol=1e-2))
+      (set! sources (list
+                     (make eigenmode-source
+                       (src (make gaussian-src (frequency fcen) (fwidth (* 0.5 fcen))))
+                       (center (vector3 (+ (* -0.5 sx) dpml) 0))
+                       (component ALL-COMPONENTS)
+                       (size (vector3 0 (- sy (* 2 dpml))))
+                       (eig-match-freq? true)
+                       (eig-band mode-num)
+                       (eig-resolution 32))))
 
-(define mode-power (car (get-fluxes mode-flux)))
+      (set! symmetries
+            (list
+             (make mirror-sym (direction Y) (phase (if (odd? mode-num) 1 -1)))))
 
-(define test-passed #t)
-(define tolerance 5.0e-3)
-(define c0 (array-ref alpha (- mode-num 1) 0 0))  ; coefficient of forward-traveling wave for mode # mode_num
+      (let ((mflux (add-mode-monitor fcen 0 1
+                      (make mode-region (center (vector3 xm 0)) (size (vector3 0 (- sy (* 2 dpml)))))))
+            (mode-flux (add-flux fcen 0 1
+              (make flux-region (center (vector3 xm 0)) (size (vector3 0 (- sy (* 2 dpml))))))))
 
-(map (lambda (nm)
-       (if (not (= mode-num nm))
-           (let ((cfrel (/ (magnitude (array-ref alpha (- nm 1) 0 0)) (magnitude c0)))
-                 (cbrel (/ (magnitude (array-ref alpha (- nm 1) 0 1)) (magnitude c0))))
-             (if (or (> cfrel tolerance) (> cbrel tolerance))
-                 (set! test-passed #f)))))
-     modes-to-check)
+        (run-sources+ 100)
 
-; test 1: coefficient of excited mode >> coeffs of all other modes
-(if (not test-passed)
-    (begin
-      (print "Test failed")
-      (exit 1)))
+        (let* ((alpha-vgrp-kpoints (get-eigenmode-coefficients mflux modes-to-check #:kpoint-func kpoint-func))
+               (alpha (first alpha-vgrp-kpoints))
+               (vgrp (second alpha-vgrp-kpoints))
+               (kpoints (third alpha-vgrp-kpoints))
+               (mode-power (car (get-fluxes mode-flux)))
+               (test-passed #t)
+               (tolerance 5.0e-3)
+               (c0 (array-ref alpha (- mode-num 1) 0 0)))  ; coefficient of forward-traveling wave for mode # mode_num
 
-; test 2: |mode coeff|^2 = power
-(if (> (abs (- 1 (/ mode-power (* (magnitude c0) (magnitude c0))))) 0.1)
-    (begin
-      (print "Test failed")
-      (exit 1)))
+               ;; self.assertTrue(kpoints[0].close(mp.Vector3(0.604301, 0, 0)))
+               ;; self.assertTrue(kpoints[1].close(mp.Vector3(0.494353, 0, 0), tol=1e-2))
+
+          (map (lambda (nm)
+                 (if (not (= mode-num nm))
+                     (let ((cfrel (/ (magnitude (array-ref alpha (- nm 1) 0 0)) (magnitude c0)))
+                           (cbrel (/ (magnitude (array-ref alpha (- nm 1) 0 1)) (magnitude c0))))
+                       (if (or (> cfrel tolerance) (> cbrel tolerance))
+                           (set! test-passed #f)))))
+               modes-to-check)
+
+          ;; test 1: coefficient of excited mode >> coeffs of all other modes
+          (if (not test-passed)
+              (begin
+                (print "Test failed")
+                (exit 1)))
+
+          ;; test 2: |mode coeff|^2 = power
+          (if (> (abs (- 1 (/ mode-power (* (magnitude c0) (magnitude c0))))) 0.1)
+              (begin
+                (print "Test failed")
+                (exit 1)))))))
+
+(run-test 1 '())
+(run-test 2 '())
+(run-test 1 (lambda (freq mode) (vector3 0 0)))

--- a/scheme/meep-ctl-swig.hpp
+++ b/scheme/meep-ctl-swig.hpp
@@ -23,11 +23,15 @@ meep::structure *make_structure(int dims, vector3 size, vector3 center,
 				double global_D_conductivity_diag_,
 				double global_B_conductivity_diag_);
 
-ctlio::cvector3_list do_harminv(ctlio::cnumber_list vals, double dt, 
+ctlio::cvector3_list do_harminv(ctlio::cnumber_list vals, double dt,
 				double fmin, double fmax, int maxbands,
                                 double spectral_density, double Q_thresh,
                                 double rel_err_thresh, double err_thresh,
                                 double rel_amp_thresh, double amp_thresh);
+
+void do_get_eigenmode_coefficients(meep::fields *f, meep::dft_flux flux, const meep::volume &eig_vol,
+                                   int *bands, int num_bands, int parity, std::complex<double> *coeffs,
+                                   double *vgrp, double eig_resolution, double eigensolver_tol);
 
 ctlio::number_list dft_flux_flux(meep::dft_flux *f);
 ctlio::number_list dft_force_force(meep::dft_force *f);

--- a/scheme/meep-ctl-swig.hpp
+++ b/scheme/meep-ctl-swig.hpp
@@ -5,6 +5,11 @@
 #ifndef MEEP_CTL_SWIG_HPP
 #define MEEP_CTL_SWIG_HPP 1
 
+struct kpoint_list {
+    meep::vec *kpoints;
+    size_t n;
+};
+
 vector3 vec_to_vector3(const meep::vec &);
 meep::vec vector3_to_vec(const vector3 v3);
 void set_dimensions(int dims);
@@ -29,7 +34,7 @@ ctlio::cvector3_list do_harminv(ctlio::cnumber_list vals, double dt,
                                 double rel_err_thresh, double err_thresh,
                                 double rel_amp_thresh, double amp_thresh);
 
-void do_get_eigenmode_coefficients(meep::fields *f, meep::dft_flux flux, const meep::volume &eig_vol,
+kpoint_list do_get_eigenmode_coefficients(meep::fields *f, meep::dft_flux flux, const meep::volume &eig_vol,
                                    int *bands, int num_bands, int parity, std::complex<double> *coeffs,
                                    double *vgrp, double eig_resolution, double eigensolver_tol,
                                    meep::kpoint_func user_kpoint_func, void *user_kpoint_data);

--- a/scheme/meep-ctl-swig.hpp
+++ b/scheme/meep-ctl-swig.hpp
@@ -31,7 +31,8 @@ ctlio::cvector3_list do_harminv(ctlio::cnumber_list vals, double dt,
 
 void do_get_eigenmode_coefficients(meep::fields *f, meep::dft_flux flux, const meep::volume &eig_vol,
                                    int *bands, int num_bands, int parity, std::complex<double> *coeffs,
-                                   double *vgrp, double eig_resolution, double eigensolver_tol);
+                                   double *vgrp, double eig_resolution, double eigensolver_tol,
+                                   meep::kpoint_func user_kpoint_func, void *user_kpoint_data);
 
 ctlio::number_list dft_flux_flux(meep::dft_flux *f);
 ctlio::number_list dft_force_force(meep::dft_force *f);

--- a/scheme/meep.cpp
+++ b/scheme/meep.cpp
@@ -66,13 +66,20 @@ ctlio::cvector3_list do_harminv(ctlio::cnumber_list vals, double dt,
   return res;
 }
 
-void do_get_eigenmode_coefficients(fields *f, dft_flux flux, const volume &eig_vol, int *bands, int num_bands,
+kpoint_list do_get_eigenmode_coefficients(fields *f, dft_flux flux, const volume &eig_vol, int *bands, int num_bands,
                                    int parity, std::complex<double> *coeffs, double *vgrp, double eig_resolution,
                                    double eigensolver_tol, meep::kpoint_func user_kpoint_func,
                                    void *user_kpoint_data)
 {
-  f->get_eigenmode_coefficients(flux, eig_vol, bands, num_bands, parity, eig_resolution,
-                                eigensolver_tol, coeffs, vgrp, user_kpoint_func, user_kpoint_data);
+  size_t num_kpoints = num_bands * flux.Nfreq;
+  meep::vec *kpoints = new meep::vec[num_kpoints];
+
+  f->get_eigenmode_coefficients(flux, eig_vol, bands, num_bands, parity, eig_resolution, eigensolver_tol,
+                                coeffs, vgrp, user_kpoint_func, user_kpoint_data, kpoints);
+
+  kpoint_list res = {kpoints, num_kpoints};
+
+  return res;
 }
 
 /**************************************************************************/

--- a/scheme/meep.cpp
+++ b/scheme/meep.cpp
@@ -68,10 +68,11 @@ ctlio::cvector3_list do_harminv(ctlio::cnumber_list vals, double dt,
 
 void do_get_eigenmode_coefficients(fields *f, dft_flux flux, const volume &eig_vol, int *bands, int num_bands,
                                    int parity, std::complex<double> *coeffs, double *vgrp, double eig_resolution,
-                                   double eigensolver_tol)
+                                   double eigensolver_tol, meep::kpoint_func user_kpoint_func,
+                                   void *user_kpoint_data)
 {
   f->get_eigenmode_coefficients(flux, eig_vol, bands, num_bands, parity, eig_resolution,
-                                eigensolver_tol, coeffs, vgrp);
+                                eigensolver_tol, coeffs, vgrp, user_kpoint_func, user_kpoint_data);
 }
 
 /**************************************************************************/

--- a/scheme/meep.cpp
+++ b/scheme/meep.cpp
@@ -33,7 +33,7 @@ void ctl_export_hook(void)
 
 /**************************************************************************/
 
-ctlio::cvector3_list do_harminv(ctlio::cnumber_list vals, double dt, 
+ctlio::cvector3_list do_harminv(ctlio::cnumber_list vals, double dt,
 				double fmin, double fmax, int maxbands,
                                 double spectral_density, double Q_thresh,
                                 double rel_err_thresh, double err_thresh,
@@ -64,6 +64,14 @@ ctlio::cvector3_list do_harminv(ctlio::cnumber_list vals, double dt,
   delete[] freq_re;
   delete[] amp;
   return res;
+}
+
+void do_get_eigenmode_coefficients(fields *f, dft_flux flux, const volume &eig_vol, int *bands, int num_bands,
+                                   int parity, std::complex<double> *coeffs, double *vgrp, double eig_resolution,
+                                   double eigensolver_tol)
+{
+  f->get_eigenmode_coefficients(flux, eig_vol, bands, num_bands, parity, eig_resolution,
+                                eigensolver_tol, coeffs, vgrp);
 }
 
 /**************************************************************************/

--- a/scheme/meep.i
+++ b/scheme/meep.i
@@ -238,6 +238,16 @@ static meep::vec my_kpoint_func(double freq, int mode, void *user_data) {
   scm_array_handle_release(&vgrp_handle);
 }
 
+%typemap(out) kpoint_list {
+  int i;
+  list cur_list = SCM_EOL;
+  for (i = $1.n - 1; i >= 0; --i) {
+    cur_list = gh_cons(vector32scm(vec_to_vector3($1.kpoints[i])), cur_list);
+  }
+  $result = cur_list;
+  delete[] $1.kpoints;
+}
+
 // Need to tell SWIG about any method that returns a new object
 // which needs to be garbage-collected.
 %newobject meep::fields::open_h5file;

--- a/scheme/meep.i
+++ b/scheme/meep.i
@@ -60,6 +60,14 @@ static inline std::complex<double> my_complex_func3(std::complex<double> x) {
   return std::complex<double>(cret.re, cret.im);
 }
 
+static meep::vec my_kpoint_func(double freq, int mode, void *user_data) {
+  SCM scm_res = gh_call2((SCM)user_data, ctl_convert_number_to_scm(freq),
+                         ctl_convert_number_to_scm(mode));
+  vector3 v3 = ctl_convert_vector3_to_c(scm_res);
+  meep::vec result(v3.x, v3.y, v3.z);
+  return result;
+}
+
 %}
 
 %typecheck(SWIG_TYPECHECK_COMPLEX) std::complex<double> {
@@ -196,6 +204,17 @@ static inline std::complex<double> my_complex_func3(std::complex<double> x) {
 %typemap(freearg) (int *bands, int num_bands) {
   if ($1) {
     delete[] $1;
+  }
+}
+
+%typemap(in) (meep::kpoint_func user_kpoint_func, void *user_kpoint_data) {
+  if (SCM_NFALSEP(scm_procedure_p($input))) {
+    $1 = my_kpoint_func;
+    $2 = (void*)$input;
+  }
+  else {
+    $1 = NULL;
+    $2 = NULL;
   }
 }
 

--- a/scheme/meep.scm.in
+++ b/scheme/meep.scm.in
@@ -1128,9 +1128,9 @@
     (begin
       (define coeffs (make-typed-array 'c64 '0 num-bands (meep-dft-flux-Nfreq-get flux) 2))
       (define vgrp (make-typed-array 'f64 '0 num-bands (meep-dft-flux-Nfreq-get flux)))
-      (do-get-eigenmode-coefficients fields flux eig-vol bands eig-parity coeffs vgrp
-                                     eig-resolution eig-tolerance kpoint-func)
-      (list coeffs vgrp '()))))
+      (define kpoints (do-get-eigenmode-coefficients fields flux eig-vol bands eig-parity coeffs vgrp
+                                                     eig-resolution eig-tolerance kpoint-func))
+      (list coeffs vgrp kpoints))))
 
 ; ****************************************************************
 ; dft-ldos step function

--- a/scheme/meep.scm.in
+++ b/scheme/meep.scm.in
@@ -515,8 +515,6 @@
   (define-property direction AUTOMATIC 'integer)
   (define-property weight 1.0 'cnumber))
 
-(define mode-region flux-region)
-
 (define (fields-add-fluxish-stuff add-dft-stuff fields fcen df nfreq stufflist)
   (define vl '()) ; volume_list of flux regions
   (map (lambda (f)

--- a/scheme/meep.scm.in
+++ b/scheme/meep.scm.in
@@ -1123,12 +1123,13 @@
         (eig-vol (get-keyword-value args #:eig-vol (meep-dft-flux-where-get flux)))
         (eig-resolution (get-keyword-value args #:eig-resolution 0))
         (eig-tolerance (get-keyword-value args #:eig-tolerance 1e-7))
-        (num-bands (length bands)))
-        ;; TODO: (kpoint-func (get-keyword-value args #:kpoint-func '())))
+        (num-bands (length bands))
+        (kpoint-func (get-keyword-value args #:kpoint-func '())))
     (begin
       (define coeffs (make-typed-array 'c64 '0 num-bands (meep-dft-flux-Nfreq-get flux) 2))
       (define vgrp (make-typed-array 'f64 '0 num-bands (meep-dft-flux-Nfreq-get flux)))
-      (do-get-eigenmode-coefficients fields flux eig-vol bands eig-parity coeffs vgrp eig-resolution eig-tolerance)
+      (do-get-eigenmode-coefficients fields flux eig-vol bands eig-parity coeffs vgrp
+                                     eig-resolution eig-tolerance kpoint-func)
       (list coeffs vgrp '()))))
 
 ; ****************************************************************

--- a/scheme/meep.scm.in
+++ b/scheme/meep.scm.in
@@ -515,6 +515,8 @@
   (define-property direction AUTOMATIC 'integer)
   (define-property weight 1.0 'cnumber))
 
+(define mode-region flux-region)
+
 (define (fields-add-fluxish-stuff add-dft-stuff fields fcen df nfreq stufflist)
   (define vl '()) ; volume_list of flux regions
   (map (lambda (f)
@@ -578,6 +580,26 @@
 (define (load-minus-flux fname flux)
   (load-flux fname flux)
   (meep-dft-flux-scale-dfts flux -1.0))
+
+; ****************************************************************
+; Mode monitor
+
+(define mode-region flux-region)
+
+(define (fields-add-mode-monitor fields fcen df nfreq . fluxes)
+  (if (not (= (length fluxes) 1)) (error "add-mode-monitor expected just one mode-region."))
+  (let* ((region (car fluxes))
+         (v (volume (center (object-property-value region 'center))
+                    (size (object-property-value region 'size))))
+         (d0 (object-property-value region 'direction))
+         (d (if (< d0 0)
+                (meep-fields-normal-direction fields v)
+                d0)))
+    (meep-fields-add-mode-monitor fields d v (- fcen (/ df 2)) (+ fcen (/ df 2)) nfreq)))
+
+(define (add-mode-monitor fcen df nfreq . fluxes)
+  (if (null? fields) (init-fields))
+  (apply fields-add-mode-monitor (append (list fields fcen df nfreq) fluxes)))
 
 ; ****************************************************************
 ; Force spectra (from stress tensor) - very similar interface to flux spectra
@@ -1083,6 +1105,31 @@
 (define harminv-results '())
 (define (harminv c pt fcen df . mxbands)
   (harminv! harminv-data harminv-data-dt harminv-results c pt fcen df mxbands))
+
+
+; ****************************************************************
+; get-eigenmode-coefficients
+
+(define (get-keyword-value args keyword default)
+  (let ((kv (memq keyword args)))
+    (if (and kv (>= (length kv) 2))
+        (cadr kv)
+        default)))
+
+(define (get-eigenmode-coefficients flux bands . args)
+  (if (null? fields)
+      (error "init-fields is required before using get-eigenmode-coefficients"))
+  (let ((eig-parity (get-keyword-value args #:eig-parity NO-PARITY))
+        (eig-vol (get-keyword-value args #:eig-vol (meep-dft-flux-where-get flux)))
+        (eig-resolution (get-keyword-value args #:eig-resolution 0))
+        (eig-tolerance (get-keyword-value args #:eig-tolerance 1e-7))
+        (num-bands (length bands)))
+        ;; TODO: (kpoint-func (get-keyword-value args #:kpoint-func '())))
+    (begin
+      (define coeffs (make-typed-array 'c64 '0 num-bands (meep-dft-flux-Nfreq-get flux) 2))
+      (define vgrp (make-typed-array 'f64 '0 num-bands (meep-dft-flux-Nfreq-get flux)))
+      (do-get-eigenmode-coefficients fields flux eig-vol bands eig-parity coeffs vgrp eig-resolution eig-tolerance)
+      (list coeffs vgrp '()))))
 
 ; ****************************************************************
 ; dft-ldos step function


### PR DESCRIPTION
* I allocate space for `coeffs` and `vgrp` using guile arrays, which allow me to get a C pointer to the data. The `mode-coeffs.ctl` test works, but I'm not sure if the arrays are guaranteed to be contiguous. The docs say they may not be contiguous if you perform any slicing, so I'm assuming that means a newly-created array is contiguous.
* `get-eigenmode-coefficients` accepts keyword arguments, with the same defaults as python.
* Added `add-mode-monitor`, and `mode-region` as alias of `flux-region`.
* `mode-coeffs.ctl` is the same as `python/tests/mode_coeffs.py`. Since the guile interface doesn't really have a test suite, we can replace that with an example similar to `python/examples/mode-decomposition.py`.

I checked the manual to make sure the guile features I'm using are present in versions >= 1.8, but I've only tested it on 2.0.11.
@stevengj @oskooi 