### PR TITLE
Expose more ldos data

### DIFF
--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -1178,13 +1178,17 @@ As `load_force_data`, but negates the Fourier-transformed fields after they are 
 
 Meep can also calculate the LDOS (local density of states) spectrum, as described in [Tutorial/Local Density of States](Python_Tutorials/Local_Density_of_States.md). To do this, you simply pass the following step function to your `run` command:
 
-**`dft_ldos(fcen, df, nfreq)`**
+**`dft_ldos(fcen=None, df=None, nfreq=None, ldos=None)`**
 —
-Compute the power spectrum of the sources (usually a single point dipole source), normalized to correspond to the LDOS, in a frequency bandwidth `df` centered at `fcen`, at `nfreq` frequency points.
+Compute the power spectrum of the sources (usually a single point dipole source), normalized to correspond to the LDOS, in a frequency bandwidth `df` centered at `fcen`, at `nfreq` frequency points. One can also pass in an `ldos` created with `DftLdos` as `dft_ldos(ldos=my_ldos)`. This is useful for passing to `get_ldos_freqs` or accessing C++ properties like `ldos.omega_min`.
+
+**`DftLdos(fcen, df, nfreq)`**
+—
+Create a `dft_ldos` C++ instance with frequency bandwidth `df` centered at `fcen`, at `nfreq` frequency points.
 
 **`get_ldos_freqs(ldos)`**
 —
-Given an ldos object, returns a list of the frequencies that it is computing the spectrum for.
+Given an ldos object created with `DftLdos`, returns a list of the frequencies that it is computing the spectrum for.
 
 The resulting spectrum is outputted as comma-delimited text, prefixed by `ldos:,`, and is also stored in the `ldos_data` variable of the `Simulation` object after the `run` is complete.
 

--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -1178,17 +1178,17 @@ As `load_force_data`, but negates the Fourier-transformed fields after they are 
 
 Meep can also calculate the LDOS (local density of states) spectrum, as described in [Tutorial/Local Density of States](Python_Tutorials/Local_Density_of_States.md). To do this, you simply pass the following step function to your `run` command:
 
+**`Ldos(fcen, df, nfreq)`**
+—
+Create an LDOS object with frequency bandwidth `df` centered at `fcen`, at `nfreq` frequency points. This can be passed to the `dft_ldos` step function below, and has the properties `freq_min`, `nfreq` and `dfreq`.
+
+**`freqs()`**
+—
+Method of `Ldos` that returns a list of the frequencies that this `Ldos` instance is computing the spectrum for.
+
 **`dft_ldos(fcen=None, df=None, nfreq=None, ldos=None)`**
 —
-Compute the power spectrum of the sources (usually a single point dipole source), normalized to correspond to the LDOS, in a frequency bandwidth `df` centered at `fcen`, at `nfreq` frequency points. One can also pass in an `ldos` created with `DftLdos` as `dft_ldos(ldos=my_ldos)`. This is useful for passing to `get_ldos_freqs` or accessing C++ properties like `ldos.omega_min`.
-
-**`DftLdos(fcen, df, nfreq)`**
-—
-Create a `dft_ldos` C++ instance with frequency bandwidth `df` centered at `fcen`, at `nfreq` frequency points.
-
-**`get_ldos_freqs(ldos)`**
-—
-Given an ldos object created with `DftLdos`, returns a list of the frequencies that it is computing the spectrum for.
+Compute the power spectrum of the sources (usually a single point dipole source), normalized to correspond to the LDOS, in a frequency bandwidth `df` centered at `fcen`, at `nfreq` frequency points. One can also pass in an `ldos` created with `DftLdos` as `dft_ldos(ldos=my_ldos)`.
 
 The resulting spectrum is outputted as comma-delimited text, prefixed by `ldos:,`, and is also stored in the `ldos_data` variable of the `Simulation` object after the `run` is complete.
 

--- a/python/meep.i
+++ b/python/meep.i
@@ -1200,6 +1200,35 @@ void _get_eigenmode(meep::fields *f, double omega_src, meep::direction d, const 
                     bool verbose, double kdom[3]);
 #endif // HAVE_MPB
 
+// Make omega members of meep::dft_ldos available as 'freq' in python
+%extend meep::dft_ldos {
+
+    double get_omega_min() {
+        return $self->omega_min;
+    }
+    double get_domega() {
+        return $self->domega;
+    }
+    int get_Nomega() {
+        return $self->Nomega;
+    }
+    %pythoncode %{
+        def freqs(self):
+            import math
+            import numpy as np
+            start = self.omega_min / (2 * math.pi)
+            stop = start + (self.domega / (2 * math.pi)) * self.Nomega
+            return np.linspace(start, stop, num=self.Nomega, endpoint=False).tolist()
+
+        __swig_getmethods__["freq_min"] = get_omega_min
+        __swig_getmethods__["nfreq"] = get_Nomega
+        __swig_getmethods__["dfreq"] = get_domega
+        if _newclass: freq_min = property(get_omega_min)
+        if _newclass: nfreq = property(get_Nomega)
+        if _newclass: dfreq = property(get_domega)
+    %}
+}
+
 extern boolean point_in_objectp(vector3 p, GEOMETRIC_OBJECT o);
 extern boolean point_in_periodic_objectp(vector3 p, GEOMETRIC_OBJECT o);
 void display_geometric_object_info(int indentby, GEOMETRIC_OBJECT o);
@@ -1266,7 +1295,7 @@ kpoint_list get_eigenmode_coefficients_and_kpoints(meep::fields *f, meep::dft_fl
     )
     from .simulation import (
         Absorber,
-        DftLdos,
+        Ldos,
         FluxRegion,
         ForceRegion,
         Harminv,
@@ -1299,7 +1328,6 @@ kpoint_list get_eigenmode_coefficients_and_kpoints(meep::fields *f, meep::dft_fl
         get_force_freqs,
         get_forces,
         get_near2far_freqs,
-        get_ldos_freqs,
         in_point,
         in_volume,
         interpolate,

--- a/python/meep.i
+++ b/python/meep.i
@@ -1266,6 +1266,7 @@ kpoint_list get_eigenmode_coefficients_and_kpoints(meep::fields *f, meep::dft_fl
     )
     from .simulation import (
         Absorber,
+        DftLdos,
         FluxRegion,
         ForceRegion,
         Harminv,

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -2166,8 +2166,15 @@ def get_ldos_freqs(f):
     return np.linspace(start, stop, num=f.Nomega, endpoint=False).tolist()
 
 
-def dft_ldos(fcen, df, nfreq):
-    ldos = mp._dft_ldos(fcen - df / 2, fcen + df / 2, nfreq)
+def DftLdos(fcen, df, nfreq):
+    return mp._dft_ldos(fcen - df / 2, fcen + df / 2, nfreq)
+
+
+def dft_ldos(fcen=None, df=None, nfreq=None, ldos=None):
+    if ldos is None:
+        if fcen is None or df is None or nfreq is None:
+            raise ValueError("fcen, df, and nfreq are required for dft_ldos")
+        ldos = mp._dft_ldos(fcen - df / 2, fcen + df / 2, nfreq)
 
     def _ldos(sim, todo):
         if todo == 'step':

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -2160,20 +2160,14 @@ def output_sfield_p(sim):
     sim.output_component(mp.Sp)
 
 
-def get_ldos_freqs(f):
-    start = f.omega_min / (2 * math.pi)
-    stop = start + (f.domega / (2 * math.pi)) * f.Nomega
-    return np.linspace(start, stop, num=f.Nomega, endpoint=False).tolist()
-
-
-def DftLdos(fcen, df, nfreq):
+def Ldos(fcen, df, nfreq):
     return mp._dft_ldos(fcen - df / 2, fcen + df / 2, nfreq)
 
 
 def dft_ldos(fcen=None, df=None, nfreq=None, ldos=None):
     if ldos is None:
         if fcen is None or df is None or nfreq is None:
-            raise ValueError("fcen, df, and nfreq are required for dft_ldos")
+            raise ValueError("Either fcen, df, and nfreq, or an Ldos is required for dft_ldos")
         ldos = mp._dft_ldos(fcen - df / 2, fcen + df / 2, nfreq)
 
     def _ldos(sim, todo):
@@ -2183,7 +2177,7 @@ def dft_ldos(fcen=None, df=None, nfreq=None, ldos=None):
             sim.ldos_data = mp._dft_ldos_ldos(ldos)
             sim.ldos_Fdata = mp._dft_ldos_F(ldos)
             sim.ldos_Jdata = mp._dft_ldos_J(ldos)
-            display_csv(sim, 'ldos', zip(get_ldos_freqs(ldos), sim.ldos_data))
+            display_csv(sim, 'ldos', zip(ldos.freqs(), sim.ldos_data))
     return _ldos
 
 

--- a/python/tests/ldos.py
+++ b/python/tests/ldos.py
@@ -1,3 +1,4 @@
+import math
 import unittest
 
 import meep as mp
@@ -33,6 +34,23 @@ class TestLDOS(unittest.TestCase):
         )
 
         self.assertAlmostEqual(self.sim.ldos_data[0], 1.011459560620368)
+
+    def test_ldos_user_object(self):
+        ldos = mp.DftLdos(self.fcen, 0, 1)
+        self.sim.run(
+            mp.dft_ldos(ldos=ldos),
+            until_after_sources=mp.stop_when_fields_decayed(50, mp.Ez, mp.Vector3(), 1e-6)
+        )
+
+        self.assertAlmostEqual(self.sim.ldos_data[0], 1.011459560620368)
+        freqs = mp.get_ldos_freqs(ldos)
+        self.assertEqual(ldos.omega_min, freqs[0] * 2 * math.pi)
+        self.assertEqual(ldos.Nomega, 1)
+        self.assertEqual(ldos.domega, 0)
+
+    def test_invalid_dft_ldos(self):
+        with self.assertRaises(ValueError):
+            self.sim.run(mp.dft_ldos(mp.DftLdos(self.fcen, 0, 1)), until=200)
 
 
 if __name__ == '__main__':

--- a/python/tests/ldos.py
+++ b/python/tests/ldos.py
@@ -36,21 +36,21 @@ class TestLDOS(unittest.TestCase):
         self.assertAlmostEqual(self.sim.ldos_data[0], 1.011459560620368)
 
     def test_ldos_user_object(self):
-        ldos = mp.DftLdos(self.fcen, 0, 1)
+        ldos = mp.Ldos(self.fcen, 0, 1)
         self.sim.run(
             mp.dft_ldos(ldos=ldos),
             until_after_sources=mp.stop_when_fields_decayed(50, mp.Ez, mp.Vector3(), 1e-6)
         )
 
         self.assertAlmostEqual(self.sim.ldos_data[0], 1.011459560620368)
-        freqs = mp.get_ldos_freqs(ldos)
-        self.assertEqual(ldos.omega_min, freqs[0] * 2 * math.pi)
-        self.assertEqual(ldos.Nomega, 1)
-        self.assertEqual(ldos.domega, 0)
+        freqs = ldos.freqs()
+        self.assertEqual(ldos.freq_min, freqs[0] * 2 * math.pi)
+        self.assertEqual(ldos.nfreq, 1)
+        self.assertEqual(ldos.dfreq, 0)
 
     def test_invalid_dft_ldos(self):
         with self.assertRaises(ValueError):
-            self.sim.run(mp.dft_ldos(mp.DftLdos(self.fcen, 0, 1)), until=200)
+            self.sim.run(mp.dft_ldos(mp.Ldos(self.fcen, 0, 1)), until=200)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
A user on the mailing list wanted programmatic access to ldos data printed by the step function `mp.dft_ldos`. I added a public `DftLdos` function that returns a C++ `dft_ldos` that can then be

1. passed to `mp.dft_ldos`
2. passed to `mp.get_ldos_freqs`
3. queried for `dft_ldos::omega_min`

@stevengj @oskooi 