### PR TITLE
use same MPB phase on all processes

### DIFF
--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -56,7 +56,7 @@ endif # WITH_MPB
 endif # WITH_MPI
 
 if WITH_MPB
-  BINARY_GRATING_TEST = # $(TEST_DIR)/binary_grating.py
+  BINARY_GRATING_TEST = $(TEST_DIR)/binary_grating.py
   KDOM_TEST = $(TEST_DIR)/kdom.py
   MODE_COEFFS_TEST = $(TEST_DIR)/mode_coeffs.py
   MODE_DECOMPOSITION_TEST = $(TEST_DIR)/mode_decomposition.py

--- a/src/mpb.cpp
+++ b/src/mpb.cpp
@@ -337,8 +337,9 @@ void *fields::get_eigenmode(double omega_src,
 
   evectmatrix H = create_evectmatrix(n[0] * n[1] * n[2], 2, band_num,
 				     local_N, N_start, alloc_N);
+  unsigned seed = 0; // use the same initialization on all processes
   for (int i = 0; i < H.n * H.p; ++i) {
-    ASSIGN_SCALAR(H.data[i], rand() * 1.0/RAND_MAX, rand() * 1.0/RAND_MAX);
+    ASSIGN_SCALAR(H.data[i], rand_r(&seed) * 1.0/RAND_MAX, rand_r(&seed) * 1.0/RAND_MAX);
   }
 
   mpb_real *eigvals = new mpb_real[band_num];


### PR DESCRIPTION
Hopefully fixes #568 … this looks like it has been a longstanding bug, I'm surprised we didn't notice it before now.

The basic problem I noticed is that MPB computes modes with a "random" phase, but it is a *different* random phase on every processor.  Therefore, in any situation where we are using the same mode calculation distributed across multiple processors (either an eigenmode source that spans multiple chunks or a mode overlap integral that spans multiple chunks), the different processors will be doing the calculation with inconsistent phases.

(The fix uses the POSIX `rand_r` function, which should be okay since I think we only run on POSIX platforms anyway?  We don't require high-quality random numbers here, since we are only initializing to "random" values to make sure the starting vectors are not accidentally nearly orthogonal to the desired modes.)