### PR TITLE
Silence warnings in meep/scheme

### DIFF
--- a/scheme/Makefile.am
+++ b/scheme/Makefile.am
@@ -11,6 +11,7 @@ CTLHDRS = $(LIBHDRS) $(srcdir)/meep-ctl.hpp $(top_builddir)/config.h $(srcdir)/m
 meep_SOURCES = meep.cpp structure.cpp meep_wrap.cxx $(HDRS) meep.i meep_op_renames.i meep_renames.i meep_enum_renames.i meep_swig_bug_workaround.i
 nodist_meep_SOURCES = main.cpp geom.cpp ctl-io.cpp ctl-io.h ctl-io.i
 meep_LDADD = $(LIBMEEP) @LIBCTL_LIBS@
+meep_CPPFLAGS = -Wno-unused-parameter -Wno-unused-variable -Wno-empty-body
 
 BUILT_SOURCES = $(nodist_meep_SOURCES) meep_renames.i meep_enum_renames.i meep_swig_bug_workaround.i meep-enums.scm meep_wrap.cxx
 

--- a/scheme/Makefile.am
+++ b/scheme/Makefile.am
@@ -11,7 +11,7 @@ CTLHDRS = $(LIBHDRS) $(srcdir)/meep-ctl.hpp $(top_builddir)/config.h $(srcdir)/m
 meep_SOURCES = meep.cpp structure.cpp meep_wrap.cxx $(HDRS) meep.i meep_op_renames.i meep_renames.i meep_enum_renames.i meep_swig_bug_workaround.i
 nodist_meep_SOURCES = main.cpp geom.cpp ctl-io.cpp ctl-io.h ctl-io.i
 meep_LDADD = $(LIBMEEP) @LIBCTL_LIBS@
-meep_CPPFLAGS = -Wno-unused-parameter -Wno-unused-variable -Wno-empty-body
+meep_CPPFLAGS = $(AM_CPPFLAGS) -Wno-unused-parameter -Wno-unused-variable -Wno-empty-body
 
 BUILT_SOURCES = $(nodist_meep_SOURCES) meep_renames.i meep_enum_renames.i meep_swig_bug_workaround.i meep-enums.scm meep_wrap.cxx
 

--- a/scheme/meep.i
+++ b/scheme/meep.i
@@ -261,6 +261,8 @@ static meep::vec my_kpoint_func(double freq, int mode, void *user_data) {
 %newobject *::clone;
 %newobject meep::dft_flux::flux;
 
+%warnfilter(302,325,451,503,509);
+
 %include "meep_renames.i"
 %include "meep_enum_renames.i"
 %include "meep_op_renames.i"


### PR DESCRIPTION
These warnings contribute a lot of noise to the build output, and they all come from generated code.
@stevengj @oskooi @HomerReid 