### PR TITLE
Added missing MPB (python) magnetic field density output:

### DIFF
--- a/python/mpb.i
+++ b/python/mpb.i
@@ -368,6 +368,7 @@ static mpb_real field_integral_energy_callback(mpb_real energy, mpb_real epsilon
         output_efield_z,
         output_charge_density,
         output_bpwr,
+        output_hpwr,
         output_dpwr,
         output_tot_pwr,
         output_dpwr_in_objects,

--- a/python/solver.py
+++ b/python/solver.py
@@ -1055,6 +1055,12 @@ def output_efield_z(ms, which_band):
     ms.output_field_z()
 
 
+def output_hpwr(ms, which_band):
+    ms.get_hfield(which_band, False)
+    ms.compute_field_energy()
+    ms.output_field()
+
+
 def output_bpwr(ms, which_band):
     ms.get_bfield(which_band, False)
     ms.compute_field_energy()


### PR DESCRIPTION
Added output of time-averaged magnetic field density (i.e. H-field)
as documented in [1].

[1] https://mpb.readthedocs.io/en/latest/Python_User_Interface/#bandoutput-functions