### PR TITLE
Support PML and Absorbers in fragment_stats

### DIFF
--- a/libmeepgeom/meepgeom.cpp
+++ b/libmeepgeom/meepgeom.cpp
@@ -1852,7 +1852,7 @@ static size_t get_pixels_in_box(geom_box *b, int empty_pixel=1) {
                          (empty_y ? empty_pixel : (b->high.y - b->low.y) * fragment_stats::resolution) *
                          (empty_z ? empty_pixel : (b->high.z - b->low.z) * fragment_stats::resolution));
 
-  return total_pixels == 1 ? 0 : (size_t)ceil(total_pixels);
+  return (size_t)ceil(total_pixels);
 }
 
 static void center_box(geom_box *b) {
@@ -1893,6 +1893,9 @@ std::vector<fragment_stats> compute_fragment_stats(geometric_object_list geom,
                                                    vector3 cell_center,
                                                    material_type default_mat,
                                                    std::vector<dft_data> dft_data_list,
+                                                   std::vector<meep::volume> pml_1d_vols,
+                                                   std::vector<meep::volume> pml_2d_vols,
+                                                   std::vector<meep::volume> pml_3d_vols,
                                                    double tol,
                                                    int maxeval,
                                                    bool ensure_per,
@@ -1905,6 +1908,7 @@ std::vector<fragment_stats> compute_fragment_stats(geometric_object_list geom,
   for (size_t i = 0; i < fragments.size(); ++i) {
     fragments[i].compute_stats(&geom);
     fragments[i].compute_dft_stats(&dft_data_list);
+    fragments[i].compute_pml_stats(pml_1d_vols, pml_2d_vols, pml_3d_vols);
   }
   return fragments;
 }
@@ -1915,6 +1919,9 @@ fragment_stats::fragment_stats(geom_box& bx, size_t pixels):
   num_nonlinear_pixels(0),
   num_susceptibility_pixels(0),
   num_nonzero_conductivity_pixels(0),
+  num_1d_pml_pixels(0),
+  num_2d_pml_pixels(0),
+  num_3d_pml_pixels(0),
   num_dft_pixels(0),
   num_pixels_in_box(pixels),
   box(bx) {
@@ -2080,6 +2087,12 @@ void fragment_stats::compute_dft_stats(std::vector<dft_data> *dft_data_list) {
       }
     }
   }
+}
+
+void fragment_stats::compute_pml_stats(std::vector<meep::volume> pml_1d_vols,
+                                       std::vector<meep::volume> pml_2d_vols,
+                                       std::vector<meep::volume> pml_3d_vols) {
+  return;
 }
 
 void fragment_stats::print_stats() {

--- a/libmeepgeom/meepgeom.cpp
+++ b/libmeepgeom/meepgeom.cpp
@@ -2117,6 +2117,9 @@ void fragment_stats::print_stats() {
   master_printf("  num_nonlinear_pixels: %zd\n", num_nonlinear_pixels);
   master_printf("  num_susceptibility_pixels: %zd\n", num_susceptibility_pixels);
   master_printf("  num_nonzero_conductivity_pixels: %zd\n", num_nonzero_conductivity_pixels);
+  master_printf("  num_1d_pml_pixels: %zd\n", num_1d_pml_pixels);
+  master_printf("  num_2d_pml_pixels: %zd\n", num_2d_pml_pixels);
+  master_printf("  num_3d_pml_pixels: %zd\n", num_3d_pml_pixels);
   master_printf("  num_dft_pixels: %zd\n", num_dft_pixels);
   master_printf("  num_pixels_in_box: %zd\n", num_pixels_in_box);
   master_printf("  box.low:  {%f, %f, %f}\n", box.low.x, box.low.y, box.low.z);

--- a/libmeepgeom/meepgeom.cpp
+++ b/libmeepgeom/meepgeom.cpp
@@ -2089,10 +2089,25 @@ void fragment_stats::compute_dft_stats(std::vector<dft_data> *dft_data_list) {
   }
 }
 
-void fragment_stats::compute_pml_stats(std::vector<meep::volume> pml_1d_vols,
-                                       std::vector<meep::volume> pml_2d_vols,
-                                       std::vector<meep::volume> pml_3d_vols) {
-  return;
+void fragment_stats::compute_pml_stats(const std::vector<meep::volume> &pml_1d_vols,
+                                       const std::vector<meep::volume> &pml_2d_vols,
+                                       const std::vector<meep::volume> &pml_3d_vols) {
+
+  const std::vector<meep::volume> *pml_vols[] = {&pml_1d_vols, &pml_2d_vols, &pml_3d_vols};
+  size_t *pml_pixels[] = {&num_1d_pml_pixels, &num_2d_pml_pixels, &num_3d_pml_pixels};
+
+  for (int j = 0; j < 3; ++j) {
+    for (size_t i = 0; i < pml_vols[j]->size(); ++i) {
+      geom_box pml_box = gv2box((*pml_vols[j])[i]);
+
+      if (geom_boxes_intersect(&pml_box, &box)) {
+        geom_box overlap_box;
+        geom_box_intersection(&overlap_box, &pml_box, &box);
+        size_t overlap_pixels = get_pixels_in_box(&overlap_box, 1);
+        *pml_pixels[j] += overlap_pixels;
+      }
+    }
+  }
 }
 
 void fragment_stats::print_stats() {

--- a/libmeepgeom/meepgeom.hpp
+++ b/libmeepgeom/meepgeom.hpp
@@ -72,6 +72,15 @@ struct fragment_stats {
   size_t num_nonlinear_pixels;
   size_t num_susceptibility_pixels;
   size_t num_nonzero_conductivity_pixels;
+
+  // Pixels in single PML regions
+  size_t num_1d_pml_pixels;
+
+  // Pixels where 2 PML regions overlap
+  size_t num_2d_pml_pixels;
+
+  // Pixels where 3 PML regions overlap
+  size_t num_3d_pml_pixels;
   size_t num_dft_pixels;
   size_t num_pixels_in_box;
   geom_box box;
@@ -85,6 +94,9 @@ struct fragment_stats {
   void count_susceptibility_pixels(medium_struct *med, size_t pixels);
   void count_nonzero_conductivity_pixels(medium_struct *med, size_t pixels);
   void compute_dft_stats(std::vector<dft_data> *dft_data_list);
+  void compute_pml_stats(std::vector<meep::volume> pml_1d_vols,
+                         std::vector<meep::volume> pml_2d_vols,
+                         std::vector<meep::volume> pml_3d_vols);
   void print_stats();
 };
 
@@ -94,6 +106,9 @@ std::vector<fragment_stats> compute_fragment_stats(geometric_object_list geom,
                                                    vector3 cell_center,
                                                    material_type default_mat,
                                                    std::vector<dft_data> dft_data_list,
+                                                   std::vector<meep::volume> pml_1d_vols,
+                                                   std::vector<meep::volume> pml_2d_vols,
+                                                   std::vector<meep::volume> pml_3d_vols,
                                                    double tol,
                                                    int maxeval,
                                                    bool ensure_per,

--- a/libmeepgeom/meepgeom.hpp
+++ b/libmeepgeom/meepgeom.hpp
@@ -94,9 +94,9 @@ struct fragment_stats {
   void count_susceptibility_pixels(medium_struct *med, size_t pixels);
   void count_nonzero_conductivity_pixels(medium_struct *med, size_t pixels);
   void compute_dft_stats(std::vector<dft_data> *dft_data_list);
-  void compute_pml_stats(std::vector<meep::volume> pml_1d_vols,
-                         std::vector<meep::volume> pml_2d_vols,
-                         std::vector<meep::volume> pml_3d_vols);
+  void compute_pml_stats(const std::vector<meep::volume> &pml_1d_vols,
+                         const std::vector<meep::volume> &pml_2d_vols,
+                         const std::vector<meep::volume> &pml_3d_vols);
   void print_stats();
 };
 

--- a/libmeepgeom/meepgeom.hpp
+++ b/libmeepgeom/meepgeom.hpp
@@ -97,6 +97,9 @@ struct fragment_stats {
   void compute_pml_stats(const std::vector<meep::volume> &pml_1d_vols,
                          const std::vector<meep::volume> &pml_2d_vols,
                          const std::vector<meep::volume> &pml_3d_vols);
+  void compute_absorber_stats(const std::vector<meep::volume> &absorber_1d_vols,
+                              const std::vector<meep::volume> &absorber_2d_vols,
+                              const std::vector<meep::volume> &absorber_3d_vols);
   void print_stats();
 };
 
@@ -109,6 +112,9 @@ std::vector<fragment_stats> compute_fragment_stats(geometric_object_list geom,
                                                    std::vector<meep::volume> pml_1d_vols,
                                                    std::vector<meep::volume> pml_2d_vols,
                                                    std::vector<meep::volume> pml_3d_vols,
+                                                   std::vector<meep::volume> absorber_1d_vols,
+                                                   std::vector<meep::volume> absorber_2d_vols,
+                                                   std::vector<meep::volume> absorber_3d_vols,
                                                    double tol,
                                                    int maxeval,
                                                    bool ensure_per,

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 import warnings
 from collections import namedtuple
+from collections import OrderedDict
 from collections import Sequence
 
 import numpy as np
@@ -653,12 +654,11 @@ class Simulation(object):
         return v1
 
     def _pml_to_vol_list_2d(self, cyl=False):
-        side_thickness = {
-            'top': 0,
-            'bottom': 0,
-            'left': 0,
-            'right': 0,
-        }
+        side_thickness = OrderedDict()
+        side_thickness['top'] = 0
+        side_thickness['bottom'] = 0
+        side_thickness['left'] = 0
+        side_thickness['right'] = 0
 
         for pml in self.boundary_layers:
             d = pml.direction
@@ -719,7 +719,8 @@ class Simulation(object):
         v1 = []
         v2 = []
 
-        for side, thickness in side_thickness.items():
+        for side in side_thickness.keys():
+            thickness = side_thickness[side]
             if thickness == 0:
                 continue
 
@@ -731,14 +732,13 @@ class Simulation(object):
         return v1, v2
 
     def _pml_to_vol_list_3d(self):
-        side_thickness = {
-            'top': 0,
-            'bottom': 0,
-            'left': 0,
-            'right': 0,
-            'near': 0,
-            'far': 0
-        }
+        side_thickness = OrderedDict()
+        side_thickness['top'] = 0
+        side_thickness['bottom'] = 0
+        side_thickness['left'] = 0
+        side_thickness['right'] = 0
+        side_thickness['near'] = 0
+        side_thickness['far'] = 0
 
         for pml in self.boundary_layers:
             d = pml.direction

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -719,8 +719,104 @@ class Simulation(object):
         return v1, v2
 
     def _pml_to_vol_list_3d(self):
-        # TODO
-        return [], [], []
+        side_thickness = {
+            'top': 0,
+            'bottom': 0,
+            'left': 0,
+            'right': 0,
+            'near': 0,
+            'far': 0
+        }
+
+        for pml in self.boundary_layers:
+            d = pml.direction
+            s = pml.side
+            if d == mp.X or d == mp.ALL:
+                if s == mp.High or s == mp.ALL:
+                    side_thickness['right'] = pml.thickness
+                if s == mp.Low or s == mp.ALL:
+                    side_thickness['left'] = pml.thickness
+            if d == mp.Y or d == mp.ALL:
+                if s == mp.High or s == mp.ALL:
+                    side_thickness['top'] = pml.thickness
+                if s == mp.Low or s == mp.ALL:
+                    side_thickness['bottom'] = pml.thickness
+            if d == mp.Z or d == mp.ALL:
+                if s == mp.High or s == mp.ALL:
+                    side_thickness['far'] = pml.thickness
+                if s == mp.Low or s == mp.ALL:
+                    side_thickness['near'] = pml.thickness
+
+        xmax = self.cell_size.x / 2
+        ymax = self.cell_size.y / 2
+        zmax = self.cell_size.z / 2
+
+        def get_overlap_0(side, d):
+            if side == 'top' or side == 'bottom':
+                xcen = 0
+                xsz = 0
+                ycen = 0
+                ysz = 0
+                zcen = 0
+                zsz = 0
+            elif side == 'left' or side == 'right':
+                xcen = 0
+                xsz = 0
+                ycen = 0
+                ysz = 0
+                zcen = 0
+                zsz = 0
+            elif side == 'near' or side == 'far':
+                xcen = 0
+                xsz = 0
+                ycen = 0
+                ysz = 0
+                zcen = 0
+                zsz = 0
+
+            cen = mp.Vector3(xcen, ycen, zcen)
+            sz = mp.Vector3(xsz, ysz, zsz)
+            return self._volume_from_kwargs(center=cen, size=sz)
+
+        def get_overlap_1(side1, side2, d):
+            xcen = 0
+            ycen = 0
+            zcen = 0
+            cen = mp.Vector3(xcen, ycen, zcen)
+            sz = mp.Vector3()
+            return self._volume_from_kwargs(center=cen, size=sz)
+
+        def get_overlap_2(side1, side2, side3, d):
+            xcen = 0
+            ycen = 0
+            zcen = 0
+            cen = mp.Vector3(xcen, ycen, zcen)
+            sz = mp.Vector3()
+            return self._volume_from_kwargs(center=cen, size=sz)
+
+        v1 = []
+        v2 = []
+        v3 = []
+
+        for side, thickness in side_thickness.items():
+            if thickness == 0:
+                continue
+
+            v1.append(get_overlap_0(side, thickness))
+            if side == 'top' or side == 'bottom':
+                v2.append(get_overlap_1(side, 'left', thickness))
+                v2.append(get_overlap_1(side, 'right', thickness))
+                v2.append(get_overlap_1(side, 'near', thickness))
+                v2.append(get_overlap_1(side, 'far', thickness))
+                v3.append(get_overlap_2(side, 'left', 'near', thickness))
+                v3.append(get_overlap_2(side, 'right', 'near', thickness))
+                v3.append(get_overlap_2(side, 'left', 'far', thickness))
+                v3.append(get_overlap_2(side, 'right', 'far', thickness))
+            if side == 'near' or side == 'far':
+                v2.append(get_overlap_1(side, 'left', thickness))
+                v2.append(get_overlap_1(side, 'right', thickness))
+
+        return v1, v2, v3
 
     def _pml_to_vol_list_cyl(self):
         # TODO

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -753,45 +753,78 @@ class Simulation(object):
 
         def get_overlap_0(side, d):
             if side == 'top' or side == 'bottom':
-                xcen = 0
-                xsz = 0
-                ycen = 0
-                ysz = 0
-                zcen = 0
-                zsz = 0
+                ydir = 1 if side == 'top' else -1
+                xsz = self.cell_size.x - (side_thickness['left'] + side_thickness['right'])
+                ysz = d
+                zsz = self.cell_size.z - (side_thickness['near'] + side_thickness['far'])
+                xcen = xmax - side_thickness['right'] - (xsz / 2)
+                ycen = ydir*ymax + (-ydir*0.5*d)
+                zcen = zmax - side_thickness['far'] - (zsz / 2)
             elif side == 'left' or side == 'right':
-                xcen = 0
-                xsz = 0
-                ycen = 0
-                ysz = 0
-                zcen = 0
-                zsz = 0
+                xdir = 1 if side == 'right' else -1
+                xsz = d
+                ysz = self.cell_size.y - (side_thickness['top'] + side_thickness['bottom'])
+                zsz = self.cell_size.z - (side_thickness['near'] + side_thickness['far'])
+                xcen = xdir*xmax + (-xdir*0.5*d)
+                ycen = ymax - side_thickness['top'] - (ysz / 2)
+                zcen = zmax - side_thickness['far'] - (zsz / 2)
             elif side == 'near' or side == 'far':
-                xcen = 0
-                xsz = 0
-                ycen = 0
-                ysz = 0
-                zcen = 0
-                zsz = 0
+                zdir = 1 if side == 'far' else -1
+                xsz = self.cell_size.x - (side_thickness['left'] + side_thickness['right'])
+                ysz = self.cell_size.y - (side_thickness['top'] + side_thickness['bottom'])
+                zsz = d
+                xcen = xmax - side_thickness['right'] - (xsz / 2)
+                ycen = ymax - side_thickness['top'] - (ysz / 2)
+                zcen = zdir*zmax + (-zdir*0.5*d)
 
             cen = mp.Vector3(xcen, ycen, zcen)
             sz = mp.Vector3(xsz, ysz, zsz)
             return self._volume_from_kwargs(center=cen, size=sz)
 
         def get_overlap_1(side1, side2, d):
-            xcen = 0
-            ycen = 0
-            zcen = 0
+            if side1 == 'top' or side1 == 'bottom':
+                ydir = 1 if side1 == 'top' else -1
+                ysz = d
+                ycen = ydir*ymax + (-ydir*0.5*d)
+                if side2 == 'left' or side2 == 'right':
+                    xdir = 1 if side2 == 'right' else -1
+                    xsz = side_thickness[side2]
+                    zsz = self.cell_size.z - (side_thickness['near'] + side_thickness['far'])
+                    xcen = xdir*xmax + (-xdir*0.5*side_thickness[side2])
+                    zcen = zmax - side_thickness['far'] - (zsz / 2)
+                elif side2 == 'near' or side2 == 'far':
+                    zdir = 1 if side2 == 'far' else -1
+                    xsz = self.cell_size.x - (side_thickness['left'] + side_thickness['right'])
+                    zsz = side_thickness[side2]
+                    xcen = xmax - side_thickness['right'] - (xsz / 2)
+                    zcen = zdir*zmax + (-zdir*0.5*side_thickness[side2])
+            elif side1 == 'near' or side1 == 'far':
+                xdir = 1 if side2 == 'right' else -1
+                zdir = 1 if side1 == 'far' else -1
+                xsz = side_thickness[side2]
+                ysz = self.cell_size.y - (side_thickness['top'] + side_thickness['bottom'])
+                zsz = d
+                xcen = xdir*xmax + (-xdir*0.5*side_thickness[side2])
+                ycen = ymax - side_thickness['top'] - (ysz / 2)
+                zcen = zdir*zmax + (-zdir*0.5*d)
+
             cen = mp.Vector3(xcen, ycen, zcen)
-            sz = mp.Vector3()
+            sz = mp.Vector3(xsz, ysz, zsz)
             return self._volume_from_kwargs(center=cen, size=sz)
 
         def get_overlap_2(side1, side2, side3, d):
-            xcen = 0
-            ycen = 0
-            zcen = 0
+            xdir = 1 if side2 == 'right' else -1
+            ydir = 1 if side1 == 'top' else -1
+            zdir = 1 if side3 == 'far' else -1
+            xsz = side_thickness[side2]
+            ysz = d
+            zsz = side_thickness[side3]
+            xcen = xdir*xmax + (-xdir*0.5*side_thickness[side2])
+            ycen = ydir*ymax + (-ydir*0.5*d)
+            zcen = zdir*zmax + (-zdir*0.5*side_thickness[side3])
+
             cen = mp.Vector3(xcen, ycen, zcen)
-            sz = mp.Vector3()
+            sz = mp.Vector3(xsz, ysz, zsz)
             return self._volume_from_kwargs(center=cen, size=sz)
 
         v1 = []

--- a/python/tests/fragment_stats.py
+++ b/python/tests/fragment_stats.py
@@ -800,6 +800,19 @@ class TestPMLToVolList(unittest.TestCase):
         # bottom right far
         self.check3d(v3[7], mp.Vector3(4, -5, 4), mp.Vector3(5, -4, 5))
 
+    def test_3d_X_direction_only(self):
+        sim = self.make_sim(mp.Vector3(10, 10, 10), 10, [mp.PML(1, mp.X)], 3)
+        v1, v2, v3 = sim._pml_to_vol_list()
+
+        self.assertEqual(len(v1), 2)
+        self.assertEqual(len(v2), 0)
+        self.assertEqual(len(v3), 0)
+
+        # left
+        self.check3d(v1[0], mp.Vector3(-5, -5, -5), mp.Vector3(-4, 5, 5))
+        # right
+        self.check3d(v1[1], mp.Vector3(4, -5, -5), mp.Vector3(5, 5, 5))
+
     def test_cylindrical_all_directions_all_sides(self):
         sim = self.make_sim(mp.Vector3(10, 0, 10), 10, [mp.PML(1)], mp.CYLINDRICAL)
         v1, v2, v3 = sim._pml_to_vol_list()

--- a/python/tests/fragment_stats.py
+++ b/python/tests/fragment_stats.py
@@ -304,6 +304,19 @@ class TestFragmentStats(unittest.TestCase):
         # Left center
         self.assertEqual(self.fs[1].num_1d_pml_pixels, 2000)
 
+    def test_2d_with_absorbers(self):
+        fs = self.get_fragment_stats(mp.Vector3(10, 10), mp.Vector3(30, 30), 2,
+                                     geom=[], pml=[mp.Absorber(1)])
+
+        total_nonzero_cond_pixels = 0
+        for i in range(len(fs)):
+            self.assertEqual(fs[i].num_1d_pml_pixels, 0)
+            self.assertEqual(fs[i].num_2d_pml_pixels, 0)
+            self.assertEqual(fs[i].num_3d_pml_pixels, 0)
+            total_nonzero_cond_pixels += fs[i].num_nonzero_conductivity_pixels
+
+        self.assertEqual(total_nonzero_cond_pixels, 12000)
+
     def test_2d_with_overlap(self):
         # A 30 x 30 cell, with a 20 x 20 block in the middle, split into 9 10 x 10 fragments.
 
@@ -436,6 +449,19 @@ class TestFragmentStats(unittest.TestCase):
         self.assertEqual(self.fs[0].num_1d_pml_pixels, 416000)
         self.assertEqual(self.fs[0].num_2d_pml_pixels, 124000)
         self.assertEqual(self.fs[0].num_3d_pml_pixels, 12000)
+
+    def test_3d_with_absorbers(self):
+        fs = self.get_fragment_stats(mp.Vector3(), mp.Vector3(30, 30, 30), 3,
+                                     geom=[], pml=[mp.Absorber(1)])
+
+        total_nonzero_cond_pixels = 0
+        for i in range(len(fs)):
+            self.assertEqual(fs[i].num_1d_pml_pixels, 0)
+            self.assertEqual(fs[i].num_2d_pml_pixels, 0)
+            self.assertEqual(fs[i].num_3d_pml_pixels, 0)
+            total_nonzero_cond_pixels += fs[i].num_nonzero_conductivity_pixels
+
+        self.assertEqual(total_nonzero_cond_pixels, 5400000)
 
     def test_3d_with_overlap(self):
         # A 30 x 30 x 30 cell with a 20 x 20 x 20 block placed at the center, split

--- a/python/tests/fragment_stats.py
+++ b/python/tests/fragment_stats.py
@@ -774,7 +774,7 @@ class TestPMLToVolList(unittest.TestCase):
         # bottom right far
         self.check3d(v3[7], mp.Vector3(4, -5, 4), mp.Vector3(5, -4, 5))
 
-    def test_cyl_all_directions_all_sides(self):
+    def test_cylindrical_all_directions_all_sides(self):
         sim = self.make_sim(mp.Vector3(10, 0, 10), 10, [mp.PML(1)], mp.CYLINDRICAL)
         v1, v2, v3 = sim._pml_to_vol_list()
 

--- a/python/tests/fragment_stats.py
+++ b/python/tests/fragment_stats.py
@@ -704,33 +704,53 @@ class TestPMLToVolList(unittest.TestCase):
         # right
         self.check3d(v1[3], mp.Vector3(4, -4, -4), mp.Vector3(5, 4, 4))
         # near
-        self.check3d(v1[4], mp.Vector3(-4, -4, 4), mp.Vector3(4, 4, 5))
+        self.check3d(v1[4], mp.Vector3(-4, -4, -5), mp.Vector3(4, 4, -4))
         # far
-        self.check3d(v1[5], mp.Vector3(-4, -4, -5), mp.Vector3(4, 4, -4))
+        self.check3d(v1[5], mp.Vector3(-4, -4, 4), mp.Vector3(4, 4, 5))
 
         # Two PMLs overlap (cube edges)
-        # self.check3d(v2[0], mp.Vector3(), mp.Vector3())
-        # self.check3d(v2[1], mp.Vector3(), mp.Vector3())
-        # self.check3d(v2[2], mp.Vector3(), mp.Vector3())
-        # self.check3d(v2[3], mp.Vector3(), mp.Vector3())
-        # self.check3d(v2[4], mp.Vector3(), mp.Vector3())
-        # self.check3d(v2[5], mp.Vector3(), mp.Vector3())
-        # self.check3d(v2[6], mp.Vector3(), mp.Vector3())
-        # self.check3d(v2[7], mp.Vector3(), mp.Vector3())
-        # self.check3d(v2[8], mp.Vector3(), mp.Vector3())
-        # self.check3d(v2[9], mp.Vector3(), mp.Vector3())
-        # self.check3d(v2[10], mp.Vector3(), mp.Vector3())
-        # self.check3d(v2[11], mp.Vector3(), mp.Vector3())
+        # top left
+        self.check3d(v2[0], mp.Vector3(-5, 4, -4), mp.Vector3(-4, 5, 4))
+        # top right
+        self.check3d(v2[1], mp.Vector3(4, 4, -4), mp.Vector3(5, 5, 4))
+        # top near
+        self.check3d(v2[2], mp.Vector3(-4, 4, -5), mp.Vector3(4, 5, -4))
+        # top far
+        self.check3d(v2[3], mp.Vector3(-4, 4, 4), mp.Vector3(4, 5, 5))
+        # bottom left
+        self.check3d(v2[4], mp.Vector3(-5, -5, -4), mp.Vector3(-4, -4, 4))
+        # bottom right
+        self.check3d(v2[5], mp.Vector3(4, -5, -4), mp.Vector3(5, -4, 4))
+        # bottom near
+        self.check3d(v2[6], mp.Vector3(-4, -5, -5), mp.Vector3(4, -4, -4))
+        # bottom far
+        self.check3d(v2[7], mp.Vector3(-4, -5, 4), mp.Vector3(4, -4, 5))
+        # near left
+        self.check3d(v2[8], mp.Vector3(-5, -4, -5), mp.Vector3(-4, 4, -4))
+        # near right
+        self.check3d(v2[9], mp.Vector3(4, -4, -5), mp.Vector3(5, 4, -4))
+        # far left
+        self.check3d(v2[10], mp.Vector3(-5, -4, 4), mp.Vector3(-4, 4, 5))
+        # far right
+        self.check3d(v2[11], mp.Vector3(4, -4, 4), mp.Vector3(5, 4, 5))
 
         # Three PMLs overlap (cube corners)
-        # self.check3d(v3[0], mp.Vector3(), mp.Vector3())
-        # self.check3d(v3[1], mp.Vector3(), mp.Vector3())
-        # self.check3d(v3[2], mp.Vector3(), mp.Vector3())
-        # self.check3d(v3[3], mp.Vector3(), mp.Vector3())
-        # self.check3d(v3[4], mp.Vector3(), mp.Vector3())
-        # self.check3d(v3[5], mp.Vector3(), mp.Vector3())
-        # self.check3d(v3[6], mp.Vector3(), mp.Vector3())
-        # self.check3d(v3[7], mp.Vector3(), mp.Vector3())
+        # top left near
+        self.check3d(v3[0], mp.Vector3(-5, 4, -5), mp.Vector3(-4, 5, -4))
+        # top right near
+        self.check3d(v3[1], mp.Vector3(4, 4, -5), mp.Vector3(5, 5, -4))
+        # top left far
+        self.check3d(v3[2], mp.Vector3(-5, 4, 4), mp.Vector3(-4, 5, 5))
+        # top right far
+        self.check3d(v3[3], mp.Vector3(4, 4, 4), mp.Vector3(5, 5, 5))
+        # bottom left near
+        self.check3d(v3[4], mp.Vector3(-5, -5, -5), mp.Vector3(-4, -4, -4))
+        # bottom right near
+        self.check3d(v3[5], mp.Vector3(4, -5, -5), mp.Vector3(5, -4, -4))
+        # bottom left far
+        self.check3d(v3[6], mp.Vector3(-5, -5, 4), mp.Vector3(-4, -4, 5))
+        # bottom right far
+        self.check3d(v3[7], mp.Vector3(4, -5, 4), mp.Vector3(5, -4, 5))
 
 
 if __name__ == '__main__':

--- a/python/tests/fragment_stats.py
+++ b/python/tests/fragment_stats.py
@@ -570,6 +570,14 @@ class TestPMLToVolList(unittest.TestCase):
         self.assertEqual(expected_min, min_v3)
         self.assertEqual(expected_max, max_v3)
 
+    def check3d(self, vol, expected_min, expected_max):
+        min_vec = vol.get_min_corner()
+        max_vec = vol.get_max_corner()
+        min_v3 = mp.Vector3(min_vec.x(), min_vec.y(), min_vec.z())
+        max_v3 = mp.Vector3(max_vec.x(), max_vec.y(), max_vec.z())
+        self.assertEqual(expected_min, min_v3)
+        self.assertEqual(expected_max, max_v3)
+
     def test_1d_all_sides(self):
         sim = self.make_sim(mp.Vector3(z=10), 10, [mp.PML(1)], 1)
         v1, v2, v3 = sim._pml_to_vol_list()
@@ -677,6 +685,52 @@ class TestPMLToVolList(unittest.TestCase):
         self.assertEqual(len(v1), 2)
         self.check2d(v1[0], mp.Vector3(-5, -5), mp.Vector3(-4, 5))
         self.check2d(v1[1], mp.Vector3(4, -5), mp.Vector3(5, 5))
+
+    def test_3d_all_directions_all_sides(self):
+        sim = self.make_sim(mp.Vector3(10, 10, 10), 10, [mp.PML(1)], 3)
+        v1, v2, v3 = sim._pml_to_vol_list()
+
+        self.assertEqual(len(v1), 6)
+        self.assertEqual(len(v2), 12)
+        self.assertEqual(len(v3), 8)
+
+        # No overlapping regions (cube faces)
+        # top
+        self.check3d(v1[0], mp.Vector3(-4, 4, -4), mp.Vector3(4, 5, 4))
+        # bottom
+        self.check3d(v1[1], mp.Vector3(-4, -5, -4), mp.Vector3(4, -4, 4))
+        # left
+        self.check3d(v1[2], mp.Vector3(-5, -4, -4), mp.Vector3(-4, 4, 4))
+        # right
+        self.check3d(v1[3], mp.Vector3(4, -4, -4), mp.Vector3(5, 4, 4))
+        # near
+        self.check3d(v1[4], mp.Vector3(-4, -4, 4), mp.Vector3(4, 4, 5))
+        # far
+        self.check3d(v1[5], mp.Vector3(-4, -4, -5), mp.Vector3(4, 4, -4))
+
+        # Two PMLs overlap (cube edges)
+        # self.check3d(v2[0], mp.Vector3(), mp.Vector3())
+        # self.check3d(v2[1], mp.Vector3(), mp.Vector3())
+        # self.check3d(v2[2], mp.Vector3(), mp.Vector3())
+        # self.check3d(v2[3], mp.Vector3(), mp.Vector3())
+        # self.check3d(v2[4], mp.Vector3(), mp.Vector3())
+        # self.check3d(v2[5], mp.Vector3(), mp.Vector3())
+        # self.check3d(v2[6], mp.Vector3(), mp.Vector3())
+        # self.check3d(v2[7], mp.Vector3(), mp.Vector3())
+        # self.check3d(v2[8], mp.Vector3(), mp.Vector3())
+        # self.check3d(v2[9], mp.Vector3(), mp.Vector3())
+        # self.check3d(v2[10], mp.Vector3(), mp.Vector3())
+        # self.check3d(v2[11], mp.Vector3(), mp.Vector3())
+
+        # Three PMLs overlap (cube corners)
+        # self.check3d(v3[0], mp.Vector3(), mp.Vector3())
+        # self.check3d(v3[1], mp.Vector3(), mp.Vector3())
+        # self.check3d(v3[2], mp.Vector3(), mp.Vector3())
+        # self.check3d(v3[3], mp.Vector3(), mp.Vector3())
+        # self.check3d(v3[4], mp.Vector3(), mp.Vector3())
+        # self.check3d(v3[5], mp.Vector3(), mp.Vector3())
+        # self.check3d(v3[6], mp.Vector3(), mp.Vector3())
+        # self.check3d(v3[7], mp.Vector3(), mp.Vector3())
 
 
 if __name__ == '__main__':

--- a/python/tests/fragment_stats.py
+++ b/python/tests/fragment_stats.py
@@ -551,22 +551,22 @@ class TestPMLToVolList(unittest.TestCase):
         v1, v2, v3 = sim._pml_to_vol_list()
 
         self.assertFalse(v3)
-        # self.assertEqual(len(v1), 4)
-        # self.assertEqual(len(v2), 4)
+        self.assertEqual(len(v1), 4)
+        self.assertEqual(len(v2), 4)
 
         # No overlap
         self.check2d(v1[0], mp.Vector3(-4, 4), mp.Vector3(4, 5))
-        # self.check2d(v1[1], mp.Vector3(-4, -5), mp.Vector3(4, -4))
-        # self.check2d(v1[2], mp.Vector3(4, -4), mp.Vector3(5, 4))
-        # self.check2d(v1[3], mp.Vector3(-5, -4), mp.Vector3(-4, 4))
+        self.check2d(v1[1], mp.Vector3(-4, -5), mp.Vector3(4, -4))
+        self.check2d(v1[2], mp.Vector3(-5, -4), mp.Vector3(-4, 4))
+        self.check2d(v1[3], mp.Vector3(4, -4), mp.Vector3(5, 4))
 
         # Two PMLs overlap
         self.check2d(v2[0], mp.Vector3(-5, 4), mp.Vector3(-4, 5))
         self.check2d(v2[1], mp.Vector3(4, 4), mp.Vector3(5, 5))
-        # self.check2d(v2[2], mp.Vector3(4, -5), mp.Vector3(5, -4))
-        # self.check2d(v2[3], mp.Vector3(-5, -5), mp.Vector3(-4, -4))
+        self.check2d(v2[2], mp.Vector3(-5, -5), mp.Vector3(-4, -4))
+        self.check2d(v2[3], mp.Vector3(4, -5), mp.Vector3(5, -4))
 
-    def test_2d_all_sides_different_thickness(self):
+    def test_2d_all_sides_different_thickness_in_X(self):
         # Thickness 1 on top and bottom, 3 on right, 2 on left
         pmls = [
             mp.PML(thickness=1, direction=mp.Y),
@@ -577,8 +577,53 @@ class TestPMLToVolList(unittest.TestCase):
         v1, v2, v3 = sim._pml_to_vol_list()
 
         self.assertFalse(v3)
-        # self.assertEqal(len(v1), 4)
-        # self.assertEqal(len(v2), 4)
+        self.assertEqual(len(v1), 4)
+        self.assertEqual(len(v2), 4)
+
+        # No overlap
+        self.check2d(v1[0], mp.Vector3(-3, 4), mp.Vector3(2, 5))
+        self.check2d(v1[1], mp.Vector3(-3, -5), mp.Vector3(2, -4))
+        self.check2d(v1[2], mp.Vector3(-5, -4), mp.Vector3(-3, 4))
+        self.check2d(v1[3], mp.Vector3(2, -4), mp.Vector3(5, 4))
+
+        # Two PMLs overlap
+        self.check2d(v2[0], mp.Vector3(-5, 4), mp.Vector3(-3, 5))
+        self.check2d(v2[1], mp.Vector3(2, 4), mp.Vector3(5, 5))
+        self.check2d(v2[2], mp.Vector3(-5, -5), mp.Vector3(-3, -4))
+        self.check2d(v2[3], mp.Vector3(2, -5), mp.Vector3(5, -4))
+
+    def test_2d_three_sides_different_thickness(self):
+        # Thickness 3 on top, 2 on left, 1 on right
+        pmls = [
+            mp.PML(3, mp.Y, mp.High),
+            mp.PML(2, mp.X, mp.Low),
+            mp.PML(1, mp.X, mp.High),
+        ]
+        sim = self.make_sim(mp.Vector3(10, 10), 10, pmls, 2)
+        v1, v2, v3 = sim._pml_to_vol_list()
+
+        self.assertFalse(v3)
+        self.assertEqual(len(v1), 3)
+        self.assertEqual(len(v2), 2)
+
+        # No overlap
+        self.check2d(v1[0], mp.Vector3(-3, 2), mp.Vector3(4, 5))
+        self.check2d(v1[1], mp.Vector3(-5, -5), mp.Vector3(-3, 2))
+        self.check2d(v1[2], mp.Vector3(4, -5), mp.Vector3(5, 2))
+
+        # Two PMLs overlap
+        self.check2d(v2[0], mp.Vector3(-5, 2), mp.Vector3(-3, 5))
+        self.check2d(v2[1], mp.Vector3(4, 2), mp.Vector3(5, 5))
+
+    def test_2d_two_sides(self):
+        sim = self.make_sim(mp.Vector3(10, 10), 10, [mp.PML(1, mp.X)], 2)
+        v1, v2, v3 = sim._pml_to_vol_list()
+
+        self.assertFalse(v2)
+        self.assertFalse(v3)
+        self.assertEqual(len(v1), 2)
+        self.check2d(v1[0], mp.Vector3(-5, -5), mp.Vector3(-4, 5))
+        self.check2d(v1[1], mp.Vector3(4, -5), mp.Vector3(5, 5))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This takes the list of `boundary_layers` and splits it into three lists of `meep::volume`s. One for boundary regions that don't overlap, one for where 2 boundary regions overlap, and one for where 3 overlap. These lists are passed to C++ to compute the number of PML pixels in each fragment, separated by degree of overlap. If the boundary layers are `Absorber`s, these pixel amounts are added to `num_nonzero_conductivity_pixels` instead (multiplied by degree of overlap).
@stevengj @oskooi 