### PR TITLE
Add get_center_and_size

### DIFF
--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -775,6 +775,10 @@ Note that the flux is always computed in the *positive* coordinate direction, al
 
 Many Meep functions require you to specify a volume in space, corresponding to the C++ type `meep::volume`. This class creates such a volume object, given the `center` and `size` properties (just like e.g. a `Block` object). If the `size` is not specified, it defaults to `(0,0,0)`, i.e. a single point. Any method that accepts such a volume also accepts `center` and `size` keyword arguments. If these are specified instead of the volume, the library will construct a volume for you.
 
+**`meep.get_center_and_size(vol)`**
+—
+Utility function that takes a `meep::volume` `vol` and returns the center and size of the volume as a tuple of `Vector3`.
+
 Miscellaneous Functions
 -----------------------
 

--- a/python/examples/coupler.py
+++ b/python/examples/coupler.py
@@ -29,19 +29,6 @@ lcen = 1.55
 fcen = 1/lcen
 df = 0.2*fcen
 
-# extract center and size of meep::volume
-def get_center_and_size(v):
-    rmin = v.get_min_corner()
-    rmax = v.get_max_corner()
-    v3rmin = mp.Vector3(rmin.x(),rmin.y(),rmin.z())
-    v3rmax = mp.Vector3(rmax.x(),rmax.y(),rmax.z())
-    if v.dim<mp.D3:
-      v3rmin.z = v3rmax.z=0
-    if v.dim<mp.D2:
-      v3rmin.y = v3rmax.y=0
-    center = 0.5*(v3rmin+v3rmax)
-    size = v3rmax-v3rmin
-    return (center,size)
 
 def main(args):
     d  = args.d
@@ -57,12 +44,12 @@ def main(args):
     upper_branch = mp.get_GDSII_prisms(silicon, gdsII_file, UPPER_BRANCH_LAYER, si_zmin, si_zmax)
     lower_branch = mp.get_GDSII_prisms(silicon, gdsII_file, LOWER_BRANCH_LAYER, si_zmin, si_zmax)
 
-    (cell_center,cell_size) = get_center_and_size(mp.get_GDSII_volume(gdsII_file,CELL_LAYER, cell_zmin, cell_zmax))
-    (p1_center,p1_size) = get_center_and_size(mp.get_GDSII_volume(gdsII_file,PORT1_LAYER, si_zmin, si_zmax))
-    (p2_center,p2_size) = get_center_and_size(mp.get_GDSII_volume(gdsII_file,PORT2_LAYER, si_zmin, si_zmax))
-    (p3_center,p3_size) = get_center_and_size(mp.get_GDSII_volume(gdsII_file,PORT3_LAYER, si_zmin, si_zmax))
-    (p4_center,p4_size) = get_center_and_size(mp.get_GDSII_volume(gdsII_file,PORT4_LAYER, si_zmin, si_zmax))
-    (src_center,src_size) = get_center_and_size(mp.get_GDSII_volume(gdsII_file,SOURCE_LAYER, si_zmin, si_zmax))
+    (cell_center,cell_size) = mp.get_center_and_size(mp.get_GDSII_volume(gdsII_file,CELL_LAYER, cell_zmin, cell_zmax))
+    (p1_center,p1_size) = mp.get_center_and_size(mp.get_GDSII_volume(gdsII_file,PORT1_LAYER, si_zmin, si_zmax))
+    (p2_center,p2_size) = mp.get_center_and_size(mp.get_GDSII_volume(gdsII_file,PORT2_LAYER, si_zmin, si_zmax))
+    (p3_center,p3_size) = mp.get_center_and_size(mp.get_GDSII_volume(gdsII_file,PORT3_LAYER, si_zmin, si_zmax))
+    (p4_center,p4_size) = mp.get_center_and_size(mp.get_GDSII_volume(gdsII_file,PORT4_LAYER, si_zmin, si_zmax))
+    (src_center,src_size) = mp.get_center_and_size(mp.get_GDSII_volume(gdsII_file,SOURCE_LAYER, si_zmin, si_zmax))
 
     # displace upper and lower branches of coupler (as well as source and flux regions)
     if d != default_d:

--- a/python/meep.i
+++ b/python/meep.i
@@ -1256,6 +1256,7 @@ py_eigenmode_data _get_eigenmode(meep::fields *f, double omega_src, meep::direct
         dft_ldos,
         display_progress,
         during_sources,
+        get_center_and_size,
         get_flux_freqs,
         get_fluxes,
         get_eigenmode_freqs,

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -2211,3 +2211,22 @@ def interpolate(n, nums):
     return res + [nums[-1]]
 
 
+# extract center and size of a meep::volume
+def get_center_and_size(v):
+    rmin = v.get_min_corner()
+    rmax = v.get_max_corner()
+    v3rmin = mp.Vector3(rmin.x(), rmin.y(), rmin.z())
+    v3rmax = mp.Vector3(rmax.x(), rmax.y(), rmax.z())
+
+    if v.dim == mp.D2:
+        v3rmin.z = 0
+        v3rmax.z = 0
+    elif v.dim == mp.D1:
+        v3rmin.x = 0
+        v3rmin.y = 0
+        v3rmin.y = 0
+        v3rmax.y = 0
+
+    center = 0.5 * (v3rmin + v3rmax)
+    size = v3rmax - v3rmin
+    return center, size

--- a/python/tests/simulation.py
+++ b/python/tests/simulation.py
@@ -518,6 +518,22 @@ class TestSimulation(unittest.TestCase):
         with self.assertRaises(TypeError):
             sim.get_filename_prefix()
 
+    def test_get_center_and_size(self):
+        v1d = mp.volume(mp.vec(-2), mp.vec(2))
+        center, size = mp.get_center_and_size(v1d)
+        self.assertTrue(center.close(mp.Vector3()))
+        self.assertTrue(size.close(mp.Vector3(z=4)))
+
+        v2d = mp.volume(mp.vec(-1, -1), mp.vec(1, 1))
+        center, size = mp.get_center_and_size(v2d)
+        self.assertTrue(center.close(mp.Vector3()))
+        self.assertTrue(size.close(mp.Vector3(2, 2)))
+
+        v3d = mp.volume(mp.vec(-1, -1, -1), mp.vec(1, 1, 1))
+        center, size = mp.get_center_and_size(v3d)
+        self.assertTrue(center.close(mp.Vector3()))
+        self.assertTrue(size.close(mp.Vector3(2, 2, 2)))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Closes #506. The original implementation used `x` for 1d center and size, but I thought 1d vecs used `z` so I changed it. Is that correct? 
@stevengj @oskooi 