### PR TITLE
Revert 528

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,14 +26,11 @@ env:
   - CPPFLAGS=-I${HOME}/local/include LDFLAGS=-L${HOME}/local/lib GEN_CTL_IO=${HOME}/local/bin/gen-ctl-io
   - CORETESTS1="known_results symmetry bragg_transmission one_dimensional integrate convergence_cyl_waveguide aniso_disp harmonics stress_tensor near2far"
   - CORETESTS2="h5test three_d bench flux cylindrical two_dimensional physical 2D_convergence pml"
-  - CHANGED_FILES=$(git diff-tree --no-commit-id --name-only -r HEAD)
-  - DO_FULL_BUILD=$(for f in ${CHANGED_FILES}; do if [[ $f != doc/* ]] && [[ $f != mkdocs.yml ]]; then echo "true" && break; fi done)
 
 ##################################################
 # common installations performed before all build cases
 ##################################################
 before_script:
-  - if [[ ${DO_FULL_BUILD} != true ]]; then echo "Documentation PR. Skipping build"; exit 0; fi
   - git clone https://github.com/stevengj/libctl libctl-src
   - (cd libctl-src && git checkout master && sh autogen.sh --prefix=$HOME/local --enable-shared && make -j 2 && make install)
   - git clone https://github.com/stevengj/harminv


### PR DESCRIPTION
As explained in #540, it seems more flexible and reliable to use `[skip travis]` in commit messages instead of trying to automate it, as long as Ardavan is ok with it. 
@stevengj @oskooi 