### PR TITLE
Clarification in load dump structure docs

### DIFF
--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -1152,7 +1152,7 @@ Scale the Fourier-transformed fields in `near2far` by the complex number `s`. e.
 
 ### Load and Dump Structure
 
-These functions dump the raw ε data to disk and load it back for doing multiple simulations with the same materials but different sources etc. The only prerequisite is that the dump/load simulations have the same chunks (i.e. the same grid, number of processors, symmetries, and PML). Currently only stores ε and μ, and not nonlinear coefficients or polarizability. Additional geometry can be added to a simulation that loads a structure via the normal `geometry` argument to the `Simulation` constructor, assuming it does not overlap with any objects that were loaded from disk.
+These functions dump the raw ε data to disk and load it back for doing multiple simulations with the same materials but different sources etc. The only prerequisite is that the dump/load simulations have the same chunks (i.e. the same grid, number of processors, symmetries, and PML). Currently only stores ε and μ, and not nonlinear coefficients or polarizability. Note that loading data from a file in this way overwrites any `geometry` data passed to the `Simulation` constructor.
 
 **`Simulation.dump_structure(fname)`**
 —

--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -1152,7 +1152,7 @@ Scale the Fourier-transformed fields in `near2far` by the complex number `s`. e.
 
 ### Load and Dump Structure
 
-These functions dump the raw ε data to disk and load it back for doing multiple simulations with the same materials but different sources etc. The only prerequisite is that the dump/load simulations have the same chunks (i.e. the same grid, number of processors, and PML). Currently only stores ε and μ, and not nonlinear coefficients or polarizability.
+These functions dump the raw ε data to disk and load it back for doing multiple simulations with the same materials but different sources etc. The only prerequisite is that the dump/load simulations have the same chunks (i.e. the same grid, number of processors, symmetries, and PML). Currently only stores ε and μ, and not nonlinear coefficients or polarizability. Additional geometry can be added to a simulation that loads a structure via the normal `geometry` argument to the `Simulation` constructor, assuming it does not overlap with any objects that were loaded from disk.
 
 **`Simulation.dump_structure(fname)`**
 —

--- a/src/structure_dump.cpp
+++ b/src/structure_dump.cpp
@@ -56,7 +56,7 @@ void structure::write_susceptibility_params(h5file *file, const char *dname, int
 
 void structure::dump(const char *filename) {
   if (!quiet)
-    master_printf("dumping structure to file \"%s\"...\n", filename);
+    master_printf("creating epsilon output file \"%s\"...\n", filename);
 
   // make/save a num_chunks x NUM_FIELD_COMPONENTS x 5 array counting
   // the number of entries in the chi1inv array for each chunk.
@@ -375,7 +375,7 @@ void structure::load(const char *filename) {
   h5file file(filename, h5file::READONLY, true);
 
   if (!quiet)
-    master_printf("loading structure from file \"%s\"...\n", filename);
+    master_printf("reading epsilon from file \"%s\"...\n", filename);
 
   // make/save a num_chunks x NUM_FIELD_COMPONENTS x 5 array counting
   // the number of entries in the chi1inv array for each chunk.

--- a/src/structure_dump.cpp
+++ b/src/structure_dump.cpp
@@ -55,6 +55,9 @@ void structure::write_susceptibility_params(h5file *file, const char *dname, int
 }
 
 void structure::dump(const char *filename) {
+  if (!quiet)
+    master_printf("dumping structure to file \"%s\"...\n", filename);
+
   // make/save a num_chunks x NUM_FIELD_COMPONENTS x 5 array counting
   // the number of entries in the chi1inv array for each chunk.
   size_t *num_chi1inv_ = new size_t[num_chunks*NUM_FIELD_COMPONENTS*5];
@@ -370,6 +373,9 @@ void structure::set_chiP_from_file(h5file *file, const char *dataset, field_type
 
 void structure::load(const char *filename) {
   h5file file(filename, h5file::READONLY, true);
+
+  if (!quiet)
+    master_printf("loading structure from file \"%s\"...\n", filename);
 
   // make/save a num_chunks x NUM_FIELD_COMPONENTS x 5 array counting
   // the number of entries in the chi1inv array for each chunk.


### PR DESCRIPTION
Ardavan asked for clarification on the following 2 points:

> 1) If symmetries were used in the original run which involved using dump_structure to create the epsilon file, must they also be used in the load_structure run?

 > 2) Does specifying load_structure in the Simulation constructor also support superimposing additional geometric objects using the geometry object?

I've attempted to address these in the docs, but I may be misunderstanding something.
@stevengj @oskooi 