### PR TITLE
comment out custom_dir in docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,7 +9,7 @@ site_dir: 'doc/site'
 
 theme:
    name: readthedocs
-   custom_dir: 'doc/meep-mkdocs-theme'
+   # custom_dir: 'doc/meep-mkdocs-theme'
 
 markdown_extensions:
     - wikilinks


### PR DESCRIPTION
mkdocs, which is used to build the documentation, on [readthedocs](https://meep.readthedocs.io/en/latest/) seems to have suddenly stopped supporting `custom_dir`. This is a temporary solution in order to re-enable the docs for the time being while a solution is sought.