### PR TITLE
fix incorrect #pragma ivdep statement for GCC

### DIFF
--- a/src/meep/vec.hpp
+++ b/src/meep/vec.hpp
@@ -171,11 +171,10 @@ component first_field_component(field_type ft);
 // should only use these macros where that is true!  (Basically,
 // all of this is here to support performance hacks of step_generic.)
 
-#define STRING(text) #text
 #if !defined(__INTEL_COMPILER) && (defined(__GNUC__) || defined(__GNUG__))
-  #define IVDEP STRING(GCC ivdep)
+  #define IVDEP "GCC ivdep"
 #else
-  #define IVDEP STRING(ivdep)
+  #define IVDEP "ivdep"
 #endif
 
 // loop over indices idx from is to ie (inclusive) in gv

--- a/src/meep/vec.hpp
+++ b/src/meep/vec.hpp
@@ -171,6 +171,13 @@ component first_field_component(field_type ft);
 // should only use these macros where that is true!  (Basically,
 // all of this is here to support performance hacks of step_generic.)
 
+#define STRING(text) #text
+#if !defined(__INTEL_COMPILER) && (defined(__GNUC__) || defined(__GNUG__))
+  #define IVDEP STRING(GCC ivdep)
+#else
+  #define IVDEP STRING(ivdep)
+#endif
+
 // loop over indices idx from is to ie (inclusive) in gv
 #define S1LOOP_OVER_IVECS(gv, is, ie, idx) \
   for (ptrdiff_t loop_is1 = (is).yucky_val(0), \
@@ -188,7 +195,7 @@ component first_field_component(field_type ft);
                 + (is - (gv).little_corner()).yucky_val(1) / 2 * loop_s2 \
                 + (is - (gv).little_corner()).yucky_val(2) / 2 * loop_s3,\
            loop_i1 = 0; loop_i1 < loop_n1; loop_i1++) \
-    for (int loop_i2 = 0; loop_i2 < loop_n2; loop_i2++) _Pragma("ivdep") \
+    for (int loop_i2 = 0; loop_i2 < loop_n2; loop_i2++) _Pragma(IVDEP) \
       for (ptrdiff_t idx = idx0 + loop_i1*loop_s1 + loop_i2*loop_s2, \
            loop_i3 = 0; loop_i3 < loop_n3; loop_i3++, idx++)
 

--- a/src/mpb.cpp
+++ b/src/mpb.cpp
@@ -714,7 +714,7 @@ void *fields::get_eigenmode(double omega_src,
   (void) omega_src; (void) d; (void) where; (void) eig_vol;
   (void) band_num;  (void) kpoint; (void) match_frequency;
   (void) parity; (void) resolution; (void) eigensolver_tol;
-  (void) verbose (void) kdom;
+  (void) verbose; (void) kdom;
   abort("Meep must be configured/compiled with MPB for get_eigenmode");
 }
 
@@ -740,11 +740,12 @@ void fields::get_eigenmode_coefficients(dft_flux flux,
                                         double eig_resolution, double eigensolver_tol,
                                         std::complex<double> *coeffs,
                                         double *vgrp, kpoint_func user_kpoint_func,
-                                        void *user_kpoint_data, vec *kpoints)
+                                        void *user_kpoint_data, vec *kpoints, vec *kdom_list)
 
 { (void) flux; (void) eig_vol; (void) bands; (void)num_bands;
   (void) parity; (void) eig_resolution; (void) eigensolver_tol;
   (void) coeffs; (void) vgrp; (void) kpoints; (void) user_kpoint_func; (void) user_kpoint_data;
+  (void) kdom_list;
   abort("Meep must be configured/compiled with MPB for get_eigenmode_coefficient");
 }
 


### PR DESCRIPTION
The `ivdep` compiler directive for loop optimization has different syntax in GCC and other compilers like icpc:

+ for GCC, the syntax is `#pragma GCC ivdep`

+ for icpc and other compilers, it is `#pragma ivdep`

Previously meep was hardcoded to use the latter, which was ignored by GCC, resulting in a performance hit when building with GNU compilers. This PR automatically chooses the right syntax depending on which compiler is being used. 