### PR TITLE
Add __version__ attribute to python module

### DIFF
--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -113,6 +113,7 @@ mpb.py: mpb-python.cpp
 
 __init__.py: meep.py mpb.py
 	cp $< $@
+	echo "__version__ = '$(shell git describe --tags | sed 's/^v//')'" >> $@
 	if [[ "${SWIG_VERSION}" = 3.0.12 ]]; then \
 		sed -i.bak '/^if _swig_python_version_info >= (2, 7, 0):/,/^else:/d' $@; \
 		sed -i.bak 's/    import _meep/from . import _meep/' $@; \


### PR DESCRIPTION
Having a `__version__` attribute is standard for python modules. It's based on tags, so the official releases will have versions that correspond to release tags (e.g., `1.5.0`), and the nightly builds will have a string like `<tag>-<commits>-<hash>`, where `commits` is the number of commits since the most recent release `tag`, and `hash` is the short form of the hash for the latest commit.
@stevengj @oskooi 