### PR TITLE
Add missing parameter in add-source

### DIFF
--- a/scheme/meep.scm.in
+++ b/scheme/meep.scm.in
@@ -416,6 +416,7 @@
 	       (volume (center ecen) (size esz))
 	       (object-property-value s 'eig-band)
 	       (object-property-value s 'eig-kpoint)
+	       (object-property-value s 'eig-match-freq?)
 	       (object-property-value s 'eig-parity)
 	       (object-property-value s 'eig-resolution)
 	       (object-property-value s 'eig-tolerance)


### PR DESCRIPTION
Fixes #532.
The `eigenmode-source` `amp-func` branch was missing the `eig-match-freq?` parameter.
@stevengj @oskooi 