### PR TITLE
Fix incorrect broadcast in structure::dump

### DIFF
--- a/src/structure_dump.cpp
+++ b/src/structure_dump.cpp
@@ -252,8 +252,6 @@ void structure::dump(const char *filename) {
           int d = sigma_cd[ft][j + 1];
           snprintf(dname, 20, "%c_%d_sigma_%d_%d", ft == 0 ? 'E' : 'H', i, c, d);
           size_t ntot = chunks[i]->gv.ntot() * num_sus[ft];
-          file.prevent_deadlock();
-          broadcast(i, &ntot, 1);
           file.create_data(dname, 1, &ntot);
           if (chunks[i]->is_mine()) {
             susceptibility *sus = chunks[i]->chiP[ft];


### PR DESCRIPTION
Ardavan found another bug while dumping dispersive materials. I looked at the [code](https://github.com/stevengj/meep/blob/master/src/structure.cpp#L135-L148) that creates the chunks, and it looks like the `broadcast` is not necessary here, since the current chunk, `chunks[i]`, will have the same `gv.ntot()` value, no matter which processor it's on. Does that sound correct?
@stevengj @oskooi 