### PR TITLE
Add material rotation

### DIFF
--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -276,6 +276,10 @@ List of dispersive susceptibilities (see below) added to the dielectric constant
 —
 List of dispersive susceptibilities (see below) added to the permeability μ in order to model material dispersion. Defaults to none (empty list). See also [Material Dispersion](Materials.md#material-dispersion).
 
+**`transform(m [ `Matrix` class ] )`**
+—
+Transforms epsilon, mu, and sigma of any susceptibilities by the matrix `m`.
+
 **material functions**
 
 Any function that accepts a `Medium` instance can also accept a user defined Python function. This allows you to specify the material as an arbitrary function of position. The function must have one argument, the position `Vector3`, and return the material at that point, which should be a Python `Medium` instance. This is accomplished by passing a function to the `material_function` keyword argument in the `Simulation` constructor, or the `material` keyword argument in any `GeometricObject` constructor.

--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -276,9 +276,9 @@ List of dispersive susceptibilities (see below) added to the dielectric constant
 —
 List of dispersive susceptibilities (see below) added to the permeability μ in order to model material dispersion. Defaults to none (empty list). See also [Material Dispersion](Materials.md#material-dispersion).
 
-**`transform(m [ `Matrix` class ] )`**
+**`transform(M [ `Matrix` class ] )`**
 —
-Transforms epsilon, mu, and sigma of any susceptibilities by the matrix `m`.
+Transforms epsilon, mu, and sigma of any susceptibilities by the 3×3 matrix `M`.  If `M` is a [rotation matrix](https://en.wikipedia.org/wiki/Rotation_matrix), then the principal axes of the susceptibilities are rotated by `m`.  More generally, the susceptibilities χ are transformed to MχMᵀ/|det M|, which corresponds to [transformation optics](http://math.mit.edu/~stevenj/18.369/coordinate-transform.pdf) for an arbitrary curvilinear coordinate transformation with Jacobian matrix M.  (The absolute value of the determinant is to prevent inadvertent construction of left-handed materials, which are [problematic in nondispersive media](https://meep.readthedocs.io/en/latest/FAQ/#why-does-my-simulation-diverge-if-0.)
 
 **material functions**
 

--- a/python/geom.py
+++ b/python/geom.py
@@ -196,7 +196,7 @@ class Medium(object):
         self.B_conductivity_diag = B_conductivity_diag
         self.valid_freq_range = valid_freq_range
 
-    def rotate(self, rotation_matrix):
+    def transform(self, rotation_matrix):
         eps = Matrix(mp.Vector3(self.epsilon_diag.x, self.epsilon_offdiag.x, self.epsilon_offdiag.y),
                      mp.Vector3(self.epsilon_offdiag.x, self.epsilon_diag.y, self.epsilon_offdiag.z),
                      mp.Vector3(self.epsilon_offdiag.y, self.epsilon_offdiag.z, self.epsilon_diag.z))
@@ -212,10 +212,10 @@ class Medium(object):
         self.mu_offdiag = mp.Vector3(new_mu.c2.x, new_mu.c3.x, new_mu.c3.y)
 
         for s in self.E_susceptibilities:
-            s.rotate(rotation_matrix)
+            s.transform(rotation_matrix)
 
         for s in self.H_susceptibilities:
-            s.rotate(rotation_matrix)
+            s.transform(rotation_matrix)
 
 
 class Susceptibility(object):
@@ -224,7 +224,7 @@ class Susceptibility(object):
         self.sigma_diag = Vector3(sigma, sigma, sigma) if sigma else sigma_diag
         self.sigma_offdiag = sigma_offdiag
 
-    def rotate(self, rotation_matrix):
+    def transform(self, rotation_matrix):
         sigma = Matrix(mp.Vector3(self.sigma_diag.x, self.sigma_offdiag.x, self.sigma_offdiag.y),
                        mp.Vector3(self.sigma_offdiag.x, self.sigma_diag.y, self.sigma_offdiag.z),
                        mp.Vector3(self.sigma_offdiag.y, self.sigma_offdiag.z, self.sigma_diag.z))

--- a/python/geom.py
+++ b/python/geom.py
@@ -55,6 +55,14 @@ class Vector3(object):
         else:
             raise TypeError("No operation known for 'Vector3 * {}'".format(type(other)))
 
+    def __truediv__(self, other):
+        if type(other) is Vector3:
+            return Vector3(self.x / other.x, self.y / other.y, self.z / other.z)
+        elif isinstance(other, Number):
+            return Vector3(self.x / other, self.y / other, self.z / other)
+        else:
+            raise TypeError("No operation known for 'Vector3 / {}'".format(type(other)))
+
     def __rmul__(self, other):
         if isinstance(other, Number):
             return self.scale(other)
@@ -196,7 +204,7 @@ class Medium(object):
         self.B_conductivity_diag = B_conductivity_diag
         self.valid_freq_range = valid_freq_range
 
-    def transform(self, rotation_matrix):
+    def transform(self, m):
         eps = Matrix(mp.Vector3(self.epsilon_diag.x, self.epsilon_offdiag.x, self.epsilon_offdiag.y),
                      mp.Vector3(self.epsilon_offdiag.x, self.epsilon_diag.y, self.epsilon_offdiag.z),
                      mp.Vector3(self.epsilon_offdiag.y, self.epsilon_offdiag.z, self.epsilon_diag.z))
@@ -204,18 +212,18 @@ class Medium(object):
                     mp.Vector3(self.mu_offdiag.x, self.mu_diag.y, self.mu_offdiag.z),
                     mp.Vector3(self.mu_offdiag.y, self.mu_offdiag.z, self.mu_diag.z))
 
-        new_eps = rotation_matrix * eps * rotation_matrix.transpose()
-        new_mu = rotation_matrix * mu * rotation_matrix.transpose()
+        new_eps = (m * eps * m.transpose()) / abs(m.determinant())
+        new_mu = (m * mu * m.transpose()) / abs(m.determinant())
         self.epsilon_diag = mp.Vector3(new_eps.c1.x, new_eps.c2.y, new_eps.c3.z)
         self.epsilon_offdiag = mp.Vector3(new_eps.c2.x, new_eps.c3.x, new_eps.c3.y)
         self.mu_diag = mp.Vector3(new_mu.c1.x, new_mu.c2.y, new_mu.c3.z)
         self.mu_offdiag = mp.Vector3(new_mu.c2.x, new_mu.c3.x, new_mu.c3.y)
 
         for s in self.E_susceptibilities:
-            s.transform(rotation_matrix)
+            s.transform(m)
 
         for s in self.H_susceptibilities:
-            s.transform(rotation_matrix)
+            s.transform(m)
 
 
 class Susceptibility(object):
@@ -224,11 +232,11 @@ class Susceptibility(object):
         self.sigma_diag = Vector3(sigma, sigma, sigma) if sigma else sigma_diag
         self.sigma_offdiag = sigma_offdiag
 
-    def transform(self, rotation_matrix):
+    def transform(self, m):
         sigma = Matrix(mp.Vector3(self.sigma_diag.x, self.sigma_offdiag.x, self.sigma_offdiag.y),
                        mp.Vector3(self.sigma_offdiag.x, self.sigma_diag.y, self.sigma_offdiag.z),
                        mp.Vector3(self.sigma_offdiag.y, self.sigma_offdiag.z, self.sigma_diag.z))
-        new_sigma = rotation_matrix * sigma * rotation_matrix.transpose()
+        new_sigma = (m * sigma * m.transpose()) / abs(m.determinant())
         self.sigma_diag = mp.Vector3(new_sigma.c1.x, new_sigma.c2.y, new_sigma.c3.z)
         self.sigma_offdiag = mp.Vector3(new_sigma.c2.x, new_sigma.c3.x, new_sigma.c3.y)
 
@@ -430,6 +438,9 @@ class Matrix(object):
             return self.scale(left_arg)
         else:
             raise TypeError("No operation known for 'Matrix * {}'".format(type(left_arg)))
+
+    def __truediv__(self, scalar):
+        return Matrix(self.c1 / scalar, self.c2 / scalar, self.c3 / scalar)
 
     def __add__(self, m):
         return Matrix(self.c1 + m.c1, self.c2 + m.c2, self.c3 + m.c3)

--- a/python/tests/geom.py
+++ b/python/tests/geom.py
@@ -349,7 +349,7 @@ class TestMedium(unittest.TestCase):
         sim.add_flux(15, 6, 2, fregion)
         check_warnings(sim)
 
-    def test_rotate(self):
+    def test_transform(self):
 
         e_sus = [mp.LorentzianSusceptibility(sigma_diag=mp.Vector3(1, 2, 3),
                                              sigma_offdiag=mp.Vector3(12, 13, 14)),
@@ -363,7 +363,7 @@ class TestMedium(unittest.TestCase):
         rot_matrix = mp.Matrix(mp.Vector3(math.cos(rot_angle), math.sin(rot_angle), 0),
                                mp.Vector3(-math.sin(rot_angle), math.cos(rot_angle), 0),
                                mp.Vector3(0, 0, 1))
-        mat.rotate(rot_matrix)
+        mat.transform(rot_matrix)
 
         expected_diag = mp.Vector3(-7.72552, 10.72552, 3)
         expected_offdiag = mp.Vector3(7.69024, 6.21332, 18.06640)

--- a/python/tests/geom.py
+++ b/python/tests/geom.py
@@ -349,6 +349,29 @@ class TestMedium(unittest.TestCase):
         sim.add_flux(15, 6, 2, fregion)
         check_warnings(sim)
 
+    def test_rotate(self):
+
+        e_sus = [mp.LorentzianSusceptibility(sigma_diag=mp.Vector3(1, 2, 3),
+                                             sigma_offdiag=mp.Vector3(12, 13, 14)),
+                 mp.DrudeSusceptibility(sigma_diag=mp.Vector3(1, 2, 3),
+                                        sigma_offdiag=mp.Vector3(12, 13, 14))]
+
+        mat = mp.Medium(epsilon_diag=mp.Vector3(1, 2, 3), epsilon_offdiag=mp.Vector3(12, 13, 14),
+                        E_susceptibilities=e_sus)
+
+        rot_matrix = mp.Matrix(mp.Vector3(1, 0, 0), mp.Vector3(0, 0, 1), mp.Vector3(0, -1, 0))
+        mat.rotate(rot_matrix)
+
+        self.assertEqual(mat.epsilon_diag, mp.Vector3(1, 3, 2))
+        self.assertEqual(mat.epsilon_offdiag, mp.Vector3(-13, 12, -14))
+        self.assertEqual(mat.mu_diag, mp.Vector3(1, 1, 1))
+        self.assertEqual(mat.mu_offdiag, mp.Vector3())
+        self.assertEqual(len(mat.E_susceptibilities), 2)
+        self.assertEqual(mat.E_susceptibilities[0].sigma_diag, mp.Vector3(1, 3, 2))
+        self.assertEqual(mat.E_susceptibilities[0].sigma_offdiag, mp.Vector3(-13, 12, -14))
+        self.assertEqual(mat.E_susceptibilities[1].sigma_diag, mp.Vector3(1, 3, 2))
+        self.assertEqual(mat.E_susceptibilities[1].sigma_offdiag, mp.Vector3(-13, 12, -14))
+
 
 class TestVector3(unittest.TestCase):
 

--- a/python/tests/geom.py
+++ b/python/tests/geom.py
@@ -359,18 +359,24 @@ class TestMedium(unittest.TestCase):
         mat = mp.Medium(epsilon_diag=mp.Vector3(1, 2, 3), epsilon_offdiag=mp.Vector3(12, 13, 14),
                         E_susceptibilities=e_sus)
 
-        rot_matrix = mp.Matrix(mp.Vector3(1, 0, 0), mp.Vector3(0, 0, 1), mp.Vector3(0, -1, 0))
+        rot_angle = math.radians(23.9)
+        rot_matrix = mp.Matrix(mp.Vector3(math.cos(rot_angle), math.sin(rot_angle), 0),
+                               mp.Vector3(-math.sin(rot_angle), math.cos(rot_angle), 0),
+                               mp.Vector3(0, 0, 1))
         mat.rotate(rot_matrix)
 
-        self.assertEqual(mat.epsilon_diag, mp.Vector3(1, 3, 2))
-        self.assertEqual(mat.epsilon_offdiag, mp.Vector3(-13, 12, -14))
+        expected_diag = mp.Vector3(-7.72552, 10.72552, 3)
+        expected_offdiag = mp.Vector3(7.69024, 6.21332, 18.06640)
+
+        self.assertTrue(mat.epsilon_diag.close(expected_diag, tol=4))
+        self.assertTrue(mat.epsilon_offdiag.close(expected_offdiag, tol=4))
         self.assertEqual(mat.mu_diag, mp.Vector3(1, 1, 1))
         self.assertEqual(mat.mu_offdiag, mp.Vector3())
         self.assertEqual(len(mat.E_susceptibilities), 2)
-        self.assertEqual(mat.E_susceptibilities[0].sigma_diag, mp.Vector3(1, 3, 2))
-        self.assertEqual(mat.E_susceptibilities[0].sigma_offdiag, mp.Vector3(-13, 12, -14))
-        self.assertEqual(mat.E_susceptibilities[1].sigma_diag, mp.Vector3(1, 3, 2))
-        self.assertEqual(mat.E_susceptibilities[1].sigma_offdiag, mp.Vector3(-13, 12, -14))
+        self.assertTrue(mat.E_susceptibilities[0].sigma_diag.close(expected_diag, tol=4))
+        self.assertTrue(mat.E_susceptibilities[0].sigma_offdiag.close(expected_offdiag, tol=4))
+        self.assertTrue(mat.E_susceptibilities[1].sigma_diag.close(expected_diag, tol=4))
+        self.assertTrue(mat.E_susceptibilities[1].sigma_offdiag.close(expected_offdiag, tol=4))
 
 
 class TestVector3(unittest.TestCase):


### PR DESCRIPTION
Addresses half of #560. Still need a `rotate_uniaxial`. I'll add documentation once the interface is approved.
@stevengj @oskooi 