### PR TITLE
Add python support for multilevel atom

### DIFF
--- a/libmeepgeom/material_data.hpp
+++ b/libmeepgeom/material_data.hpp
@@ -37,6 +37,30 @@ namespace meep_geom {
   limited to C functionality.  These types, especially the material types,
   should be proper C++ classes */
 
+struct transition {
+  int from_level;
+  int to_level;
+  double transition_rate;
+  double frequency;
+  vector3 sigma_diag;
+  double gamma;
+  double pumping_rate;
+
+  bool operator==(const transition &other) const {
+    return (from_level == other.from_level              &&
+            to_level == other.to_level                  &&
+            transition_rate == other.transition_rate    &&
+            frequency == other.frequency                &&
+            vector3_equal(sigma_diag, other.sigma_diag) &&
+            gamma == other.gamma                        &&
+            pumping_rate == other.pumping_rate);
+  }
+
+  bool operator!=(const transition &other) const {
+    return !(*this == other);
+  }
+};
+
 typedef struct susceptibility_struct {
   vector3 sigma_offdiag;
   vector3 sigma_diag;
@@ -45,6 +69,8 @@ typedef struct susceptibility_struct {
   double noise_amp;
   bool drude;
   bool is_file;
+  std::vector<transition> transitions;
+  std::vector<double> initial_populations;
 } susceptibility;
 
 struct susceptibility_list {

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -65,6 +65,7 @@ TESTS =                                   \
     $(MPBPYTEST)                          \
     $(TEST_DIR)/mode_coeffs.py            \
     $(TEST_DIR)/mode_decomposition.py     \
+    $(TEST_DIR)/multilevel_atom.py        \
     $(TEST_DIR)/physical.py               \
     $(TEST_DIR)/pw_source.py              \
     $(TEST_DIR)/refl_angular.py           \

--- a/python/examples/multilevel-atom.py
+++ b/python/examples/multilevel-atom.py
@@ -1,0 +1,104 @@
+from __future__ import division
+
+import math
+import meep as mp
+
+# This file realizes a 1D, one-sided Fabry-Perot laser, as described in Fig. 2 of Cerjan et al.,
+# Opt. Express 20, 474 (2012).
+
+# Cavity definitions
+resolution = 400
+ncav = 1.5        # cavity refractive index
+Lcav = 1          # cavity length
+dpad = 1          # padding thickness
+dpml = 1          # PML thickness
+sz = Lcav + dpad + dpml
+
+cell_size = mp.Vector3(z=sz)
+dimensions = 1
+pml_layers = [mp.PML(dpml, side=mp.High)]
+
+# For defining laser properties in MEEP, the transition rates / frequencies are specified in units of 2*pi*a/c.
+# gamma_21 in MEEP is the Full-Width Half-Max, as opposed to gamma_perp, which is the HWHM in SALT.
+# Additionally, the classical coupling element sigma = 2*theta^2*omega_a/hbar, where
+# theta is the off-diagonal dipole matrix element.
+
+# These different conventions can cause a bit of confusion when comparing against SALT, so here we perform
+# this transformation explicitly.
+
+omega_a = 40                           # omega_a in SALT
+freq_21 = omega_a / (2 * math.pi)       # emission frequency  (units of 2\pia/c)
+
+gamma_perp = 4                         # HWHM in angular frequency, SALT
+gamma_21 = (2 * gamma_perp) / (2 * math.pi)  # FWHM emission linewidth in sec^-1 (units of 2\pia/c)
+# Note that 2*pi*gamma-21 = 2*gamma_perp in SALT.
+
+theta = 1                                # theta, the off-diagonal dipole matrix element, in SALT
+sigma_21 = 2 * theta * theta * omega_a   # dipole coupling strength (hbar = 1)
+
+# The gain medium in MEEP is allowed to have an arbitrary number of levels, and is not
+# restricted to a two-level gain medium, as it simulates the populations of every individual
+# atomic energy level.
+
+# If you are using a 2 level gain model, you can compare against
+# results which only simulate the atomic inversion, using the definitions
+# gamma_parallel = pumping_rate + rate_21
+# D_0 = (pumping_rate - rate_21)/(pumping_rate + rate_21) * N0
+
+# In fact, even if you arn't using a 2 level gain model, you can compare against an effective
+# two level model using the formula provided in Cerjan et al., Opt. Express 20, 474 (2012).
+
+# Here, D_0 as written above is not yet in "SALT" units. To make this conversion,
+# D_0 (SALT) = theta^2/(hbar*gamma_perp) * D_0 (as written above)
+
+# Finally, note the lack of 4*pi in the above conversion that is written in many published SALT papers.
+# This 4*pi comes from using Gaussian units, in which the displacement field, D = E + 4*pi*P, whereas
+# in SI units, D = eps0*E + P, which is what MEEP uses.
+
+# Gain medium pump and decay rates are specified in units of c/a.
+
+rate_21 = 0.005        # non-radiative rate  (units of c/a)
+N0 = 28                # initial population density of ground state
+Rp = 0.0051            # pumping rate of ground to excited state
+# so for example, these parameters have D_0 (SALT) = 0.0693.
+
+# Make the actual medium in MEEP:
+transitions = [mp.Transition(1, 2, pumping_rate=Rp, frequency=freq_21, gamma=gamma_21,
+                             sigma_diag=mp.Vector3(sigma_21, sigma_21, sigma_21)),
+               mp.Transition(2, 1, transition_rate=rate_21)]
+ml_atom = mp.MultilevelAtom(sigma=1, transitions=transitions, initial_populations=[N0])
+two_level = mp.Medium(index=ncav, E_susceptibilities=[ml_atom])
+
+# Specify the cavity geometry:
+geometry = [mp.Block(center=mp.Vector3(z=(-0.5 * sz) + (0.5 * Lcav)),
+                     size=mp.Vector3(mp.inf, mp.inf, Lcav), material=two_level)]
+
+sim = mp.Simulation(cell_size=cell_size,
+                    resolution=resolution,
+                    boundary_layers=pml_layers,
+                    geometry=geometry,
+                    dimensions=dimensions)
+
+# Initialize the fields, has to be non-zero, doesn't really matter what.
+sim.init_sim()
+
+
+def field_func(p):
+    return 1 if p.z == (-0.5 * sz) + (0.5 * Lcav) else 0
+
+
+sim.fields.initialize_field(mp.Ex, field_func)
+
+# Specify the end time:
+endt = 7000
+# Note that the total number of time steps run is endt*resolution*2. This is the origin of the extra
+# factor of 2 in the definition of dt in fieldfft_meep.m.
+
+
+# Run it:
+def print_field(sim):
+    fp = sim.get_field_point(mp.Ex, mp.Vector3(z=(-0.5 * sz) + Lcav + (0.5 * dpad))).real
+    print("field:, {}, {}".format(sim.meep_time(), fp))
+
+
+sim.run(mp.after_time(endt - 250, print_field), until=endt)

--- a/python/geom.py
+++ b/python/geom.py
@@ -234,6 +234,34 @@ class NoisyDrudeSusceptibility(DrudeSusceptibility):
         self.noise_amp = noise_amp
 
 
+class MultilevelAtom(Susceptibility):
+
+    def __init__(self, initial_populations=[], transitions=[], **kwargs):
+        super(MultilevelAtom, self).__init__(**kwargs)
+        self.initial_populations = initial_populations
+        self.transitions = transitions
+
+
+class Transition(object):
+
+    def __init__(self,
+                 from_level,
+                 to_level,
+                 transition_rate=0,
+                 frequency=0,
+                 sigma_diag=Vector3(1, 1, 1),
+                 gamma=0,
+                 pumping_rate=0):
+
+        self.from_level = check_nonnegative('from_level', from_level)
+        self.to_level = check_nonnegative('to_level', to_level)
+        self.transition_rate = transition_rate
+        self.frequency = frequency
+        self.sigma_diag = sigma_diag
+        self.gamma = gamma
+        self.pumping_rate = pumping_rate
+
+
 class GeometricObject(object):
 
     def __init__(self, material=Medium(), center=Vector3(), epsilon_func=None):

--- a/python/meep.i
+++ b/python/meep.i
@@ -72,20 +72,8 @@ typedef struct {
     int num_components;
 } py_field_func_data;
 
+
 #include "typemap_utils.cpp"
-
-static int get_attr_int(PyObject *py_obj, int *result, const char *name) {
-    PyObject *py_attr = PyObject_GetAttrString(py_obj, name);
-
-    if (!py_attr) {
-        PyErr_Format(PyExc_ValueError, "Class attribute '%s' is None\n", name);
-        return 0;
-    }
-
-    *result = PyInteger_AsLong(py_attr);
-    Py_XDECREF(py_attr);
-    return 1;
-}
 
 static PyObject *py_source_time_object() {
     static PyObject *source_time_object = NULL;
@@ -438,7 +426,7 @@ kpoint_list get_eigenmode_coefficients_and_kpoints(meep::fields *f, meep::dft_fl
     f->get_eigenmode_coefficients(flux, eig_vol, bands, num_bands, parity, eig_resolution, eigensolver_tol,
                                   coeffs, vgrp, user_kpoint_func, user_kpoint_data, kpoints, kdom);
 
-    kpoint_list res = {kpoints, num_kpoints, kdom, num_bands};
+    kpoint_list res = {kpoints, num_kpoints, kdom, (size_t)num_bands};
 
     return res;
 }
@@ -1211,11 +1199,13 @@ py_eigenmode_data _get_eigenmode(meep::fields *f, double omega_src, meep::direct
         LorentzianSusceptibility,
         Matrix,
         Medium,
+        MultilevelAtom,
         NoisyDrudeSusceptibility,
         NoisyLorentzianSusceptibility,
         Prism,
         Sphere,
         Susceptibility,
+        Transition,
         Vector3,
         Wedge,
         check_nonnegative,

--- a/python/tests/multilevel_atom.py
+++ b/python/tests/multilevel_atom.py
@@ -1,0 +1,70 @@
+from __future__ import division
+
+import math
+import unittest
+
+import meep as mp
+
+
+class TestMultiLevelAtom(unittest.TestCase):
+
+    def test_multilevel_atom(self):
+        resolution = 20
+        ncav = 1.5
+        Lcav = 1
+        dpad = 1
+        dpml = 1
+        sz = Lcav + dpad + dpml
+
+        cell_size = mp.Vector3(z=sz)
+        dimensions = 1
+        pml_layers = [mp.PML(dpml, side=mp.High)]
+
+        omega_a = 40
+        freq_21 = omega_a / (2 * math.pi)
+
+        gamma_perp = 4
+        gamma_21 = (2 * gamma_perp) / (2 * math.pi)
+
+        theta = 1
+        sigma_21 = 2 * theta * theta * omega_a
+
+        rate_21 = 0.005
+        N0 = 28
+        Rp = 0.0051
+
+        t1 = mp.Transition(
+            1,
+            2,
+            pumping_rate=Rp,
+            frequency=freq_21,
+            gamma=gamma_21,
+            sigma_diag=mp.Vector3(sigma_21, sigma_21, sigma_21)
+        )
+        t2 = mp.Transition(2, 1, transition_rate=rate_21)
+        ml_atom = mp.MultilevelAtom(sigma=1, transitions=[t1, t2], initial_populations=[N0])
+        two_level = mp.Medium(index=ncav, E_susceptibilities=[ml_atom])
+
+        geometry = [mp.Block(center=mp.Vector3(z=(-0.5 * sz) + (0.5 * Lcav)),
+                             size=mp.Vector3(mp.inf, mp.inf, Lcav), material=two_level)]
+
+        sim = mp.Simulation(cell_size=cell_size,
+                            resolution=resolution,
+                            boundary_layers=pml_layers,
+                            geometry=geometry,
+                            dimensions=dimensions)
+
+        def field_func(p):
+            return 1 if p.z == (-0.5 * sz) + (0.5 * Lcav) else 0
+
+        def check_field(sim):
+            fp = sim.get_field_point(mp.Ex, mp.Vector3(z=(-0.5 * sz) + Lcav + (0.5 * dpad))).real
+            self.assertAlmostEqual(fp, 1.8040684243391956)
+
+        sim.init_sim()
+        sim.fields.initialize_field(mp.Ex, field_func)
+        sim.run(mp.at_end(check_field), until=7000)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scheme/examples/multilevel-atom.ctl
+++ b/scheme/examples/multilevel-atom.ctl
@@ -67,7 +67,7 @@
 ;; Specify the cavity geometry:
 (set! geometry (list (make block (center 0 0 (+ (* -0.5 sz) (* 0.5 Lcav)))
 			   (size infinity infinity Lcav) (material two-level))))
-			   
+
 ;; Initialize the fields, has to be non-zero, doesn't really matter what.
 (init-fields)
 (meep-fields-initialize-field fields Ex

--- a/src/multilevel-atom.cpp
+++ b/src/multilevel-atom.cpp
@@ -227,7 +227,7 @@ realnum *multilevel_susceptibility::cinternal_notowned_ptr(
 					int n,
 					void *P_internal_data) const {
   multilevel_data *d = (multilevel_data *) P_internal_data;
-  if (!d->P[c][cmp] || inotowned < 0 || inotowned >= T) // never true
+  if (!d || !d->P[c][cmp] || inotowned < 0 || inotowned >= T) // never true
     return NULL;
   return d->P[c][cmp][inotowned] + n;
 }


### PR DESCRIPTION
* Added Python version of `scheme/examples/multilevel-atom.ctl` and a test. I ran the scheme example at resolution 20 to obtain the reference data for the test.
* Added code from #500 to `meepgeom.cpp`. 
* Added python wrapper classes for `Transition` and `MulitlevelAtom`.
* Running `scheme/examples/multilevel-atom.ctl` with MPI was producing a segfault, but checking for a NULL pointer on `src/multilevel-atom.cpp:230` seems to have fixed it.

@stevengj @oskooi @acerjan 