### PR TITLE
Read epsilon input from numpy array

### DIFF
--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -71,7 +71,7 @@ Specifies the size of the computational cell which is centered on the origin of 
 
 **`default_material` [`Medium` class ]**
 —
-Holds the default material that is used for points not in any object of the geometry list. Defaults to `air` (ε=1). See also `epsilon_input_file` below.
+Holds the default material that is used for points not in any object of the geometry list. Defaults to `air` (ε=1). This can also be a numpy array that defines a dielectric function much like `epsilon_input_file` below (see below).
 
 **`material_function` [ function ]**
 —

--- a/libmeepgeom/material_data.hpp
+++ b/libmeepgeom/material_data.hpp
@@ -182,7 +182,7 @@ struct material_data
    meep::realnum *epsilon_data;
    size_t epsilon_dims[3];
 
-   material_data(): which_subclass(MEDIUM), medium(), user_data(NULL), epsilon_data(NULL) {
+   material_data(): which_subclass(MEDIUM), medium(), user_func(NULL), user_data(NULL), epsilon_data(NULL) {
      epsilon_dims[0] = 0;
      epsilon_dims[1] = 0;
      epsilon_dims[2] = 0;
@@ -206,7 +206,6 @@ material_type make_dielectric(double epsilon);
 material_type make_user_material(user_material_func user_func,
                                  void *user_data);
 material_type make_file_material(char *epsilon_input_file);
-
 void read_epsilon_file(const char *eps_input_file);
 
 

--- a/libmeepgeom/meepgeom.cpp
+++ b/libmeepgeom/meepgeom.cpp
@@ -1627,11 +1627,7 @@ void set_materials_from_geometry(meep::structure *s,
 /***************************************************************/
 material_type make_dielectric(double epsilon)
 {
-  material_data *md = (material_data *)malloc(sizeof(*md));
-  md->which_subclass=material_data::MEDIUM;
-  md->user_func=0;
-  md->user_data=0;
-  md->medium = medium_struct();
+  material_data *md = new material_data();
   md->medium.epsilon_diag.x=epsilon;
   md->medium.epsilon_diag.y=epsilon;
   md->medium.epsilon_diag.z=epsilon;
@@ -1641,11 +1637,10 @@ material_type make_dielectric(double epsilon)
 material_type make_user_material(user_material_func user_func,
                                  void *user_data)
 {
-  material_data *md = (material_data *)malloc(sizeof(*md));
+  material_data *md = new material_data();
   md->which_subclass=material_data::MATERIAL_USER;
   md->user_func=user_func;
   md->user_data=user_data;
-  md->medium = medium_struct();
   return md;
 }
 
@@ -1653,7 +1648,7 @@ material_type make_user_material(user_material_func user_func,
 // 'read_epsilon_file' routine
 material_type make_file_material(const char *eps_input_file)
 {
-  material_data *md = (material_data *)malloc(sizeof(*md));
+  material_data *md = new material_data();
   md->which_subclass=material_data::MATERIAL_FILE;
 
   md->epsilon_dims[0] = md->epsilon_dims[1] = md->epsilon_dims[2] = 1;
@@ -1667,13 +1662,12 @@ material_type make_file_material(const char *eps_input_file)
     int rank; // ignored since rank < 3 is equivalent to singleton dims
     md->epsilon_data = eps_file.read(dataname, &rank, md->epsilon_dims, 3);
     master_printf("read in %zdx%zdx%zd epsilon-input-file \"%s\"\n",
-		  md->epsilon_dims[0],
+                  md->epsilon_dims[0],
                   md->epsilon_dims[1],
                   md->epsilon_dims[2],
-		  eps_input_file);
+                  eps_input_file);
+    delete[] fname;
   }
-
-  md->medium = medium_struct();
 
   return md;
 }

--- a/python/meep.i
+++ b/python/meep.i
@@ -746,8 +746,9 @@ meep::volume_list *make_volume_list(const meep::volume &v, int c,
     int py_material = PyObject_IsInstance($input, py_material_object());
     int user_material = PyFunction_Check($input);
     int file_material = IsPyString($input);
+    int numpy_material = PyArray_Check($input);
 
-    $1 = py_material || user_material || file_material;
+    $1 = py_material || user_material || file_material || numpy_material;
 }
 
 %typemap(in) material_type {

--- a/python/meep.i
+++ b/python/meep.i
@@ -603,7 +603,8 @@ meep::volume_list *make_volume_list(const meep::volume &v, int c,
         if (((material_data *)$1.material)->medium.H_susceptibilities.items) {
             delete[] ((material_data *)$1.material)->medium.H_susceptibilities.items;
         }
-        free((material_data *)$1.material);
+        delete[] ((material_data *)$1.material)->epsilon_data;
+        delete (material_data *)$1.material;
         geometric_object_destroy($1);
     }
 }
@@ -642,7 +643,8 @@ meep::volume_list *make_volume_list(const meep::volume &v, int c,
         if (((material_data *)$1.items[i].material)->medium.H_susceptibilities.items) {
             delete[] ((material_data *)$1.items[i].material)->medium.H_susceptibilities.items;
         }
-        free((material_data *)$1.items[i].material);
+        delete[] ((material_data *)$1.items[i].material)->epsilon_data;
+        delete (material_data *)$1.items[i].material;
         geometric_object_destroy($1.items[i]);
     }
     delete[] $1.items;
@@ -764,7 +766,8 @@ meep::volume_list *make_volume_list(const meep::volume &v, int c,
     if ($1->medium.H_susceptibilities.items) {
         delete[] $1->medium.H_susceptibilities.items;
     }
-    free($1);
+    delete[] $1->epsilon_data;
+    delete $1;
 }
 
 // Typemap suite for array_slice
@@ -1058,7 +1061,7 @@ meep::volume_list *make_volume_list(const meep::volume &v, int c,
             if ($1.items[i]->medium.H_susceptibilities.items) {
                 delete[] $1.items[i]->medium.H_susceptibilities.items;
             }
-            free($1.items[i]);
+            delete[] $1.items[i]->epsilon_data;
         }
         delete[] $1.items;
     }

--- a/python/mpb.i
+++ b/python/mpb.i
@@ -26,6 +26,8 @@
 using namespace py_mpb;
 %}
 
+%include "numpy.i"
+
 %{
 using namespace meep;
 using namespace meep_geom;

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -894,7 +894,7 @@ class Simulation(object):
         elif self.epsilon_input_file:
             self.default_material = self.epsilon_input_file
 
-        self.fragment_stats = self._compute_fragment_stats(gv)
+        self.fragment_stats = self._compute_fragment_stats(gv) if isinstance(self.default_material, mp.Medium) else []
 
         self.structure = mp.structure(gv, None, br, sym, self.num_chunks, self.Courant,
                                       self.eps_averaging, self.subpixel_tol, self.subpixel_maxeval)

--- a/python/tests/simulation.py
+++ b/python/tests/simulation.py
@@ -231,6 +231,20 @@ class TestSimulation(unittest.TestCase):
             fp = sim.get_field_point(mp.Ez, mp.Vector3(x=1))
             self.assertAlmostEqual(fp, -0.002989654055823199 + 0j)
 
+    def test_numpy_epsilon(self):
+        sim = self.init_simple_simulation()
+        eps_input_fname = 'cyl-ellipsoid-eps-ref.h5'
+        eps_input_dir = os.path.join(os.path.abspath(os.path.realpath(os.path.dirname(__file__))),
+                                     '..', '..', 'libmeepgeom')
+        eps_input_path = os.path.join(eps_input_dir, eps_input_fname)
+
+        with h5py.File(eps_input_path, 'r') as f:
+            sim.default_material = f['eps'].value
+
+        sim.run(until=200)
+        fp = sim.get_field_point(mp.Ez, mp.Vector3(x=1))
+        self.assertAlmostEqual(fp, -0.002989654055823199 + 0j)
+
     def test_set_materials(self):
 
         def change_geom(sim):

--- a/python/tests/simulation.py
+++ b/python/tests/simulation.py
@@ -18,6 +18,9 @@ class TestSimulation(unittest.TestCase):
 
     fname = 'simulation-ez-000200.00.h5'
 
+    def setUp(self):
+        print("Running {}".format(self._testMethodName))
+
     def test_interpolate_numbers(self):
 
         expected = [

--- a/python/typemap_utils.cpp
+++ b/python/typemap_utils.cpp
@@ -481,10 +481,11 @@ static int pymaterial_to_material(PyObject *po, material_type *mt) {
             PyErr_SetString(PyExc_TypeError, "Numpy array must be C-style contiguous.");
             return 0;
         }
-        md = (material_data *)malloc(sizeof(*md));
+        md = new material_data();
         md->which_subclass=material_data::MATERIAL_FILE;
         md->epsilon_dims[0] = md->epsilon_dims[1] = md->epsilon_dims[2] = 1;
-        md->epsilon_data = (double*)PyArray_DATA(pao);
+        md->epsilon_data = new realnum[PyArray_SIZE(pao)];
+        memcpy(md->epsilon_data, (realnum*)PyArray_DATA(pao), PyArray_SIZE(pao) * sizeof(realnum));
 
         for (int i = 0; i < PyArray_NDIM(pao); ++i) {
             md->epsilon_dims[i] = (size_t)PyArray_DIMS(pao)[i];
@@ -494,8 +495,6 @@ static int pymaterial_to_material(PyObject *po, material_type *mt) {
                       md->epsilon_dims[0],
                       md->epsilon_dims[1],
                       md->epsilon_dims[2]);
-
-        md->medium = medium_struct();
     } else {
         PyErr_SetString(PyExc_TypeError, "Expected a Medium, a function, or a filename");
         return 0;

--- a/scheme/structure.cpp
+++ b/scheme/structure.cpp
@@ -188,8 +188,9 @@ static void read_epsilon_file(const char *eps_input_file)
     int rank; // ignored since rank < 3 is equivalent to singleton dims
     epsilon_data = eps_file.read(dataname, &rank, epsilon_dims, 3);
     master_printf("read in %zdx%zdx%zd epsilon-input-file \"%s\"\n",
-		  epsilon_dims[0], epsilon_dims[1], epsilon_dims[2],
-		  eps_input_file);
+                  epsilon_dims[0], epsilon_dims[1], epsilon_dims[2],
+                  eps_input_file);
+    delete[] fname;
   }
 }
 


### PR DESCRIPTION
Closes #584. Reuses the epsilon input file mechanism of `material_data` to allow setting the `default_material` to a numpy array. 
@stevengj @oskooi 