### PR TITLE
Add python interface to maxwell_dominant_planewave

### DIFF
--- a/libpympb/pympb.cpp
+++ b/libpympb/pympb.cpp
@@ -2500,6 +2500,13 @@ number mode_solver::compute_energy_integral(field_integral_func field_func,
   return cnumber_re(compute_field_integral(field_func, energy_func, py_func));
 }
 
+vector3 mode_solver::get_dominant_planewave(int band) {
+  double kdom[3];
+  maxwell_dominant_planewave(mdata, H, band, kdom);
+  vector3 result = {kdom[0], kdom[1], kdom[2]};
+  return result;
+}
+
 // Used in MPBData python class
 
 /* A macro to set x = fractional part of x input, xi = integer part,

--- a/libpympb/pympb.hpp
+++ b/libpympb/pympb.hpp
@@ -180,6 +180,8 @@ struct mode_solver {
                                  field_integral_energy_func energy_func,
                                  void *py_func);
 
+  vector3 get_dominant_planewave(int band);
+
 private:
   int kpoint_index;
   scalar_complex *curfield;

--- a/python/solver.py
+++ b/python/solver.py
@@ -969,6 +969,9 @@ class ModeSolver(object):
 
         return try_all_and_repeat(k0) if n(k0) < n(k) else try_all_and_repeat(k)
 
+    def get_dominant_planewave(self, band):
+        return self.mode_solver.get_dominant_planewave(band)
+
 
 # Predefined output functions (functions of the band index), for passing to `run`
 

--- a/python/tests/mpb.py
+++ b/python/tests/mpb.py
@@ -282,6 +282,8 @@ class TestModeSolver(unittest.TestCase):
         ms = self.init_solver()
         ms.run_te()
 
+        kdom = ms.get_dominant_planewave(1)
+
         self.check_band_range_data(expected_brd, ms.band_range_data)
         for e, r in zip(expected_freqs, ms.all_freqs[-1]):
             self.assertAlmostEqual(e, r, places=3)


### PR DESCRIPTION
This needs a proper test. I'll add the same thing that's advised in stevengj/mpb#73.
@stevengj @oskooi 