### PR TITLE
Enable coveralls in Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ test-driver
 gen-ctl-io
 ctl-io.c
 ctl-io.h
+*.coverage
 scheme/ctl-io.cpp
 scheme/ctl-io.i
 scheme/geom.cpp

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,14 +74,14 @@ matrix:
       - pip install numpy mpi4py scipy
       - pip install --no-binary=h5py h5py
   - python: "3.4"
-    env: MPICONF="--without-mpi" CORETESTS="${CORETESTS2}" MKCHECKFLAGS="-j 2"
+    env: MPICONF="--without-mpi" CORETESTS="${CORETESTS2}" MKCHECKFLAGS="-j 2" RUN_COVERAGE="1"
     addons:
       apt:
         packages:
           - *common_deps
           - libhdf5-serial-dev
     install:
-      - pip install numpy mpi4py scipy h5py
+      - pip install numpy mpi4py scipy h5py coverage coveralls
   - python: "3.4"
     env: MPICONF="--with-mpi"    CORETESTS="${CORETESTS2}" MKCHECKFLAGS="" CC=mpicc CXX=mpic++
     addons:
@@ -114,8 +114,20 @@ script:
   # Output something every 9 minutes so travis doesn't kill the job
   - while sleep 540; do echo "still running"; done &
   - make ${MKCHECKFLAGS} distcheck DISTCHECK_CONFIGURE_FLAGS="--with-libctl=${HOME}/local/share/libctl ${MPICONF}"
+  - >
+    if [[ "${RUN_COVERAGE}" = "1" ]]; then
+      make ${MKCHECKFLAGS} &&
+      pushd python &&
+      echo "[run]" > .coveragerc &&
+      echo "data_file = ${TRAVIS_BUILD_DIR}/.coverage" >> .coveragerc &&
+      make ${MKCHECKFLAGS} check &&
+      popd;
+    fi
   # Kill background sleep loop
   - kill %1
+
+after_success:
+  - if [[ "${RUN_COVERAGE}" = "1" ]]; then cd ${TRAVIS_BUILD_DIR} && coveralls; fi
 
 after_script:
   - BUILD_PREFIX=${TRAVIS_BUILD_DIR}/build/meep-${MEEP_VERSION}/_build

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Latest Docs](https://readthedocs.org/projects/meep/badge/?version=latest)](http://meep.readthedocs.io/en/latest/)
 [![Build Status](https://travis-ci.org/stevengj/meep.svg?branch=master)](https://travis-ci.org/stevengj/meep)
+[![Coverage Status](https://coveralls.io/repos/github/stevengj/meep/badge.svg?branch=master)](https://coveralls.io/github/stevengj/meep?branch=master)
 ![Python versions 2.7–3.6](https://img.shields.io/badge/python-2.7%2C%203.4%2C%203.5%2C%203.6-brightgreen.svg)
 
 **Meep** is a free and open-source software package for simulating electromagnetic systems via the [finite-difference time-domain](https://en.wikipedia.org/wiki/Finite-difference_time-domain_method) (FDTD) method. Meep is an acronym for *MIT Electromagnetic Equation Propagation*.

--- a/configure.ac
+++ b/configure.ac
@@ -523,6 +523,16 @@ else
         AC_CHECK_HEADER([numpy/arrayobject.h],[],[
           AC_MSG_WARN([disabling Python wrappers])
           have_python=no],[#include <Python.h>])
+
+        AC_MSG_CHECKING([for coverage module])
+        $PYTHON -c 'import coverage'
+        if test $? = 0; then
+          AC_MSG_RESULT([yes])
+          have_coverage=yes
+        else
+          AC_MSG_RESULT([no])
+          have_coverage=no
+        fi
       fi
 
       CPPFLAGS=$save_CPPFLAGS
@@ -533,6 +543,7 @@ fi # with_python
 
 AC_SUBST(PYTHON_INCLUDES)
 AM_CONDITIONAL(WITH_PYTHON, test x"$have_python" = "xyes")
+AM_CONDITIONAL(WITH_COVERAGE, test x"$have_coverage" = "xyes")
 
 # Copy/symlink casimir.scm and materials.scm to builddir for out-of-tree builds
 AC_CONFIG_LINKS(scheme/casimir.scm:scheme/casimir.scm)

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -10,7 +10,7 @@ HPPFILES=                                    \
 BUILT_SOURCES = meep-python.cpp mpb-python.cpp __init__.py mpb.py
 EXTRA_DIST = $(BUILT_SOURCES) typemap_utils.cpp solver.py mpb_data.py materials.py examples tests
 
-CLEANFILES = $(BUILT_SOURCES) meep.py
+CLEANFILES = $(BUILT_SOURCES) meep.py .coverage
 
 if WITH_MPB
   PYMPBINCLUDE=-I$(top_srcdir)/libpympb
@@ -76,8 +76,13 @@ TESTS =                                   \
     $(TEST_DIR)/user_defined_material.py  \
     $(TEST_DIR)/wvg_src.py
 
+if WITH_COVERAGE
+  PY_LOG_COMPILER = coverage run -a --omit=$(top_srcdir)/python/tests/*,${HOME}/virtualenv/*,$(top_srcdir)/python/examples/*
+else
+  PY_LOG_COMPILER = $(RUNCODE) $(PYTHON)
+endif
+
 TEST_EXTENSIONS = .py
-PY_LOG_COMPILER = $(RUNCODE) $(PYTHON)
 TESTS_ENVIRONMENT = export PYTHONPATH=$(abs_top_builddir)/python:$$PYTHONPATH;
 
 if WITH_PYTHON


### PR DESCRIPTION
Here's the badge for my fork: [![Coverage Status](https://coveralls.io/repos/github/ChristopherHogan/meep/badge.svg?branch=chogan%2Fcoverage)](https://coveralls.io/github/ChristopherHogan/meep?branch=chogan%2Fcoverage)

To get it working in the main repo, I believe Steven just needs to link his github account at [coveralls.io](https://coveralls.io) and add Meep as a coveralls project.

Some notes:
* The 89% above only reflects the test coverage of the pure Python portions of the Python interface. I.e., it doesn't measure the SWIG C++ extension, or anything in Meep itself. It's possible to add this in the future.
* We can't browse `__init__.py` or `mpb/__init__.py` (the SWIG generated Python wrappers) to see line-by-line coverage on coveralls because these files are generated and coveralls can only pull files that are stored on Github.
* Coverage is only run in Travis for serial Python 3. I had to run the Python tests twice (once in `make distcheck` and once afterwards with coverage) because the autotools world is so incongruous with the Python world.

@stevengj @oskooi 
